### PR TITLE
Fix .env.template comment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
-# .env.template — op:// references only, safe to commit
+# .env.template — 1Password secret references, safe to commit
 # Generate .env.local from this file:
 #   op inject -i .env.template -o .env.local
 #   echo 'APP_URL="http://localhost:5050"' >> .env.local


### PR DESCRIPTION
Changes `op:// references only` to `1Password secret references` in the header comment for clarity.