### PR TITLE
Fix sign-in 500 error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Project Notes
+
+## Vercel
+- Vercel project name: `construction-web`
+- Production URL: https://construction-web-ashen.vercel.app
+- Database: Neon PostgreSQL (configured via Vercel integration)

--- a/vercel.json
+++ b/vercel.json
@@ -3,8 +3,5 @@
   "buildCommand": "npx prisma generate && npx next build",
   "installCommand": "npm install",
   "outputDirectory": ".next",
-  "env": {
-    "SKIP_ENV_VALIDATION": "1",
-    "DATABASE_URL": "postgresql://placeholder:placeholder@localhost:5432/placeholder"
-  }
+  "env": {}
 }


### PR DESCRIPTION
## Summary
- Removed hardcoded `DATABASE_URL` placeholder from `vercel.json` that was overriding the Neon database URL at runtime, causing all database queries to fail with `Can't reach database server at localhost:5432`
- Removed `SKIP_ENV_VALIDATION` since it's no longer needed

## Test plan
- [ ] Verify sign-in works on the preview deployment
- [ ] Verify sign-up works
- [ ] Merge to main and confirm production sign-in works