### PR TITLE
Fix staging origin: use APP_URL as Better Auth base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,12 @@
-# Since the ".env.local" file is gitignored, you can use the ".env.example" file to
-# build a new ".env.local" file when you clone the repo. Keep this file up-to-date
-# when you add new variables to `.env`.
-
-# This file will be committed to version control, so make sure not to have any
-# secrets in it. If you are cloning this repo, create a copy of this file named
-# ".env.local" and populate it with your secrets.
-
-# When adding additional environment variables, the schema in "/src/env.js"
-# should be updated accordingly.
+# Environment files per target:
+#   Local dev  → .env.local       (copy this file, fill in values)
+#   Staging    → .env.preview     (pull via: vercel env pull .env.preview --environment preview --scope celn --yes)
+#   Production → .env.production  (pull via: vercel env pull .env.production --environment production --scope celn --yes)
+#
+# To push a single var: printf 'value' | vercel env add KEY environment --scope celn --force
+# See claudedocs/vercel.md for full Vercel CLI reference.
+#
+# When adding new env vars, update the schema in /src/env.js accordingly.
 
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
@@ -15,13 +14,14 @@ DATABASE_URL="postgresql://USER@localhost:5432/construction?schema=public"
 
 # Better Auth
 BETTER_AUTH_SECRET="replace-me"
-BETTER_AUTH_URL="http://localhost:5050"
+
+# App URL — drives Better Auth base URL, trusted origins, and email links
+APP_URL="http://localhost:5050"
 
 # Resend (Email)
 RESEND_API_KEY=""
-APP_URL="http://localhost:5050"
 
-# Vercel (optional, for Vercel CLI)
+# Vercel Blob (auto-provisioned on Vercel, set manually for local dev if needed)
 BLOB_READ_WRITE_TOKEN=""
 
 # Client base URL (optional)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@
 @claudedocs/testing-guide.md
 @claudedocs/components-guide.md
 @claudedocs/embeddings.md
+@claudedocs/vercel.md
 
 ## Documentation Update Rules
 When making changes that affect these docs, update them in the same task:
@@ -17,6 +18,7 @@ When making changes that affect these docs, update them in the same task:
 - New components, naming/styling changes, or new feature slices → update `claudedocs/components-guide.md`
 
 ## Vercel
-- Vercel project name: `construction-web`
-- Production URL: https://construction-web-ashen.vercel.app
-- Database: Neon PostgreSQL (configured via Vercel integration)
+- See `claudedocs/vercel.md` for full Vercel configuration reference
+- Team: CELN (`celn`) — always use `--scope celn` with Vercel CLI
+- Production URL: https://celn.app
+- Staging URL: https://preview.celn.app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ When making changes that affect these docs, update them in the same task:
 - Architecture or TypeScript pattern changes → update `claudedocs/architecture-and-typescript.md`
 - New tests added or test patterns change → update `claudedocs/testing-guide.md`
 - New components, naming/styling changes, or new feature slices → update `claudedocs/components-guide.md`
+- Vercel env vars, deployments, or project config changes → update `claudedocs/vercel.md`
 
 ## Vercel
 - See `claudedocs/vercel.md` for full Vercel configuration reference

--- a/claudedocs/auth-and-permissions.md
+++ b/claudedocs/auth-and-permissions.md
@@ -8,7 +8,7 @@
 - **Session**: Cookie-cached for 5 minutes (`cookieCache.maxAge = 300`)
 - **Cookie names**: `better-auth.session_token` (localhost) / `__Secure-better-auth.session_token` (production)
 - **Custom pages**: `/sign-in`, `/sign-up`
-- **Trusted origins**: Dynamic — in development, any `localhost` origin (any port) is trusted; in production, only `BETTER_AUTH_URL`, `APP_URL`, and `VERCEL_URL`
+- **Trusted origins**: Dynamic — in development, any `localhost` origin (any port) is trusted; in production, `APP_URL` and `VERCEL_URL`. `APP_URL` is also set as `baseURL` in the auth config, so it is the single env var controlling Better Auth's base URL and trusted origins.
 
 ### Client Setup
 

--- a/claudedocs/environment-setup.md
+++ b/claudedocs/environment-setup.md
@@ -8,8 +8,7 @@ Construction project management SaaS (BuildTrack Pro) built on the T3 stack: Nex
 |---|---|---|---|
 | `DATABASE_URL` | PostgreSQL connection string (Neon on Vercel) | Yes | `postgresql://USER@localhost:5432/construction?schema=public` |
 | `BETTER_AUTH_SECRET` | Signing secret for Better Auth sessions | Yes | Any strong random string |
-| `BETTER_AUTH_URL` | Base URL Better Auth uses for callbacks | Yes | `http://localhost:5050` |
-| `APP_URL` | Server-side base URL for email links and redirects | Yes (defaults to `http://localhost:5050`) | `https://construction-web-ashen.vercel.app` |
+| `APP_URL` | Base URL for Better Auth callbacks, trusted origins, invite links, and password reset links. Must be set per-environment — see `claudedocs/vercel.md`. | Yes (defaults to `http://localhost:5050`) | `https://celn.app` |
 | `RESEND_API_KEY` | Resend transactional email API key | Optional | `re_...` (omit for dev console logging) |
 | `BLOB_READ_WRITE_TOKEN` | Vercel Blob storage token for file uploads | Optional | Provided by Vercel integration |
 | `OPENAI_API_KEY` | OpenAI API key for semantic search embeddings | Optional | `sk-proj-...` (get from platform.openai.com) |
