### PR TITLE
Update auth page logo colors and theme alignment

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -103,6 +103,7 @@ export default function ForgotPasswordPage() {
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
+                  color: 'white',
                 }}
               >
                 <LogoIcon size={28} />

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -184,6 +184,7 @@ function ResetPasswordForm() {
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
+                  color: 'white',
                 }}
               >
                 <LogoIcon size={28} />

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -117,6 +117,7 @@ function SignInForm() {
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
+                  color: 'white',
                 }}
               >
                 <LogoIcon size={28} />

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -114,6 +114,7 @@ export default function SignUpPage() {
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
+                  color: 'white',
                 }}
               >
                 <LogoIcon size={28} />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -16,7 +16,7 @@
   --border-color: #e5e5e5;
   --border-light: #f0f0f0;
 
-  --accent-primary: #171717;
+  --accent-primary: #2B2D42;
   --accent-subtle: rgba(23, 23, 23, 0.06);
 
   --sidebar-border: rgba(0, 0, 0, 0.08);

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -208,8 +208,8 @@ lightTheme.palette.status = {
   badge: '#E67E22',
 };
 lightTheme.palette.warm = {
-  main: '#2B2D42', // $--primary
-  dark: '#1A1C2B',
+  main: '#d97706', // amber, matching --accent-warm
+  dark: '#b45309',
 };
 lightTheme.palette.grid = {
   line: 'rgba(0, 0, 0, 0.04)',


### PR DESCRIPTION
## Summary
Updated logo background colors on all auth pages from dark navy to warm amber for better visual distinction and brand consistency. Aligned CSS variable `--accent-primary` with MUI theme primary color to ensure color consistency across buttons and elements. Added explicit white color to logo icons for proper contrast on the new amber backgrounds.

## Changes
- **Theme palette**: Changed `warm.main` from #2B2D42 (navy) to #d97706 (amber) and `warm.dark` from #1A1C2B to #b45309
- **CSS variables**: Aligned `--accent-primary` from #171717 to #2B2D42 to match MUI primary
- **Logo containers**: Added `color: 'white'` to all logo icon containers (sign-in, sign-up, forgot-password, reset-password)

The logo boxes on auth pages now display with warm amber backgrounds and white icons, improving visual hierarchy and brand warmth for the construction product.