### PR TITLE
Drop redundant BETTER_AUTH_URL from auth config

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,7 +17,6 @@ export const auth = betterAuth({
     "http://localhost:3000",
     "http://localhost:5050",
     "https://localhost:5050",
-    process.env.BETTER_AUTH_URL || "",
     process.env.APP_URL || "",
     process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "",
   ].filter(Boolean),


### PR DESCRIPTION
Remove BETTER_AUTH_URL from trusted origins since APP_URL and VERCEL_URL already provide the necessary coverage. This simplifies configuration and reduces redundancy.