@@ -49,7 +48,7 @@ npm run dev          # http://localhost:5050
 
 **Notes**
 - Email functionality falls back to console logging when `RESEND_API_KEY` is not set.
-- Better Auth trusts `localhost:3000`, `localhost:5050`, plus any URL in `BETTER_AUTH_URL` and `APP_URL`.
+- Better Auth trusts any localhost origin in development, and `APP_URL` in production (see `src/lib/auth.ts`).
 
 ## Available Scripts
 
@@ -72,9 +71,10 @@ npm run dev          # http://localhost:5050
 
 - **Platform**: Vercel
 - **Project name**: `construction-web`
-- **Production URL**: https://construction-web-ashen.vercel.app
+- **Production URL**: https://celn.app
+- **Staging URL**: https://preview.celn.app
 - **Database**: Neon PostgreSQL (configured via Vercel integration)
 - **Build command** (vercel.json): `npx prisma migrate deploy && npx prisma generate && npx next build`
 - **Install command**: `npm install`
 
-Database migrations run automatically on every Vercel build. Set `DATABASE_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `APP_URL`, and `RESEND_API_KEY` in the Vercel project environment settings. `BLOB_READ_WRITE_TOKEN` is auto-provisioned by the Vercel Blob integration.
+Database migrations run automatically on every Vercel build. Set `DATABASE_URL`, `BETTER_AUTH_SECRET`, `APP_URL`, and `RESEND_API_KEY` in the Vercel project environment settings per environment. `BLOB_READ_WRITE_TOKEN` is auto-provisioned by the Vercel Blob integration. See `claudedocs/vercel.md` for CLI commands.

--- a/claudedocs/vercel.md
+++ b/claudedocs/vercel.md
@@ -1,0 +1,64 @@
+# Vercel Configuration
+
+## Project
+- **Team**: CELN (`celn`)
+- **Project**: `construction-web`
+- **Production URL**: https://celn.app
+- **Staging URL**: https://preview.celn.app
+- **Dashboard**: https://vercel.com/celn/construction-web
+
+## CLI Usage
+
+Always pass `--scope celn` when using Vercel CLI:
+
+```bash
+# List env vars
+vercel env ls --scope celn
+
+# Pull env vars locally
+vercel env pull .env.preview --environment preview --scope celn --yes
+vercel env pull .env.production --environment production --scope celn --yes
+
+# Push a single env var
+printf 'value' | vercel env add KEY_NAME environment --scope celn --force
+
+# Remove an env var
+vercel env rm KEY_NAME --scope celn --yes
+
+# Deploy
+vercel deploy --scope celn
+```
+
+## Environment Structure
+
+| Environment | URL | Purpose |
+|---|---|---|
+| `development` | http://localhost:5050 | Local dev |
+| `preview` | https://preview.celn.app | Staging |
+| `production` | https://celn.app | Live |
+
+## Per-Environment Managed Vars
+
+These must be set correctly per environment via Vercel CLI:
+
+| Variable | development | preview | production |
+|---|---|---|---|
+| `APP_URL` | http://localhost:5050 | https://preview.celn.app | https://celn.app |
+
+`APP_URL` is the single source of truth — it drives Better Auth's base URL, trusted origins, invite email links, and password reset links.
+
+## Auto-Provisioned (do not manage manually)
+
+`DATABASE_URL`, `BLOB_READ_WRITE_TOKEN`, and all `POSTGRES_*` / `PG*` vars are managed by Vercel integrations. Do not overwrite these manually.
+
+## Shared Resources
+
+All environments currently share the same Neon database. Do not change without explicit discussion.
+
+## Local Env Files
+
+| File | Environment | Git |
+|---|---|---|
+| `.env.local` | development | gitignored |
+| `.env.preview` | preview | gitignored |
+| `.env.production` | production | gitignored |

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,7 @@ import { db } from "@/server/db";
 
 export const auth = betterAuth({
   basePath: "/api/auth",
+  baseURL: process.env.APP_URL,
   emailAndPassword: {
     enabled: true,
     minPasswordLength: 8,
@@ -20,7 +21,6 @@ export const auth = betterAuth({
       return [origin];
     }
     return [
-      process.env.BETTER_AUTH_URL ?? "",
       process.env.APP_URL ?? "",
       process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "",
     ].filter(Boolean);


### PR DESCRIPTION
Fixes an invalid origin on staging by consolidating Better Auth's base URL and trusted origins to use `APP_URL` instead of the now-removed `BETTER_AUTH_URL`.

- Removes `BETTER_AUTH_URL` env var and sets `APP_URL` as Better Auth's `baseURL` in `src/lib/auth.ts`
- Adds `claudedocs/vercel.md` with full Vercel CLI reference, environment structure, and per-environment `APP_URL` values
- Updates `CLAUDE.md`, `environment-setup.md`, `auth-and-permissions.md`, and `.env.example` to reflect the consolidated env var and correct production/staging URLs (`celn.app` / `preview.celn.app`)