### PR TITLE
Add parent task duration validation and save UI to Gantt chart

### DIFF
--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -65,14 +65,18 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
     handlePresetChange,
   } = useGanttControls();
 
-  // toggleParentTasksOnClick is a config-only prop in Bryntum's React adapter, so it must
-  // also be set imperatively on the instance after load to guarantee it takes effect.
+  // After data loads, finalize the project so the scheduling engine and layout are
+  // fully ready before the user can interact.  delayCalculation defers the initial
+  // engine run until commitAsync — calling it here ensures the project is calculated
+  // before "Add Task" or any other interaction.
   useEffect(() => {
     if (isLoading) return;
     const gantt = getGanttInstance();
     if (!gantt) return;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     gantt.toggleParentTasksOnClick = false;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    void gantt.project.commitAsync();
   }, [isLoading, getGanttInstance]);
 
   const handleSave = useCallback(async () => {
@@ -232,16 +236,25 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
         justSaved={justSaved}
       />
 
-      <div style={GANTT_CONTENT_STYLE} className="bryntum-gantt-container">
+      {/* Bryntum must always render in a visible container so its internal layout
+          calculations use real dimensions.  The loading/error overlays sit on top. */}
+      <div style={{ ...GANTT_CONTENT_STYLE, position: 'relative' }} className="bryntum-gantt-container">
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+          <BryntumGantt ref={ganttRef} {...ganttConfig} />
+        </div>
+
         {isLoading && (
           <Box
             sx={{
+              position: 'absolute',
+              inset: 0,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              height: '100%',
               flexDirection: 'column',
               gap: 2,
+              bgcolor: 'var(--bg-card)',
+              zIndex: 1,
             }}
           >
             <CircularProgress />
@@ -252,28 +265,22 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
         {loadError && (
           <Box
             sx={{
+              position: 'absolute',
+              inset: 0,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              height: '100%',
               flexDirection: 'column',
               gap: 2,
               color: 'error.main',
+              bgcolor: 'var(--bg-card)',
+              zIndex: 1,
             }}
           >
             <div>Failed to load Gantt chart</div>
             <div style={{ fontSize: '0.875rem' }}>{loadError}</div>
           </Box>
         )}
-
-        <div style={{
-          display: isLoading || loadError ? 'none' : 'flex',
-          flexDirection: 'column',
-          flex: 1,
-          minHeight: 0,
-        }}>
-          <BryntumGantt ref={ganttRef} {...ganttConfig} />
-        </div>
       </div>
 
       <TaskDetailsPopover

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -262,7 +262,6 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
   return (
     <div style={WRAPPER_STYLE}>
       <BryntumPanelHeader
-        title="Bryntum Schedule"
         onAddTask={handleAddTask}
         onPresetChange={handlePresetChange}
         onZoomIn={handleZoomIn}
@@ -279,7 +278,9 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
       {/* Bryntum must always render in a visible container so its internal layout
           calculations use real dimensions.  The loading/error overlays sit on top. */}
       <div style={GANTT_CONTENT_STYLE} className="bryntum-gantt-container">
-        <BryntumGantt ref={ganttRef} {...ganttConfig} />
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+          <BryntumGantt ref={ganttRef} {...ganttConfig} />
+        </div>
 
         {isLoading && (
           <Box

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -33,6 +33,9 @@ const GANTT_CONTENT_STYLE: CSSProperties = {
 };
 
 const STALE_THRESHOLD_MS = 60_000; // 60 seconds
+// Short settle time so the Bryntum scheduling engine finishes before we sync
+const AUTO_SAVE_DELAY_MS = 1_000; // 1 second
+const AUTO_SAVE_STORAGE_KEY = 'gantt-autosave-enabled';
 
 interface BryntumGanttWrapperProps {
   projectId?: string;
@@ -46,8 +49,20 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
   const [isSaving, setIsSaving] = useState(false);
   const [hasPendingChanges, setHasPendingChanges] = useState(false);
   const [justSaved, setJustSaved] = useState(false);
+  const [autoSaveEnabled, setAutoSaveEnabled] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    return localStorage.getItem(AUTO_SAVE_STORAGE_KEY) !== 'false';
+  });
+
   const justSavedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // Refs so timer callbacks always read fresh state without stale closures
+  const isSavingRef = useRef(false);
+  const autoSaveEnabledRef = useRef(autoSaveEnabled);
   const isRevertingRef = useRef(false);
+
+  useEffect(() => { isSavingRef.current = isSaving; }, [isSaving]);
+  useEffect(() => { autoSaveEnabledRef.current = autoSaveEnabled; }, [autoSaveEnabled]);
 
   const { showSnackbar } = useSnackbar();
 
@@ -90,6 +105,16 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
     // isSaving and hasPendingChanges are reset by the sync/syncFail event listeners
   }, [getGanttInstance]);
 
+  const handleToggleAutoSave = useCallback(() => {
+    setAutoSaveEnabled(prev => {
+      const next = !prev;
+      localStorage.setItem(AUTO_SAVE_STORAGE_KEY, String(next));
+      // Cancel any pending auto-save when turning off
+      if (!next) clearTimeout(autoSaveTimerRef.current);
+      return next;
+    });
+  }, []);
+
   // Invalidate tRPC cache when Bryntum syncs so sibling components (e.g. file tree) refetch
   const utils = api.useUtils();
   useEffect(() => {
@@ -98,6 +123,7 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
     if (!gantt?.project) return;
 
     const onSync = () => {
+      clearTimeout(autoSaveTimerRef.current);
       setIsSaving(false);
       setHasPendingChanges(false);
       setJustSaved(true);
@@ -119,7 +145,9 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
     };
   }, [isLoading, getGanttInstance, utils]);
 
-  // Mark pending changes when any store is modified locally
+  // Mark pending changes when any store is modified locally.
+  // When auto-save is enabled, schedule a save shortly after each change so the
+  // Bryntum scheduling engine has time to settle before we sync.
   useEffect(() => {
     if (isLoading) return;
     const gantt = getGanttInstance();
@@ -133,14 +161,25 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
       gantt.project.assignmentStore,
       gantt.project.timeRangeStore,
     ];
-    const onStoreChange = () => setHasPendingChanges(true);
+
+    const onStoreChange = () => {
+      setHasPendingChanges(true);
+      if (!autoSaveEnabledRef.current) return;
+      // Debounce so rapid successive engine updates collapse into one sync call
+      clearTimeout(autoSaveTimerRef.current);
+      autoSaveTimerRef.current = setTimeout(() => {
+        if (!isSavingRef.current) void handleSave();
+      }, AUTO_SAVE_DELAY_MS);
+    };
+
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     stores.forEach(store => store?.on('change', onStoreChange));
     return () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       stores.forEach(store => store?.un('change', onStoreChange));
+      clearTimeout(autoSaveTimerRef.current);
     };
-  }, [isLoading, getGanttInstance]);
+  }, [isLoading, getGanttInstance, handleSave]);
 
   // Validate parent task duration: revert and warn if shortened below subtask span
   useEffect(() => {
@@ -273,6 +312,8 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
         isSaving={isSaving}
         hasPendingChanges={hasPendingChanges}
         justSaved={justSaved}
+        autoSaveEnabled={autoSaveEnabled}
+        onToggleAutoSave={handleToggleAutoSave}
       />
 
       {/* Bryntum must always render in a visible container so its internal layout

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, useRef, useEffect, useCallback, type CSSProperties } from 'react';
+import { useState, useRef, useEffect, useCallback, type CSSProperties } from 'react';
 import { BryntumGantt } from '@bryntum/gantt-react';
 import '@bryntum/gantt/gantt.css';
 import { CircularProgress, Box } from '@mui/material';
@@ -188,6 +188,30 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
     };
   }, [isLoading, getGanttInstance, showSnackbar]);
 
+  // Close the task popover when the selected task is removed (e.g. parent deletion cascades)
+  useEffect(() => {
+    if (isLoading) return;
+    const gantt = getGanttInstance();
+    if (!gantt?.project?.taskStore) return;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onTaskRemove = ({ records }: { records: any[] }) => {
+      if (!selectedTask) return;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const removedIds = new Set(records.map((r) => String(r.id)));
+      if (removedIds.has(selectedTask.id)) {
+        closeTaskPopover();
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    gantt.project.taskStore.on('remove', onTaskRemove);
+    return () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      gantt.project?.taskStore?.un('remove', onTaskRemove);
+    };
+  }, [isLoading, getGanttInstance, selectedTask, closeTaskPopover]);
+
   // Silently refresh data when returning to the Gantt tab after the stale threshold.
   // Bryntum's CrudManager merges fresh data without resetting scroll, selections, or expanded state.
   const hiddenSinceRef = useRef(0);
@@ -205,22 +229,35 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
     }
   }, [isVisible, getGanttInstance]);
 
-  const ganttConfig = useMemo(
-    () => createGanttConfig(handleTaskClick, projectId, {
-      onLoadStart: () => {
-        setIsLoading(true);
-        setLoadError(null);
-      },
-      onLoadComplete: () => {
-        setIsLoading(false);
-      },
-      onLoadError: (error: string) => {
-        setIsLoading(false);
-        setLoadError(error);
-      },
-    }),
-    [handleTaskClick, projectId]
-  );
+  // Bryntum React best practice: use useState (not useMemo) so the config object is
+  // created exactly once and never recreated on re-render.  A new config reference
+  // would make the React wrapper re-initialise the Bryntum instance (including
+  // autoLoad), which wipes locally-added tasks.
+  const [ganttConfig] = useState(() => createGanttConfig(projectId, {
+    onLoadStart: () => {
+      setIsLoading(true);
+      setLoadError(null);
+    },
+    onLoadComplete: () => {
+      setIsLoading(false);
+    },
+    onLoadError: (error: string) => {
+      setIsLoading(false);
+      setLoadError(error);
+    },
+  }));
+
+  // Attach the taskClick listener on the Bryntum instance (not in the static config)
+  // so we can use the latest handleTaskClick reference from useTaskPopover.
+  useEffect(() => {
+    if (isLoading) return;
+    const gantt = getGanttInstance();
+    if (!gantt) return;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    gantt.on('taskClick', handleTaskClick);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    return () => { gantt.un('taskClick', handleTaskClick); };
+  }, [isLoading, getGanttInstance, handleTaskClick]);
 
   return (
     <div style={WRAPPER_STYLE}>

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, useRef, useEffect, type CSSProperties } from 'react';
+import { useMemo, useState, useRef, useEffect, useCallback, type CSSProperties } from 'react';
 import { BryntumGantt } from '@bryntum/gantt-react';
 import '@bryntum/gantt/gantt.css';
 import { CircularProgress, Box } from '@mui/material';
@@ -9,9 +9,11 @@ import { api } from '@/trpc/react';
 import { createGanttConfig } from './config/ganttConfig';
 import { BryntumPanelHeader } from './components/BryntumPanelHeader';
 import { TaskDetailsPopover } from './components/TaskDetailsPopover';
+import { useSnackbar } from '@/hooks/useSnackbar';
 import { useBryntumThemeAssets } from './hooks/useBryntumThemeAssets';
 import { useTaskPopover } from './hooks/useTaskPopover';
 import { useGanttControls } from './hooks/useGanttControls';
+import { validateParentDuration } from './utils/ganttValidation';
 
 const WRAPPER_STYLE: CSSProperties = {
   display: 'flex',
@@ -38,6 +40,13 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
   const theme = useThemeStore((state) => state.theme);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [hasPendingChanges, setHasPendingChanges] = useState(false);
+  const [justSaved, setJustSaved] = useState(false);
+  const justSavedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const isRevertingRef = useRef(false);
+
+  const { showSnackbar } = useSnackbar();
 
   const { selectedTask, popoverPlacement, handleTaskClick, closeTaskPopover, isTaskPopoverOpen } =
     useTaskPopover();
@@ -66,6 +75,14 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
     gantt.toggleParentTasksOnClick = false;
   }, [isLoading, getGanttInstance]);
 
+  const handleSave = useCallback(async () => {
+    const gantt = getGanttInstance();
+    if (!gantt?.project) return;
+    setIsSaving(true);
+    await gantt.project.sync();
+    // isSaving and hasPendingChanges are reset by the sync/syncFail event listeners
+  }, [getGanttInstance]);
+
   // Invalidate tRPC cache when Bryntum syncs so sibling components (e.g. file tree) refetch
   const utils = api.useUtils();
   useEffect(() => {
@@ -74,14 +91,95 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
     if (!gantt?.project) return;
 
     const onSync = () => {
+      setIsSaving(false);
+      setHasPendingChanges(false);
+      setJustSaved(true);
+      clearTimeout(justSavedTimerRef.current);
+      justSavedTimerRef.current = setTimeout(() => setJustSaved(false), 2000);
       void utils.gantt.tasks.invalidate();
+    };
+    const onSyncFail = () => {
+      setIsSaving(false);
+      // hasPendingChanges stays true — changes weren't saved
     };
 
     gantt.project.on('sync', onSync);
+    gantt.project.on('syncFail', onSyncFail);
     return () => {
       gantt.project?.un('sync', onSync);
+      gantt.project?.un('syncFail', onSyncFail);
+      clearTimeout(justSavedTimerRef.current);
     };
   }, [isLoading, getGanttInstance, utils]);
+
+  // Mark pending changes when any store is modified locally
+  useEffect(() => {
+    if (isLoading) return;
+    const gantt = getGanttInstance();
+    if (!gantt?.project) return;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stores: any[] = [
+      gantt.project.taskStore,
+      gantt.project.dependencyStore,
+      gantt.project.resourceStore,
+      gantt.project.assignmentStore,
+      gantt.project.timeRangeStore,
+    ];
+    const onStoreChange = () => setHasPendingChanges(true);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    stores.forEach(store => store?.on('change', onStoreChange));
+    return () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      stores.forEach(store => store?.un('change', onStoreChange));
+    };
+  }, [isLoading, getGanttInstance]);
+
+  // Validate parent task duration: revert and warn if shortened below subtask span
+  useEffect(() => {
+    if (isLoading) return;
+    const gantt = getGanttInstance();
+    if (!gantt?.project?.taskStore) return;
+
+    const onTaskUpdate = ({ record, changes }: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      record: any;
+      changes: Record<string, { oldValue: unknown; value: unknown }>;
+    }) => {
+      if (isRevertingRef.current) return;
+
+      const schedulingFields = ['duration', 'startDate', 'endDate'];
+      const hasSchedulingChange = schedulingFields.some(f => f in changes);
+      if (!hasSchedulingChange) return;
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      const error = validateParentDuration(record);
+      if (!error) return;
+
+      isRevertingRef.current = true;
+      try {
+        const revertData: Record<string, unknown> = {};
+        for (const field of schedulingFields) {
+          if (field in changes) {
+            revertData[field] = changes[field]!.oldValue;
+          }
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        record.set(revertData);
+      } finally {
+        isRevertingRef.current = false;
+      }
+
+      showSnackbar(error, 'warning');
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    gantt.project.taskStore.on('update', onTaskUpdate);
+    return () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      gantt.project?.taskStore?.un('update', onTaskUpdate);
+    };
+  }, [isLoading, getGanttInstance, showSnackbar]);
 
   // Silently refresh data when returning to the Gantt tab after the stale threshold.
   // Bryntum's CrudManager merges fresh data without resetting scroll, selections, or expanded state.
@@ -128,6 +226,10 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
         onZoomToFit={handleZoomToFit}
         onShiftPrevious={handleShiftPrevious}
         onShiftNext={handleShiftNext}
+        onSave={handleSave}
+        isSaving={isSaving}
+        hasPendingChanges={hasPendingChanges}
+        justSaved={justSaved}
       />
 
       <div style={GANTT_CONTENT_STYLE} className="bryntum-gantt-container">

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -26,6 +26,9 @@ const WRAPPER_STYLE: CSSProperties = {
 
 const GANTT_CONTENT_STYLE: CSSProperties = {
   flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  position: 'relative',
   overflow: 'clip',
 };
 
@@ -238,10 +241,8 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
 
       {/* Bryntum must always render in a visible container so its internal layout
           calculations use real dimensions.  The loading/error overlays sit on top. */}
-      <div style={{ ...GANTT_CONTENT_STYLE, position: 'relative' }} className="bryntum-gantt-container">
-        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
-          <BryntumGantt ref={ganttRef} {...ganttConfig} />
-        </div>
+      <div style={GANTT_CONTENT_STYLE} className="bryntum-gantt-container">
+        <BryntumGantt ref={ganttRef} {...ganttConfig} />
 
         {isLoading && (
           <Box

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -318,6 +318,19 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
 
       {/* Bryntum must always render in a visible container so its internal layout
           calculations use real dimensions.  The loading/error overlays sit on top. */}
+      <style>{`
+        .bryntum-gantt-container .b-tree-cell { cursor: pointer; }
+        .bryntum-gantt-container .b-gantt-task.b-highlight {
+          animation: gantt-bar-glow 1s ease-out !important;
+          outline: none !important;
+        }
+        @keyframes gantt-bar-glow {
+          0% { box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.6); }
+          50% { box-shadow: inset 0 0 6px rgba(255, 255, 255, 0.3); }
+          100% { box-shadow: none; }
+        }
+      `}</style>
+
       <div style={GANTT_CONTENT_STYLE} className="bryntum-gantt-container">
         <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
           <BryntumGantt ref={ganttRef} {...ganttConfig} />

--- a/src/components/bryntum/components/BryntumPanelHeader.tsx
+++ b/src/components/bryntum/components/BryntumPanelHeader.tsx
@@ -93,6 +93,8 @@ type BryntumPanelHeaderProps = {
   isSaving?: boolean;
   hasPendingChanges?: boolean;
   justSaved?: boolean;
+  autoSaveEnabled?: boolean;
+  onToggleAutoSave?: () => void;
 };
 
 export function BryntumPanelHeader({
@@ -107,6 +109,8 @@ export function BryntumPanelHeader({
   isSaving,
   hasPendingChanges,
   justSaved,
+  autoSaveEnabled = false,
+  onToggleAutoSave,
 }: BryntumPanelHeaderProps) {
   const [activePreset, setActivePreset] = useState('weekAndDayLetter');
 
@@ -133,6 +137,9 @@ export function BryntumPanelHeader({
         }
         .gantt-add-task-btn:active {
           transform: scale(0.97);
+        }
+        .gantt-autosave-toggle:hover {
+          opacity: 1 !important;
         }
       `}</style>
 
@@ -188,6 +195,55 @@ export function BryntumPanelHeader({
       {/* Spacer pushes action buttons to the right */}
       <div style={{ flex: 1 }} />
 
+      {/* Auto-save toggle */}
+      {onToggleAutoSave && (
+        <button
+          className="gantt-autosave-toggle"
+          onClick={onToggleAutoSave}
+          title={autoSaveEnabled ? 'Auto-save is on — click to disable' : 'Auto-save is off — click to enable'}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '7px',
+            padding: '4px 10px',
+            fontSize: '0.75rem',
+            fontWeight: 500,
+            color: autoSaveEnabled ? 'var(--success, #16a34a)' : 'var(--text-secondary)',
+            backgroundColor: 'transparent',
+            border: `1px solid ${autoSaveEnabled ? 'var(--success, #16a34a)' : 'var(--border-color)'}`,
+            borderRadius: '6px',
+            cursor: 'pointer',
+            opacity: autoSaveEnabled ? 1 : 0.55,
+            transition: 'color 0.15s, border-color 0.15s, opacity 0.15s',
+            userSelect: 'none',
+          }}
+        >
+          {/* Toggle pill */}
+          <span style={{
+            display: 'inline-flex',
+            width: '26px',
+            height: '15px',
+            borderRadius: '8px',
+            backgroundColor: autoSaveEnabled ? 'var(--success, #16a34a)' : 'var(--border-color)',
+            padding: '2px',
+            alignItems: 'center',
+            flexShrink: 0,
+            transition: 'background-color 0.2s',
+          }}>
+            <span style={{
+              width: '11px',
+              height: '11px',
+              borderRadius: '50%',
+              backgroundColor: 'white',
+              transform: autoSaveEnabled ? 'translateX(11px)' : 'translateX(0)',
+              transition: 'transform 0.2s',
+              flexShrink: 0,
+            }} />
+          </span>
+          Auto-save
+        </button>
+      )}
+
       {onAddTask && (
         <button
           className="gantt-add-task-btn"
@@ -201,7 +257,8 @@ export function BryntumPanelHeader({
         </button>
       )}
 
-      {onSave && (
+      {/* Only show manual save button when auto-save is off */}
+      {onSave && !autoSaveEnabled && (
         <button
           style={{
             ...SAVE_BUTTON_STYLE,

--- a/src/components/bryntum/components/BryntumPanelHeader.tsx
+++ b/src/components/bryntum/components/BryntumPanelHeader.tsx
@@ -35,7 +35,22 @@ const TITLE_STYLE: CSSProperties = {
   flex: 1,
 };
 
-const ADD_BUTTON_STYLE: CSSProperties = {
+const ADD_TASK_BUTTON_STYLE: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  padding: '5px 14px',
+  fontSize: '0.8rem',
+  fontWeight: 600,
+  color: 'var(--accent-primary, #2563eb)',
+  backgroundColor: 'transparent',
+  border: '1px solid var(--accent-primary, #2563eb)',
+  borderRadius: '6px',
+  cursor: 'pointer',
+  transition: 'background-color 0.15s, color 0.15s, box-shadow 0.15s',
+};
+
+const SAVE_BUTTON_STYLE: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   gap: '4px',
@@ -140,6 +155,14 @@ export function BryntumPanelHeader({
           from { stroke-dashoffset: 20; opacity: 0; }
           to { stroke-dashoffset: 0; opacity: 1; }
         }
+        .gantt-add-task-btn:hover {
+          background-color: var(--accent-primary, #2563eb) !important;
+          color: #fff !important;
+          box-shadow: 0 1px 3px rgba(37, 99, 235, 0.25);
+        }
+        .gantt-add-task-btn:active {
+          transform: scale(0.97);
+        }
       `}</style>
       <div style={TITLE_ROW_STYLE}>
         <svg style={ICON_STYLE} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -147,14 +170,21 @@ export function BryntumPanelHeader({
         </svg>
         <h2 style={TITLE_STYLE}>{title}</h2>
         {onAddTask && (
-          <button style={ADD_BUTTON_STYLE} onClick={onAddTask}>
-            + Add Task
+          <button
+            className="gantt-add-task-btn"
+            style={ADD_TASK_BUTTON_STYLE}
+            onClick={onAddTask}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+            Add Task
           </button>
         )}
         {onSave && (
           <button
             style={{
-              ...ADD_BUTTON_STYLE,
+              ...SAVE_BUTTON_STYLE,
               ...(isSaving || justSaved
                 ? {
                     color: justSaved ? 'var(--success, #16a34a)' : 'var(--text-secondary)',

--- a/src/components/bryntum/components/BryntumPanelHeader.tsx
+++ b/src/components/bryntum/components/BryntumPanelHeader.tsx
@@ -102,6 +102,10 @@ type BryntumPanelHeaderProps = {
   onZoomToFit?: () => void;
   onShiftPrevious?: () => void;
   onShiftNext?: () => void;
+  onSave?: () => void;
+  isSaving?: boolean;
+  hasPendingChanges?: boolean;
+  justSaved?: boolean;
 };
 
 export function BryntumPanelHeader({
@@ -113,6 +117,10 @@ export function BryntumPanelHeader({
   onZoomToFit,
   onShiftPrevious,
   onShiftNext,
+  onSave,
+  isSaving,
+  hasPendingChanges,
+  justSaved,
 }: BryntumPanelHeaderProps) {
   const [activePreset, setActivePreset] = useState('weekAndDayLetter');
 
@@ -123,6 +131,16 @@ export function BryntumPanelHeader({
 
   return (
     <div style={HEADER_STYLE}>
+      <style>{`
+        @keyframes gantt-save-spin {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
+        }
+        @keyframes gantt-check-draw {
+          from { stroke-dashoffset: 20; opacity: 0; }
+          to { stroke-dashoffset: 0; opacity: 1; }
+        }
+      `}</style>
       <div style={TITLE_ROW_STYLE}>
         <svg style={ICON_STYLE} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" />
@@ -131,6 +149,65 @@ export function BryntumPanelHeader({
         {onAddTask && (
           <button style={ADD_BUTTON_STYLE} onClick={onAddTask}>
             + Add Task
+          </button>
+        )}
+        {onSave && (
+          <button
+            style={{
+              ...ADD_BUTTON_STYLE,
+              ...(isSaving || justSaved
+                ? {
+                    color: justSaved ? 'var(--success, #16a34a)' : 'var(--text-secondary)',
+                    border: justSaved ? '1px solid var(--success, #16a34a)' : '1px solid var(--border-color)',
+                    opacity: isSaving ? 0.7 : 1,
+                    cursor: 'default',
+                  }
+                : hasPendingChanges
+                  ? {
+                      color: 'var(--accent-primary, #2563eb)',
+                      border: '1px solid var(--accent-primary, #2563eb)',
+                    }
+                  : {
+                      opacity: 0.5,
+                      cursor: 'default',
+                    }),
+            }}
+            onClick={hasPendingChanges && !isSaving && !justSaved ? onSave : undefined}
+            disabled={!hasPendingChanges || isSaving || justSaved}
+            title={isSaving ? 'Saving…' : justSaved ? 'Changes saved' : hasPendingChanges ? 'Save changes' : 'No unsaved changes'}
+          >
+            {isSaving && (
+              <span style={{
+                display: 'inline-block',
+                width: 11,
+                height: 11,
+                border: '2px solid currentColor',
+                borderTopColor: 'transparent',
+                borderRadius: '50%',
+                animation: 'gantt-save-spin 0.65s linear infinite',
+                flexShrink: 0,
+              }} />
+            )}
+            {justSaved && (
+              <svg
+                width={11}
+                height={11}
+                viewBox="0 0 12 12"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                style={{ flexShrink: 0 }}
+              >
+                <path
+                  d="M1.5 6.5 L4.5 9.5 L10.5 2.5"
+                  strokeDasharray="20"
+                  style={{ animation: 'gantt-check-draw 0.35s ease-out forwards' }}
+                />
+              </svg>
+            )}
+            {isSaving ? 'Saving…' : hasPendingChanges ? 'Save' : 'Saved'}
           </button>
         )}
       </div>

--- a/src/components/bryntum/components/BryntumPanelHeader.tsx
+++ b/src/components/bryntum/components/BryntumPanelHeader.tsx
@@ -2,37 +2,10 @@ import { useState, type CSSProperties } from 'react';
 
 const HEADER_STYLE: CSSProperties = {
   display: 'flex',
-  flexDirection: 'column',
-  borderBottom: '1px solid var(--border-color)',
-};
-
-const TITLE_ROW_STYLE: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: '8px',
-  padding: '12px 16px',
-};
-
-const TOOLBAR_ROW_STYLE: CSSProperties = {
-  display: 'flex',
   alignItems: 'center',
   gap: '12px',
-  padding: '0 16px 10px',
-};
-
-const ICON_STYLE: CSSProperties = {
-  width: '16px',
-  height: '16px',
-  color: 'var(--text-secondary)',
-};
-
-const TITLE_STYLE: CSSProperties = {
-  fontSize: '0.75rem',
-  textTransform: 'uppercase',
-  letterSpacing: '0.05em',
-  fontWeight: 500,
-  color: 'var(--text-secondary)',
-  flex: 1,
+  padding: '10px 16px',
+  borderBottom: '1px solid var(--border-color)',
 };
 
 const ADD_TASK_BUTTON_STYLE: CSSProperties = {
@@ -109,7 +82,6 @@ const VIEW_PRESETS = [
 ] as const;
 
 type BryntumPanelHeaderProps = {
-  title: string;
   onAddTask?: () => void;
   onPresetChange?: (preset: string) => void;
   onZoomIn?: () => void;
@@ -124,7 +96,6 @@ type BryntumPanelHeaderProps = {
 };
 
 export function BryntumPanelHeader({
-  title,
   onAddTask,
   onPresetChange,
   onZoomIn,
@@ -164,134 +135,131 @@ export function BryntumPanelHeader({
           transform: scale(0.97);
         }
       `}</style>
-      <div style={TITLE_ROW_STYLE}>
-        <svg style={ICON_STYLE} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-          <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" />
-        </svg>
-        <h2 style={TITLE_STYLE}>{title}</h2>
-        {onAddTask && (
-          <button
-            className="gantt-add-task-btn"
-            style={ADD_TASK_BUTTON_STYLE}
-            onClick={onAddTask}
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-              <path d="M12 5v14M5 12h14" />
-            </svg>
-            Add Task
-          </button>
-        )}
-        {onSave && (
-          <button
-            style={{
-              ...SAVE_BUTTON_STYLE,
-              ...(isSaving || justSaved
+
+      {/* View preset selector */}
+      <div style={BUTTON_GROUP_STYLE}>
+        {VIEW_PRESETS.map((preset, i) => {
+          const isActive = activePreset === preset.value;
+          const isLast = i === VIEW_PRESETS.length - 1;
+          const style = isActive
+            ? { ...ACTIVE_BUTTON_STYLE, ...(isLast ? { borderRight: 'none' } : {}) }
+            : isLast
+              ? TOOLBAR_BUTTON_LAST_STYLE
+              : TOOLBAR_BUTTON_STYLE;
+          return (
+            <button
+              key={preset.value}
+              style={style}
+              onClick={() => handlePresetClick(preset.value)}
+            >
+              {preset.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={SEPARATOR_STYLE} />
+
+      {/* Zoom controls */}
+      <div style={BUTTON_GROUP_STYLE}>
+        <button style={TOOLBAR_BUTTON_STYLE} onClick={onZoomOut} title="Zoom out">
+          −
+        </button>
+        <button style={TOOLBAR_BUTTON_STYLE} onClick={onZoomIn} title="Zoom in">
+          +
+        </button>
+        <button style={TOOLBAR_BUTTON_LAST_STYLE} onClick={onZoomToFit} title="Zoom to fit">
+          Fit
+        </button>
+      </div>
+
+      <div style={SEPARATOR_STYLE} />
+
+      {/* Time navigation */}
+      <div style={BUTTON_GROUP_STYLE}>
+        <button style={TOOLBAR_BUTTON_STYLE} onClick={onShiftPrevious} title="Previous time span">
+          ←
+        </button>
+        <button style={TOOLBAR_BUTTON_LAST_STYLE} onClick={onShiftNext} title="Next time span">
+          →
+        </button>
+      </div>
+
+      {/* Spacer pushes action buttons to the right */}
+      <div style={{ flex: 1 }} />
+
+      {onAddTask && (
+        <button
+          className="gantt-add-task-btn"
+          style={ADD_TASK_BUTTON_STYLE}
+          onClick={onAddTask}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+            <path d="M12 5v14M5 12h14" />
+          </svg>
+          Add Task
+        </button>
+      )}
+
+      {onSave && (
+        <button
+          style={{
+            ...SAVE_BUTTON_STYLE,
+            ...(isSaving || justSaved
+              ? {
+                  color: justSaved ? 'var(--success, #16a34a)' : 'var(--text-secondary)',
+                  border: justSaved ? '1px solid var(--success, #16a34a)' : '1px solid var(--border-color)',
+                  opacity: isSaving ? 0.7 : 1,
+                  cursor: 'default',
+                }
+              : hasPendingChanges
                 ? {
-                    color: justSaved ? 'var(--success, #16a34a)' : 'var(--text-secondary)',
-                    border: justSaved ? '1px solid var(--success, #16a34a)' : '1px solid var(--border-color)',
-                    opacity: isSaving ? 0.7 : 1,
-                    cursor: 'default',
+                    color: 'var(--accent-primary, #2563eb)',
+                    border: '1px solid var(--accent-primary, #2563eb)',
                   }
-                : hasPendingChanges
-                  ? {
-                      color: 'var(--accent-primary, #2563eb)',
-                      border: '1px solid var(--accent-primary, #2563eb)',
-                    }
-                  : {
-                      opacity: 0.5,
-                      cursor: 'default',
-                    }),
-            }}
-            onClick={hasPendingChanges && !isSaving && !justSaved ? onSave : undefined}
-            disabled={!hasPendingChanges || isSaving || justSaved}
-            title={isSaving ? 'Saving…' : justSaved ? 'Changes saved' : hasPendingChanges ? 'Save changes' : 'No unsaved changes'}
-          >
-            {isSaving && (
-              <span style={{
-                display: 'inline-block',
-                width: 11,
-                height: 11,
-                border: '2px solid currentColor',
-                borderTopColor: 'transparent',
-                borderRadius: '50%',
-                animation: 'gantt-save-spin 0.65s linear infinite',
-                flexShrink: 0,
-              }} />
-            )}
-            {justSaved && (
-              <svg
-                width={11}
-                height={11}
-                viewBox="0 0 12 12"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                style={{ flexShrink: 0 }}
-              >
-                <path
-                  d="M1.5 6.5 L4.5 9.5 L10.5 2.5"
-                  strokeDasharray="20"
-                  style={{ animation: 'gantt-check-draw 0.35s ease-out forwards' }}
-                />
-              </svg>
-            )}
-            {isSaving ? 'Saving…' : hasPendingChanges ? 'Save' : 'Saved'}
-          </button>
-        )}
-      </div>
-
-      <div style={TOOLBAR_ROW_STYLE}>
-        {/* View preset selector */}
-        <div style={BUTTON_GROUP_STYLE}>
-          {VIEW_PRESETS.map((preset, i) => {
-            const isActive = activePreset === preset.value;
-            const isLast = i === VIEW_PRESETS.length - 1;
-            const style = isActive
-              ? { ...ACTIVE_BUTTON_STYLE, ...(isLast ? { borderRight: 'none' } : {}) }
-              : isLast
-                ? TOOLBAR_BUTTON_LAST_STYLE
-                : TOOLBAR_BUTTON_STYLE;
-            return (
-              <button
-                key={preset.value}
-                style={style}
-                onClick={() => handlePresetClick(preset.value)}
-              >
-                {preset.label}
-              </button>
-            );
-          })}
-        </div>
-
-        <div style={SEPARATOR_STYLE} />
-
-        {/* Zoom controls */}
-        <div style={BUTTON_GROUP_STYLE}>
-          <button style={TOOLBAR_BUTTON_STYLE} onClick={onZoomOut} title="Zoom out">
-            −
-          </button>
-          <button style={TOOLBAR_BUTTON_STYLE} onClick={onZoomIn} title="Zoom in">
-            +
-          </button>
-          <button style={TOOLBAR_BUTTON_LAST_STYLE} onClick={onZoomToFit} title="Zoom to fit">
-            Fit
-          </button>
-        </div>
-
-        <div style={SEPARATOR_STYLE} />
-
-        {/* Time navigation */}
-        <div style={BUTTON_GROUP_STYLE}>
-          <button style={TOOLBAR_BUTTON_STYLE} onClick={onShiftPrevious} title="Previous time span">
-            ←
-          </button>
-          <button style={TOOLBAR_BUTTON_LAST_STYLE} onClick={onShiftNext} title="Next time span">
-            →
-          </button>
-        </div>
-      </div>
+                : {
+                    opacity: 0.5,
+                    cursor: 'default',
+                  }),
+          }}
+          onClick={hasPendingChanges && !isSaving && !justSaved ? onSave : undefined}
+          disabled={!hasPendingChanges || isSaving || justSaved}
+          title={isSaving ? 'Saving…' : justSaved ? 'Changes saved' : hasPendingChanges ? 'Save changes' : 'No unsaved changes'}
+        >
+          {isSaving && (
+            <span style={{
+              display: 'inline-block',
+              width: 11,
+              height: 11,
+              border: '2px solid currentColor',
+              borderTopColor: 'transparent',
+              borderRadius: '50%',
+              animation: 'gantt-save-spin 0.65s linear infinite',
+              flexShrink: 0,
+            }} />
+          )}
+          {justSaved && (
+            <svg
+              width={11}
+              height={11}
+              viewBox="0 0 12 12"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              style={{ flexShrink: 0 }}
+            >
+              <path
+                d="M1.5 6.5 L4.5 9.5 L10.5 2.5"
+                strokeDasharray="20"
+                style={{ animation: 'gantt-check-draw 0.35s ease-out forwards' }}
+              />
+            </svg>
+          )}
+          {isSaving ? 'Saving…' : hasPendingChanges ? 'Save' : 'Saved'}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -7,7 +7,7 @@ import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
 import { TreeItem } from '@mui/x-tree-view/TreeItem';
 import { POPOVER_WIDTH } from '../constants';
 import type { PopoverPlacement } from '../types';
-import { folderData } from '@/components/projects/ProjectsTree';
+import { folderData } from '@/lib/folders';
 import { useProjectContext } from '@/components/providers/ProjectProvider';
 import UploadDialog from '@/components/documents/UploadDialog';
 import { api } from '@/trpc/react';

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -1,4 +1,4 @@
-import type { GanttConfig, TaskClickHandler } from '../types';
+import type { GanttConfig } from '../types';
 import { SCROLL_TO_COLUMN_ID } from '../constants';
 
 function formatTooltipText(record: Record<string, unknown>, field?: string): string {
@@ -21,7 +21,6 @@ interface LoadingCallbacks {
 }
 
 export function createGanttConfig(
-  onTaskClick: TaskClickHandler,
   projectId?: string,
   loadingCallbacks?: LoadingCallbacks
 ): GanttConfig {
@@ -126,7 +125,6 @@ export function createGanttConfig(
     endDate: new Date(new Date().getFullYear(), new Date().getMonth() + 24, 1),
     barMargin: 10,
     listeners: {
-      taskClick: onTaskClick,
       // Bryntum blocks the duration cell editor for parent tasks before
       // beforeCellEditStart ever fires (checked internally in DurationColumn).
       // cellDblClick fires first, so we can set manuallyScheduled: true here —

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -110,7 +110,8 @@ export function createGanttConfig(
         renderer({ record }: { record: { startDate?: Date | null } }) {
           const isScheduled = record.startDate != null;
           if (!isScheduled) return '';
-          return `<div class="scroll-to-timeline-btn" title="Scroll to timeline" style="display:flex;align-items:center;justify-content:center;height:100%;cursor:pointer;opacity:0.4;transition:opacity 0.15s" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.4'"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></div>`;
+          // Phosphor NavigationArrow (fill weight, viewBox 0 0 256 256)
+          return `<div class="scroll-to-timeline-btn" title="Scroll to timeline" style="display:flex;align-items:center;justify-content:center;height:100%;cursor:pointer;opacity:0.4;transition:opacity 0.15s" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.4'"><svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M248,121.58a15.76,15.76,0,0,1-11.29,15l-.2.06-78,21.84-21.84,78-.06.2a15.77,15.77,0,0,1-15,11.29h-.3a15.77,15.77,0,0,1-15.07-10.67L41,61.41a1,1,0,0,1-.05-.16A16,16,0,0,1,61.25,40.9l.16.05,175.92,65.26A15.78,15.78,0,0,1,248,121.58Z"/></svg></div>`;
         },
       } as any,
     ],
@@ -141,11 +142,11 @@ export function createGanttConfig(
       },
       cellClick({ record, column, grid }: {
         record: { id: string | number; startDate?: Date | null };
-        column: { id?: string };
+        column: { id?: string } | undefined;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         grid: any;
       }) {
-        if (column.id !== SCROLL_TO_COLUMN_ID) return;
+        if (!column || column.id !== SCROLL_TO_COLUMN_ID) return;
         if (!record.startDate) return;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         grid.scrollTaskIntoView(record, {

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -1,4 +1,5 @@
 import type { GanttConfig, TaskClickHandler } from '../types';
+import { SCROLL_TO_COLUMN_ID } from '../constants';
 
 function formatTooltipText(record: Record<string, unknown>, field?: string): string {
   if (!field) {
@@ -35,7 +36,7 @@ export function createGanttConfig(
 
     project: {
       autoLoad: true,
-      autoSync: !!projectId,
+      autoSync: false,
 
       // Enable delay calculation for better initial load performance
       delayCalculation: true,
@@ -72,6 +73,7 @@ export function createGanttConfig(
         },
       },
     },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     columns: [
       {
         type: 'name',
@@ -93,6 +95,24 @@ export function createGanttConfig(
         width: 100,
         resizable: true,
       },
+      // Action column: chevron icon to scroll timeline to the task's bar
+      {
+        type: 'column',
+        id: SCROLL_TO_COLUMN_ID,
+        text: '',
+        width: 40,
+        resizable: false,
+        sortable: false,
+        filterable: false,
+        htmlEncode: false,
+        editor: false,
+        cellCls: 'b-scroll-to-cell',
+        renderer({ record }: { record: { startDate?: Date | null } }) {
+          const isScheduled = record.startDate != null;
+          if (!isScheduled) return '';
+          return `<div class="scroll-to-timeline-btn" title="Scroll to timeline" style="display:flex;align-items:center;justify-content:center;height:100%;cursor:pointer;opacity:0.4;transition:opacity 0.15s" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.4'"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></div>`;
+        },
+      } as any,
     ],
     features: {
       cellTooltip: {
@@ -118,6 +138,21 @@ export function createGanttConfig(
         if (column.type === 'duration' && record.isParent && !record.manuallyScheduled) {
           record.set('manuallyScheduled', true);
         }
+      },
+      cellClick({ record, column, grid }: {
+        record: { id: string | number; startDate?: Date | null };
+        column: { id?: string };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        grid: any;
+      }) {
+        if (column.id !== SCROLL_TO_COLUMN_ID) return;
+        if (!record.startDate) return;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        grid.scrollTaskIntoView(record, {
+          block: 'center',
+          animate: { duration: 300 },
+          highlight: true,
+        });
       },
     },
   };

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -1,5 +1,4 @@
 import type { GanttConfig } from '../types';
-import { SCROLL_TO_COLUMN_ID } from '../constants';
 
 function formatTooltipText(record: Record<string, unknown>, field?: string): string {
   if (!field) {
@@ -13,6 +12,9 @@ function formatTooltipText(record: Record<string, unknown>, field?: string): str
 
   return String(value);
 }
+
+// Debounce timer so a double-click (edit) cancels the single-click scroll
+let pendingScrollTimer: ReturnType<typeof setTimeout> | undefined;
 
 interface LoadingCallbacks {
   onLoadStart?: () => void;
@@ -81,6 +83,8 @@ export function createGanttConfig(
         minWidth: 300,
         resizable: true,
       },
+      // Single-clicking the name cell scrolls the timeline to the task's bar (see cellClick listener).
+      // Double-clicking starts inline name editing (Bryntum native behavior).
       {
         type: 'startdate',
         field: 'startDate',
@@ -94,25 +98,6 @@ export function createGanttConfig(
         width: 100,
         resizable: true,
       },
-      // Action column: chevron icon to scroll timeline to the task's bar
-      {
-        type: 'column',
-        id: SCROLL_TO_COLUMN_ID,
-        text: '',
-        width: 40,
-        resizable: false,
-        sortable: false,
-        filterable: false,
-        htmlEncode: false,
-        editor: false,
-        cellCls: 'b-scroll-to-cell',
-        renderer({ record }: { record: { startDate?: Date | null } }) {
-          const isScheduled = record.startDate != null;
-          if (!isScheduled) return '';
-          // Phosphor NavigationArrow (fill weight, viewBox 0 0 256 256)
-          return `<div class="scroll-to-timeline-btn" title="Scroll to timeline" style="display:flex;align-items:center;justify-content:center;height:100%;cursor:pointer;opacity:0.4;transition:opacity 0.15s" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.4'"><svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M248,121.58a15.76,15.76,0,0,1-11.29,15l-.2.06-78,21.84-21.84,78-.06.2a15.77,15.77,0,0,1-15,11.29h-.3a15.77,15.77,0,0,1-15.07-10.67L41,61.41a1,1,0,0,1-.05-.16A16,16,0,0,1,61.25,40.9l.16.05,175.92,65.26A15.78,15.78,0,0,1,248,121.58Z"/></svg></div>`;
-        },
-      } as any,
     ],
     features: {
       cellTooltip: {
@@ -134,24 +119,32 @@ export function createGanttConfig(
         record: { isParent: boolean; manuallyScheduled: boolean; set: (field: string, value: unknown) => void };
         column: { type: string };
       }) {
+        // Cancel any pending single-click scroll so editing starts cleanly
+        clearTimeout(pendingScrollTimer);
         if (column.type === 'duration' && record.isParent && !record.manuallyScheduled) {
           record.set('manuallyScheduled', true);
         }
       },
+      // Single-click on the task name cell → scroll the timeline bar into view.
+      // Guards against unscheduled tasks (no startDate) to avoid a Bryntum crash.
       cellClick({ record, column, grid }: {
         record: { id: string | number; startDate?: Date | null };
-        column: { id?: string } | undefined;
+        column: { type?: string } | undefined;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         grid: any;
       }) {
-        if (!column || column.id !== SCROLL_TO_COLUMN_ID) return;
+        if (column?.type !== 'name') return;
         if (!record.startDate) return;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-        grid.scrollTaskIntoView(record, {
-          block: 'center',
-          animate: { duration: 300 },
-          highlight: true,
-        });
+        // Debounce: wait 200ms so a double-click (edit) can cancel the scroll
+        clearTimeout(pendingScrollTimer);
+        pendingScrollTimer = setTimeout(() => {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+          grid.scrollTaskIntoView(record, {
+            block: 'center',
+            animate: { duration: 300 },
+            highlight: true,
+          });
+        }, 200);
       },
     },
   };

--- a/src/components/bryntum/constants.ts
+++ b/src/components/bryntum/constants.ts
@@ -1,4 +1,3 @@
-export const SCROLL_TO_COLUMN_ID = 'scroll-to-task';
 export const POPOVER_WIDTH = 320;
 export const POPOVER_GAP = 8;
 export const ESTIMATED_POPOVER_HEIGHT = 200;

--- a/src/components/bryntum/constants.ts
+++ b/src/components/bryntum/constants.ts
@@ -1,3 +1,4 @@
+export const SCROLL_TO_COLUMN_ID = 'scroll-to-task';
 export const POPOVER_WIDTH = 320;
 export const POPOVER_GAP = 8;
 export const ESTIMATED_POPOVER_HEIGHT = 200;

--- a/src/components/bryntum/hooks/useGanttControls.ts
+++ b/src/components/bryntum/hooks/useGanttControls.ts
@@ -20,11 +20,14 @@ export function useGanttControls() {
       startDate: new Date(),
       duration: 1,
     });
-    // Let the scheduling engine process, then scroll to show the new task
+    // Immediately scroll the timeline to today so the task bar area is visible
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    gantt.scrollToDate(new Date(), { block: 'center', animate: true });
+    // After the scheduling engine processes, scroll to the specific task row + bar
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     void gantt.project.commitAsync().then(() => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      if (task) gantt.scrollTaskIntoView(task, { block: 'nearest', animate: { duration: 300 } });
+      if (task) gantt.scrollTaskIntoView(task, { block: 'center', animate: { duration: 300 } });
     });
   }, [getGanttInstance]);
 

--- a/src/components/bryntum/hooks/useGanttControls.ts
+++ b/src/components/bryntum/hooks/useGanttControls.ts
@@ -11,15 +11,21 @@ export function useGanttControls() {
     return (ganttRef.current as unknown as { instance: unknown })?.instance;
   }, []);
 
-  const handleAddTask = useCallback(async () => {
+  const handleAddTask = useCallback(() => {
     const gantt = getGanttInstance();
     if (!gantt) return;
-    gantt.taskStore.add({
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    const [task] = gantt.taskStore.add({
       name: 'New Task',
       startDate: new Date(),
       duration: 1,
     });
-    await gantt.project.commitAsync();
+    // Let the scheduling engine process, then scroll to show the new task
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    void gantt.project.commitAsync().then(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      if (task) gantt.scrollTaskIntoView(task, { block: 'nearest', animate: { duration: 300 } });
+    });
   }, [getGanttInstance]);
 
   const handleZoomIn = useCallback(() => getGanttInstance()?.zoomIn(), [getGanttInstance]);

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -90,5 +90,7 @@ export type GanttConfig = {
     taskClick: TaskClickHandler;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     cellDblClick?: (...args: any[]) => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    cellClick?: (...args: any[]) => void;
   };
 };

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -87,7 +87,7 @@ export type GanttConfig = {
   endDate?: Date;
   barMargin: number;
   listeners: {
-    taskClick: TaskClickHandler;
+    taskClick?: TaskClickHandler;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     cellDblClick?: (...args: any[]) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/bryntum/utils/ganttValidation.ts
+++ b/src/components/bryntum/utils/ganttValidation.ts
@@ -1,0 +1,61 @@
+/**
+ * Minimal shape we need from a Bryntum task record for validation.
+ */
+export interface BryntumTaskRecord {
+  isParent: boolean;
+  manuallyScheduled: boolean;
+  endDate: Date | null | undefined;
+  startDate: Date | null | undefined;
+  name?: string | unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  children: any; // Bryntum stores children as an internal collection
+}
+
+/**
+ * Checks whether a manually-scheduled parent task's date range
+ * still encompasses all of its direct children after a change.
+ *
+ * Returns null when valid, or a user-facing error string when invalid.
+ *
+ * Only checks direct children — sufficient because each nested parent
+ * validates independently when its own dates change via the taskStore
+ * update event.
+ */
+export function validateParentDuration(record: BryntumTaskRecord): string | null {
+  if (!record.isParent || !record.manuallyScheduled) {
+    return null;
+  }
+
+  const parentEnd = record.endDate;
+  if (!parentEnd) {
+    return null;
+  }
+
+  // Bryntum's children collection exposes .toArray() to get a plain array
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+  const children: BryntumTaskRecord[] = (record.children?.toArray?.() ?? []) as BryntumTaskRecord[];
+
+  if (children.length === 0) {
+    return null;
+  }
+
+  let latestChildEnd: Date | null = null;
+  for (const child of children) {
+    const childEnd = child.endDate;
+    if (!childEnd) continue;
+    if (!latestChildEnd || childEnd > latestChildEnd) {
+      latestChildEnd = childEnd;
+    }
+  }
+
+  if (!latestChildEnd) {
+    return null;
+  }
+
+  if (parentEnd < latestChildEnd) {
+    const taskName = typeof record.name === 'string' ? record.name : 'Task';
+    return `"${taskName}" cannot be shorter than its subtasks. Change reverted.`;
+  }
+
+  return null;
+}

--- a/src/server/api/helpers/ganttSync.ts
+++ b/src/server/api/helpers/ganttSync.ts
@@ -22,7 +22,7 @@ export async function syncTasks(
   if (changes.removed) {
     await db.ganttTask.deleteMany({
       where: {
-        id: { in: changes.removed.map((r) => r.id) },
+        id: { in: changes.removed.filter((r): r is { id: string } => r != null && typeof r.id === 'string').map((r) => r.id) },
         projectId,
       },
     });
@@ -173,7 +173,7 @@ export async function syncDependencies(
   if (changes.removed) {
     await db.ganttDependency.deleteMany({
       where: {
-        id: { in: changes.removed.map((r) => r.id) },
+        id: { in: changes.removed.filter((r): r is { id: string } => r != null && typeof r.id === 'string').map((r) => r.id) },
         projectId,
       },
     });
@@ -253,7 +253,7 @@ export async function syncResources(
   if (changes.removed) {
     await db.ganttResource.deleteMany({
       where: {
-        id: { in: changes.removed.map((r) => r.id) },
+        id: { in: changes.removed.filter((r): r is { id: string } => r != null && typeof r.id === 'string').map((r) => r.id) },
         projectId,
       },
     });
@@ -320,7 +320,7 @@ export async function syncAssignments(
   if (changes.removed) {
     await db.ganttAssignment.deleteMany({
       where: {
-        id: { in: changes.removed.map((r) => r.id) },
+        id: { in: changes.removed.filter((r): r is { id: string } => r != null && typeof r.id === 'string').map((r) => r.id) },
         projectId,
       },
     });
@@ -393,7 +393,7 @@ export async function syncTimeRanges(
   if (changes.removed) {
     await db.ganttTimeRange.deleteMany({
       where: {
-        id: { in: changes.removed.map((r) => r.id) },
+        id: { in: changes.removed.filter((r): r is { id: string } => r != null && typeof r.id === 'string').map((r) => r.id) },
         projectId,
       },
     });


### PR DESCRIPTION
## Summary

Added parent task duration validation to enforce Gantt chart best practices, and implemented save button state management with visual feedback.

**Parent Duration Validation:** When a user manually edits a parent task's duration, the system now validates that the parent still spans all of its subtasks. If the duration would be shorter than required, the change is reverted and a warning is shown via snackbar.

**Save Button State:** Added `isSaving`, `hasPendingChanges`, and `justSaved` states to the Gantt wrapper with corresponding listeners for sync events. The header now shows visual feedback: "Saving..." during sync, and a green checkmark briefly on success.

## Changes

- `src/components/bryntum/utils/ganttValidation.ts` — New utility with pure validation function
- `src/components/bryntum/BryntumGanttWrapper.tsx` — Added validation listener and save state management
- `src/components/bryntum/components/BryntumPanelHeader.tsx` — Save button UI with state indicators
- `src/components/bryntum/config/ganttConfig.ts` — Config updates
- `src/components/bryntum/constants.ts`, `types.ts` — Supporting type/constant additions

## Test Plan

1. Create a parent task with child tasks in a project
2. Double-click the parent's duration to enable manual editing
3. Try setting a shorter duration → expect warning and automatic revert
4. Try setting a duration equal to or longer → expect success
5. Make changes to any tasks and click Save → expect visual feedback
6. Verify typecheck passes: `npm run typecheck`