### PR TITLE
Fix onboarding redirect loop when user has org but incomplete flag

### DIFF
--- a/src/app/(onboarding)/onboarding/page.tsx
+++ b/src/app/(onboarding)/onboarding/page.tsx
@@ -19,6 +19,12 @@ export default async function OnboardingPage() {
   });
 
   if (userOrg) {
+    // Fix data inconsistency: user has org but onboardingComplete may be false,
+    // which causes an infinite redirect loop with (app)/layout.tsx
+    await db.user.update({
+      where: { id: session.user.id },
+      data: { onboardingComplete: true },
+    });
     redirect(`/${userOrg.slug}`);
   }
 


### PR DESCRIPTION
## Summary
- Fixes an infinite redirect loop that occurs when a user has an existing organization but their `onboardingComplete` flag is `false`
- On the onboarding page, if the user already belongs to an org, we now update `onboardingComplete` to `true` before redirecting to the org dashboard
- This resolves a data inconsistency where users could get stuck bouncing between `/onboarding` and the app layout

## Test plan
- [ ] Sign in as a user who has an org but `onboardingComplete = false` in the DB and confirm they are redirected to their org without looping
- [ ] Sign up normally and confirm the onboarding flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)