### PR TITLE
Remove BETTER_AUTH_URL and exclude bryntum from middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,6 @@ DATABASE_URL="postgresql://USER@localhost:5432/construction?schema=public"
 
 # Better Auth
 BETTER_AUTH_SECRET="replace-me"
-BETTER_AUTH_URL="http://localhost:5050"
 
 # Resend (Email)
 RESEND_API_KEY=""

--- a/claudedocs/auth-and-permissions.md
+++ b/claudedocs/auth-and-permissions.md
@@ -8,7 +8,7 @@
 - **Session**: Cookie-cached for 5 minutes (`cookieCache.maxAge = 300`)
 - **Cookie names**: `better-auth.session_token` (localhost) / `__Secure-better-auth.session_token` (production)
 - **Custom pages**: `/sign-in`, `/sign-up`
-- **Trusted origins**: Dynamic — in development, any `localhost` origin (any port) is trusted; in production, only `BETTER_AUTH_URL`, `APP_URL`, and `VERCEL_URL`
+- **Trusted origins**: Dynamic — in development, any `localhost` origin (any port) is trusted; in production, only `APP_URL` and `VERCEL_URL`
 
 ### Client Setup
 

--- a/claudedocs/environment-setup.md
+++ b/claudedocs/environment-setup.md
@@ -8,7 +8,6 @@ Construction project management SaaS (BuildTrack Pro) built on the T3 stack: Nex
 |---|---|---|---|
 | `DATABASE_URL` | PostgreSQL connection string (Neon on Vercel) | Yes | `postgresql://USER@localhost:5432/construction?schema=public` |
 | `BETTER_AUTH_SECRET` | Signing secret for Better Auth sessions | Yes | Any strong random string |
-| `BETTER_AUTH_URL` | Base URL Better Auth uses for callbacks | Yes | `http://localhost:5050` |
 | `APP_URL` | Server-side base URL for email links and redirects | Yes (defaults to `http://localhost:5050`) | `https://construction-web-ashen.vercel.app` |
 | `RESEND_API_KEY` | Resend transactional email API key | Optional | `re_...` (omit for dev console logging) |
 | `BLOB_READ_WRITE_TOKEN` | Vercel Blob storage token for file uploads | Optional | Provided by Vercel integration |

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -20,7 +20,6 @@ export const auth = betterAuth({
       return [origin];
     }
     return [
-      process.env.BETTER_AUTH_URL ?? "",
       process.env.APP_URL ?? "",
       process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "",
     ].filter(Boolean);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -114,6 +114,6 @@ export const config = {
      * - favicon.ico (favicon file)
      * - images folder (public images)
      */
-    "/((?!_next/static|_next/image|favicon.ico|favicon.svg|images).*)",
+    "/((?!_next/static|_next/image|favicon.ico|favicon.svg|images|bryntum).*)",
   ],
 };


### PR DESCRIPTION
Removes the redundant `BETTER_AUTH_URL` environment variable from auth config, `.env.example`, and docs since `APP_URL` and `VERCEL_URL` already cover the same trusted origins. Also excludes the `/bryntum` path from Next.js middleware matching to prevent interference with Bryntum Gantt static assets.