### PR TITLE
Reduce blocking DB ops and improve layout architecture

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -108,16 +108,6 @@ describe("Middleware", () => {
     expect((response as NextResponse).status).not.toBe(307);
   });
 
-  it("redirects to /onboarding for protected routes if not complete", () => {
-    const request = createRequest("/acme", {
-      "better-auth.session_token": "valid-token",
-    });
-    const response = middleware(request) as NextResponse;
-
-    expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toBe("http://localhost:5050/onboarding");
-  });
-
   it("bypasses auth with x-playwright-test header in non-production", () => {
     vi.stubEnv("NODE_ENV", "test");
 

--- a/src/app/(app)/[orgSlug]/layout.tsx
+++ b/src/app/(app)/[orgSlug]/layout.tsx
@@ -23,19 +23,25 @@ export default async function OrgLayout({
   const { orgSlug } = await params;
   const userId = session.user.id;
 
-  // Resolve organization by slug
-  const organization = await db.organization.findUnique({
-    where: { slug: orgSlug },
-    select: {
-      id: true,
-      slug: true,
-      name: true,
-      memberships: {
-        where: { userId },
-        select: { role: true },
+  // Resolve organization and current user activeOrganizationId in parallel
+  const [organization, user] = await Promise.all([
+    db.organization.findUnique({
+      where: { slug: orgSlug },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        memberships: {
+          where: { userId },
+          select: { role: true },
+        },
       },
-    },
-  });
+    }),
+    db.user.findUnique({
+      where: { id: userId },
+      select: { activeOrganizationId: true },
+    }),
+  ]);
 
   // Organization not found or user not a member
   if (!organization || organization.memberships.length === 0) {
@@ -58,11 +64,13 @@ export default async function OrgLayout({
 
   const memberRole = organization.memberships[0]!.role;
 
-  // Sync active organization in database
-  await db.user.update({
-    where: { id: userId },
-    data: { activeOrganizationId: organization.id },
-  });
+  // Only sync active organization if it actually changed
+  if (user?.activeOrganizationId !== organization.id) {
+    await db.user.update({
+      where: { id: userId },
+      data: { activeOrganizationId: organization.id },
+    });
+  }
 
   return (
     <OrgProvider

--- a/src/app/(app)/[orgSlug]/page.tsx
+++ b/src/app/(app)/[orgSlug]/page.tsx
@@ -2,7 +2,6 @@ import { redirect } from "next/navigation";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { db } from "@/server/db";
-import { getActiveProjectId } from "@/server/api/helpers/getActiveProject";
 import CreateFirstProject from "./CreateFirstProject";
 
 export default async function OrgHomePage({
@@ -17,29 +16,52 @@ export default async function OrgHomePage({
   }
 
   const { orgSlug } = await params;
+  const userId = session.user.id;
 
-  // Resolve org
-  const org = await db.organization.findUnique({
-    where: { slug: orgSlug },
-    select: { id: true, slug: true },
-  });
+  // Fetch org and user's active project preference in parallel
+  const [org, user] = await Promise.all([
+    db.organization.findUnique({
+      where: { slug: orgSlug },
+      select: { id: true },
+    }),
+    db.user.findUnique({
+      where: { id: userId },
+      select: { activeProjectId: true },
+    }),
+  ]);
 
   if (!org) {
     redirect("/onboarding");
   }
 
-  // Try to find an active project to redirect to
-  const projectId = await getActiveProjectId(db, session.user.id, org.id);
+  // Try the saved active project first
+  let project: { id: string; slug: string } | null = null;
 
-  if (projectId) {
-    const project = await db.project.findUnique({
-      where: { id: projectId },
-      select: { slug: true },
+  if (user?.activeProjectId) {
+    project = await db.project.findFirst({
+      where: { id: user.activeProjectId, organizationId: org.id },
+      select: { id: true, slug: true },
+    });
+  }
+
+  // Fall back to first project in the org
+  if (!project) {
+    project = await db.project.findFirst({
+      where: { organizationId: org.id },
+      orderBy: { createdAt: "asc" },
+      select: { id: true, slug: true },
     });
 
     if (project) {
-      redirect(`/${orgSlug}/projects/${project.slug}/gantt`);
+      void db.user.update({
+        where: { id: userId },
+        data: { activeProjectId: project.id },
+      });
     }
+  }
+
+  if (project) {
+    redirect(`/${orgSlug}/projects/${project.slug}/gantt`);
   }
 
   // No projects — show create first project page

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/layout.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/layout.tsx
@@ -23,11 +23,17 @@ export default async function ProjectLayout({
   const { orgSlug, projectSlug } = await params;
   const userId = session.user.id;
 
-  // Get organization ID from orgSlug
-  const organization = await db.organization.findUnique({
-    where: { slug: orgSlug },
-    select: { id: true },
-  });
+  // Fetch org and current user activeProjectId in parallel
+  const [organization, user] = await Promise.all([
+    db.organization.findUnique({
+      where: { slug: orgSlug },
+      select: { id: true },
+    }),
+    db.user.findUnique({
+      where: { id: userId },
+      select: { activeProjectId: true },
+    }),
+  ]);
 
   if (!organization) {
     redirect(`/${orgSlug}`);
@@ -48,11 +54,13 @@ export default async function ProjectLayout({
     redirect(`/${orgSlug}`);
   }
 
-  // Set as active project
-  await db.user.update({
-    where: { id: userId },
-    data: { activeProjectId: project.id },
-  });
+  // Only write if the active project actually changed
+  if (user?.activeProjectId !== project.id) {
+    await db.user.update({
+      where: { id: userId },
+      data: { activeProjectId: project.id },
+    });
+  }
 
   return (
     <ProjectProvider

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/loading.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/loading.tsx
@@ -1,0 +1,17 @@
+import { Box, Skeleton } from '@mui/material';
+
+export default function ProjectLoading() {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', p: 3, gap: 2 }}>
+      {/* Toolbar row */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Skeleton width={180} height={36} variant="rounded" />
+        <Skeleton width={100} height={36} variant="rounded" />
+        <Box sx={{ flex: 1 }} />
+        <Skeleton width={120} height={36} variant="rounded" />
+      </Box>
+      {/* Main content area */}
+      <Skeleton variant="rectangular" sx={{ flex: 1, borderRadius: 2 }} />
+    </Box>
+  );
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,86 +1,24 @@
-'use client';
+import { redirect } from "next/navigation";
+import { headers } from "next/headers";
+import { auth } from "@/lib/auth";
+import { db } from "@/server/db";
+import AppShell from "@/components/layout/AppShell";
 
-import React, { useState, useCallback } from 'react';
-import { Box } from '@mui/material';
-import Header from '@/components/layout/Header';
-import Sidebar from '@/components/layout/Sidebar';
-import MobileHeader from '@/components/layout/MobileHeader';
-import MobileDrawer from '@/components/layout/MobileDrawer';
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth.api.getSession({ headers: await headers() });
 
-export default function AppLayout({ children }: { children: React.ReactNode }) {
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  if (!session?.user) {
+    redirect("/sign-in");
+  }
 
-  const openDrawer = useCallback(() => setDrawerOpen(true), []);
-  const closeDrawer = useCallback(() => setDrawerOpen(false), []);
+  const user = await db.user.findUnique({
+    where: { id: session.user.id },
+    select: { onboardingComplete: true },
+  });
 
-  return (
-    <Box
-      sx={{
-        height: '100vh',
-        bgcolor: 'background.default',
-        overflow: 'hidden',
-        transition: 'background-color 0.15s',
-      }}
-    >
-      {/* Desktop Layout */}
-      <Box
-        sx={{
-          display: { xs: 'none', md: 'flex' },
-          height: '100vh',
-        }}
-      >
-        {/* Sidebar */}
-        <Sidebar />
+  if (!user?.onboardingComplete) {
+    redirect("/onboarding");
+  }
 
-        {/* Main Content Area */}
-        <Box
-          sx={{
-            flex: 1,
-            display: 'flex',
-            flexDirection: 'column',
-            minWidth: 0,
-          }}
-        >
-          <Header />
-          <Box
-            component="main"
-            sx={{
-              flex: 1,
-              display: 'flex',
-              flexDirection: 'column',
-              overflowX: 'hidden',
-              overflowY: 'auto',
-            }}
-          >
-            {children}
-          </Box>
-        </Box>
-      </Box>
-
-      {/* Mobile Layout */}
-      <Box
-        sx={{
-          display: { xs: 'flex', md: 'none' },
-          flexDirection: 'column',
-          height: '100vh',
-        }}
-      >
-        <MobileHeader onMenuOpen={openDrawer} />
-        <Box
-          component="main"
-          sx={{
-            flex: 1,
-            p: 2,
-            overflowX: 'hidden',
-            overflowY: 'auto',
-          }}
-        >
-          {children}
-        </Box>
-      </Box>
-
-      {/* Mobile Drawer Overlay */}
-      <MobileDrawer isOpen={drawerOpen} onClose={closeDrawer} />
-    </Box>
-  );
+  return <AppShell>{children}</AppShell>;
 }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
-import { usePathname } from 'next/navigation';
 import { Box } from '@mui/material';
 import Header from '@/components/layout/Header';
 import Sidebar from '@/components/layout/Sidebar';
@@ -10,7 +9,6 @@ import MobileDrawer from '@/components/layout/MobileDrawer';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const pathname = usePathname();
 
   const openDrawer = useCallback(() => setDrawerOpen(true), []);
   const closeDrawer = useCallback(() => setDrawerOpen(false), []);

--- a/src/components/dashboard/ProjectsList.tsx
+++ b/src/components/dashboard/ProjectsList.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Maximize2, CheckCircle2 } from 'lucide-react';
 import { ImageWithFallback } from '@/components/ui/image-with-fallback';
 import { Box, Typography, Paper, IconButton, Stack, Avatar, Divider } from '@mui/material';

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { Box } from '@mui/material';
+import Header from '@/components/layout/Header';
+import Sidebar from '@/components/layout/Sidebar';
+import MobileHeader from '@/components/layout/MobileHeader';
+import MobileDrawer from '@/components/layout/MobileDrawer';
+
+export default function AppShell({ children }: { children: React.ReactNode }) {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const openDrawer = useCallback(() => setDrawerOpen(true), []);
+  const closeDrawer = useCallback(() => setDrawerOpen(false), []);
+
+  return (
+    <Box
+      sx={{
+        height: '100vh',
+        bgcolor: 'background.default',
+        overflow: 'hidden',
+        transition: 'background-color 0.15s',
+      }}
+    >
+      {/* Desktop Layout */}
+      <Box
+        sx={{
+          display: { xs: 'none', md: 'flex' },
+          height: '100vh',
+        }}
+      >
+        {/* Sidebar */}
+        <Sidebar />
+
+        {/* Main Content Area */}
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            minWidth: 0,
+          }}
+        >
+          <Header />
+          <Box
+            component="main"
+            sx={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              overflowX: 'hidden',
+              overflowY: 'auto',
+            }}
+          >
+            {children}
+          </Box>
+        </Box>
+      </Box>
+
+      {/* Mobile Layout */}
+      <Box
+        sx={{
+          display: { xs: 'flex', md: 'none' },
+          flexDirection: 'column',
+          height: '100vh',
+        }}
+      >
+        <MobileHeader onMenuOpen={openDrawer} />
+        <Box
+          component="main"
+          sx={{
+            flex: 1,
+            p: 2,
+            overflowX: 'hidden',
+            overflowY: 'auto',
+          }}
+        >
+          {children}
+        </Box>
+      </Box>
+
+      {/* Mobile Drawer Overlay */}
+      <MobileDrawer isOpen={drawerOpen} onClose={closeDrawer} />
+    </Box>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -72,11 +72,6 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Enforce onboarding for all other protected routes
-  if (!onboardingComplete) {
-    return NextResponse.redirect(new URL("/onboarding", request.url));
-  }
-
   // Fast-path: /dashboard with warm cookies skips the server component entirely
   if (pathname === "/dashboard") {
     if (activeOrgSlug && activeProjectSlug) {

--- a/src/server/api/routers/document.ts
+++ b/src/server/api/routers/document.ts
@@ -153,22 +153,18 @@ export const documentRouter = createTRPCRouter({
         return {};
       }
 
-      const documents = await ctx.db.document.findMany({
+      const grouped = await ctx.db.document.groupBy({
+        by: ["folderId"],
         where: {
           projectId: input.projectId,
           taskId: input.taskId,
         },
-        select: {
-          folderId: true,
-        },
+        _count: { folderId: true },
       });
 
-      const counts: Record<string, number> = {};
-      for (const doc of documents) {
-        counts[doc.folderId] = (counts[doc.folderId] || 0) + 1;
-      }
-
-      return counts;
+      return Object.fromEntries(
+        grouped.map((g) => [g.folderId, g._count.folderId])
+      );
     }),
 
   search: orgProcedure

--- a/src/server/api/routers/organization.ts
+++ b/src/server/api/routers/organization.ts
@@ -5,7 +5,9 @@ export const organizationRouter = createTRPCRouter({
   list: protectedProcedure.query(async ({ ctx }) => {
     const memberships = await ctx.db.membership.findMany({
       where: { userId: ctx.session.user.id },
-      include: { organization: true },
+      include: {
+        organization: { select: { id: true, name: true, slug: true } },
+      },
       orderBy: { createdAt: "asc" },
     });
 

--- a/src/server/api/routers/project.ts
+++ b/src/server/api/routers/project.ts
@@ -169,7 +169,7 @@ export const projectRouter = createTRPCRouter({
       const project = await ctx.db.project.findUnique({
         where: { id: input.id },
         include: {
-          organization: true,
+          organization: { select: { id: true, name: true, slug: true } },
         },
       });
 
@@ -221,7 +221,7 @@ export const projectRouter = createTRPCRouter({
           },
         },
         include: {
-          organization: true,
+          organization: { select: { id: true, name: true, slug: true } },
         },
       });
 
@@ -274,7 +274,7 @@ export const projectRouter = createTRPCRouter({
       const project = await ctx.db.project.findUnique({
         where: { id: activeProjectId },
         include: {
-          organization: true,
+          organization: { select: { id: true, name: true, slug: true } },
         },
       });
 
@@ -288,7 +288,7 @@ export const projectRouter = createTRPCRouter({
       const project = await ctx.db.project.findUnique({
         where: { id: input.projectId },
         include: {
-          organization: true,
+          organization: { select: { id: true, name: true, slug: true } },
         },
       });
 


### PR DESCRIPTION
Converts the app layout from a client component to a server component by extracting the interactive shell into a new `AppShell` client component, moving auth and onboarding enforcement server-side. Parallelizes independent DB queries in org, project, and org home layouts using `Promise.all`, and skips write operations when the active org/project hasn't changed. Replaces a `findMany` loop in the document router with a single `groupBy` query for counting documents per folder. Narrows `include: { organization: true }` to `select` with only the fields actually used in org and project routers. Adds a skeleton loading UI for project pages and removes an unnecessary `'use client'` directive from `ProjectsList`.