### PR TITLE
Add CSI codes, sync APP_URL on dev run, add docs

### DIFF
--- a/.claude/commands/gantt.md
+++ b/.claude/commands/gantt.md
@@ -1,0 +1,166 @@
+---
+name: gantt
+description: "Bryntum Gantt chart development with automatic documentation lookup and project-aware context"
+category: workflow
+complexity: standard
+mcp-servers: [context7]
+---
+
+# /gantt - Bryntum Gantt Chart Development
+
+> **Context Framework Note**: This behavioral instruction activates when users type `/gantt` patterns. It ensures Bryntum Gantt documentation is always consulted before making changes and provides full project context for the Gantt integration.
+
+## Triggers
+- Any modification to Gantt chart components, config, hooks, or utilities
+- Bryntum API usage questions or troubleshooting
+- Gantt feature additions (columns, features, listeners, toolbar controls)
+- Task scheduling logic, sync/load transport, or conflict resolution changes
+- Gantt-related tRPC router or API route changes
+
+## Context Trigger Pattern
+```
+/gantt [task-description] [--feature columns|scheduling|sync|toolbar|popover|conflict] [--docs-only]
+```
+**Usage**: Type this in Claude Code conversation to activate Gantt development mode with automatic Bryntum documentation lookup.
+
+## Behavioral Flow
+
+### Step 1: Fetch Bryntum Documentation (MANDATORY)
+Before making ANY Gantt-related changes, you MUST:
+
+1. **Resolve the Bryntum Gantt library** via Context7:
+   ```
+   mcp__Context7__resolve-library-id("bryntum gantt")
+   ```
+2. **Query relevant documentation** for the specific task:
+   ```
+   mcp__Context7__query-docs(libraryId, "topic relevant to the task")
+   ```
+3. Review the docs for non-obvious behaviors before proceeding.
+
+**Why**: Bryntum has many internal behaviors not apparent from config alone — parent task duration auto-calculation, event firing order, scheduling engine quirks, and blocked cell editors. Skipping docs leads to subtle bugs.
+
+### Step 2: Review Project Gantt Structure
+Before editing, understand the existing file layout:
+
+```
+src/components/bryntum/
+├── BryntumGanttWrapper.tsx    ← Main wrapper: state, sync, conflict handling, auto-save debounce
+├── types.ts                   ← Shared types: PopoverPlacement, SelectedTask, GanttConfig, etc.
+├── constants.ts               ← UI constants: POPOVER_WIDTH, POPOVER_GAP, etc.
+├── config/
+│   └── ganttConfig.ts         ← Config factory: transport, columns, features, listeners
+├── components/
+│   ├── GanttToolbar.tsx       ← Toolbar: add task, zoom, shift, preset controls
+│   ├── TaskDetailsPopover.tsx ← Task detail popover (leaf tasks only)
+│   └── ConflictDialog.tsx     ← Version conflict resolution dialog
+├── hooks/
+│   ├── useGanttControls.ts    ← Gantt control methods (add, zoom, shift, preset)
+│   ├── useTaskPopover.ts      ← Task selection and popover placement state
+│   └── useBryntumThemeAssets.ts ← Dynamic theme CSS and Font Awesome loading
+└── utils/
+    ├── ganttValidation.ts     ← Parent task duration validation
+    └── calculatePopoverPlacement.ts ← Popover positioning logic
+```
+
+**Related files outside bryntum/:**
+- `src/server/api/routers/gantt.ts` — tRPC router for load/sync
+- `src/app/api/gantt/load/route.ts` — Load transport endpoint
+- `src/app/api/gantt/sync/route.ts` — Sync transport endpoint
+- `src/lib/utils/gantt.ts` — Shared Gantt data helpers
+
+### Step 3: Apply Changes Following Existing Patterns
+- New types → `types.ts`
+- New constants → `constants.ts`
+- Config changes → `config/ganttConfig.ts` (modify `createGanttConfig`)
+- New UI components → `components/`
+- New hooks → `hooks/`
+- New utility functions → `utils/`
+- Do NOT add Gantt logic to other `components/` folders
+
+### Step 4: Validate Against Bryntum Docs
+After implementing, cross-check with docs for:
+- Event firing order (e.g., `cellDblClick` fires before `beforeCellEditStart`)
+- Scheduling engine implications (auto-scheduled vs manually-scheduled tasks)
+- Parent task behaviors (duration derived from children unless `manuallyScheduled: true`)
+- CrudManager sync protocol expectations
+
+## Project Architecture Context
+
+### Optimistic Locking with Version Injection
+- Every task has a `version` field (integer, via `VersionedTaskModel`)
+- On sync, `BryntumGanttWrapper` injects current version into the update pack
+- Server detects version mismatch → returns conflict response
+- `ConflictDialog` lets user accept server changes, keep local, or cancel
+
+### Auto-Save Flow
+1. Bryntum fires `beforeSync` → version injection
+2. Changes sync via tRPC `/api/gantt/sync`
+3. 1-second debounce after scheduling engine completes
+4. Monitors: taskStore, dependencyStore, resourceStore, assignmentStore, timeRangeStore
+
+### Common Bryntum Pitfalls
+| Pitfall | Details |
+|---------|---------|
+| Parent duration is read-only | Bryntum auto-calculates parent duration from children. Must set `manuallyScheduled: true` before editing. |
+| Custom fields silently dropped | Must extend `TaskModel` with custom fields (see `VersionedTaskModel`). |
+| `cellDblClick` fires before `beforeCellEditStart` | Use `cellDblClick` to modify record state before editor opens. |
+| Duration column blocks parent editing internally | Bryntum checks `isParent` before `beforeCellEditStart` fires. |
+| Stale data after tab-away | Project uses 60-second staleness threshold for reload. |
+| Unscheduled tasks crash `scrollTaskIntoView` | Guard against `!record.startDate` before scrolling. |
+
+## MCP Integration
+- **Context7 MCP**: Primary tool — always resolve Bryntum Gantt library and query docs before changes
+- Query examples:
+  - `"TaskModel fields and configuration"` — for task model changes
+  - `"CrudManager sync protocol"` — for sync/load changes
+  - `"Gantt columns configuration"` — for column changes
+  - `"Gantt features"` — for enabling/configuring features
+  - `"scheduling engine manually scheduled"` — for scheduling behavior
+
+## External Documentation References
+- API docs: https://bryntum.com/products/gantt/docs/api/
+- Forum: https://forum.bryntum.com/
+- Support issues: https://github.com/bryntum/support/issues
+
+## Examples
+
+### Add a New Gantt Column
+```
+/gantt add a CSI code column to the Gantt chart
+# 1. Context7: query "Gantt columns configuration"
+# 2. Review ganttConfig.ts columns array
+# 3. Add column following existing pattern
+# 4. Validate column type/renderer against Bryntum docs
+```
+
+### Fix Scheduling Bug
+```
+/gantt parent tasks aren't updating duration correctly --feature scheduling
+# 1. Context7: query "scheduling engine parent task duration"
+# 2. Review ganttValidation.ts and BryntumGanttWrapper.tsx
+# 3. Check manuallyScheduled flag handling
+# 4. Fix with awareness of Bryntum's auto-calculation behavior
+```
+
+### Add Toolbar Control
+```
+/gantt add an undo/redo button to the toolbar
+# 1. Context7: query "Gantt undo redo STM"
+# 2. Review GanttToolbar.tsx and useGanttControls.ts
+# 3. Implement following existing toolbar pattern
+```
+
+## Boundaries
+
+**Will:**
+- Always fetch Bryntum docs via Context7 before making changes
+- Follow the existing bryntum/ directory structure
+- Maintain optimistic locking and version injection patterns
+- Validate against known Bryntum pitfalls
+
+**Will Not:**
+- Make Gantt changes without consulting Bryntum documentation
+- Add Gantt logic outside the `src/components/bryntum/` directory
+- Bypass the version/conflict resolution system
+- Assume Bryntum behavior without doc verification

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@
 @claudedocs/testing-guide.md
 @claudedocs/components-guide.md
 @claudedocs/embeddings.md
+@claudedocs/trpc-guide.md
 @claudedocs/vercel.md
 
 ## Documentation Update Rules
@@ -16,6 +17,7 @@ When making changes that affect these docs, update them in the same task:
 - Architecture or TypeScript pattern changes → update `claudedocs/architecture-and-typescript.md`
 - New tests added or test patterns change → update `claudedocs/testing-guide.md`
 - New components, naming/styling changes, or new feature slices → update `claudedocs/components-guide.md`
+- tRPC routers, procedures, or data-fetching pattern changes → update `claudedocs/trpc-guide.md`
 - Vercel env vars, deployments, or project config changes → update `claudedocs/vercel.md`
 
 ## Vercel

--- a/claudedocs/trpc-guide.md
+++ b/claudedocs/trpc-guide.md
@@ -1,0 +1,427 @@
+# tRPC Best Practices
+
+Authoritative guide for all tRPC-related code in this project. Follow these patterns exactly.
+
+---
+
+## 1. Procedure Hierarchy
+
+```
+publicProcedure          → No auth. ctx: { db, session (nullable) }
+protectedProcedure       → Auth required. ctx: { db, session.user (guaranteed) }
+orgProcedure             → Auth + org membership. ctx: { db, session.user, membership, organization }
+projectProcedure         → Auth + project membership. ctx: { db, session.user, projectMember, project, organization }
+```
+
+**When to use each:**
+
+| Scope | Procedure | Example |
+|-------|-----------|---------|
+| No auth needed | `publicProcedure` | Beta code validation, public invite lookup |
+| User-level (no org/project context) | `protectedProcedure` | User profile, org list, onboarding |
+| Organization-scoped | `orgProcedure` | Members list, org stats, documents |
+| Project-scoped | `projectProcedure` | Invitations, project members, Gantt data |
+
+**What each procedure auto-injects into input:**
+- `orgProcedure` adds `{ organizationId: z.string() }` — access via `input.organizationId` or `ctx.organization.id`
+- `projectProcedure` adds `{ projectId: z.string() }` — access via `input.projectId` or `ctx.project.id`
+
+---
+
+## 2. Router Patterns
+
+**File location:** `src/server/api/routers/<feature>.ts`
+**Registration:** `src/server/api/root.ts`
+
+### Minimal orgProcedure router (canonical example: `src/server/api/routers/member.ts`)
+
+```ts
+import { createTRPCRouter, orgProcedure } from "@/server/api/trpc";
+
+export const memberRouter = createTRPCRouter({
+  list: orgProcedure.query(async ({ ctx, input }) => {
+    return ctx.db.membership.findMany({
+      where: { organizationId: input.organizationId },
+      include: { user: { select: { id: true, name: true, email: true } } },
+      orderBy: { createdAt: "asc" },
+    });
+  }),
+});
+```
+
+### projectProcedure router with permissions (canonical: `src/server/api/routers/invitation.ts`)
+
+```ts
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { createTRPCRouter, projectProcedure } from "@/server/api/trpc";
+import { canInviteMembers, canAssignRole } from "@/lib/permissions";
+import { createInvitationSchema } from "@/lib/validations/invitation";
+
+export const invitationRouter = createTRPCRouter({
+  create: projectProcedure
+    .input(createInvitationSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!canInviteMembers(ctx.projectMember.role)) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "..." });
+      }
+      if (!canAssignRole(ctx.projectMember.role, input.role)) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "..." });
+      }
+      // ... create logic
+    }),
+});
+```
+
+### Registering a router (`src/server/api/root.ts`)
+
+```ts
+import { featureRouter } from "@/server/api/routers/feature";
+
+export const appRouter = createTRPCRouter({
+  // ... existing
+  feature: featureRouter,
+});
+```
+
+---
+
+## 3. Error Handling
+
+Always use `TRPCError` with appropriate codes:
+
+```ts
+throw new TRPCError({ code: "NOT_FOUND", message: "Project not found" });
+throw new TRPCError({ code: "FORBIDDEN", message: "Insufficient permissions" });
+throw new TRPCError({ code: "BAD_REQUEST", message: "Invalid input" });
+throw new TRPCError({ code: "UNAUTHORIZED" }); // no session
+throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "..." });
+```
+
+---
+
+## 4. Zod Validation Schemas
+
+**File location:** `src/lib/validations/<feature>.ts`
+
+### Rules
+
+- Same schema shared between tRPC router `.input()` and React Hook Form `zodResolver()`
+- Export `z.infer<>` type aliases — never write type shapes manually
+- Use `.trim()` on all string fields
+- Use `.strict()` on API input schemas to reject unknown keys
+- Compose update schemas from create schemas via `.partial()` / `.extend()` / `.pick()`
+- Do NOT include `organizationId` or `projectId` in schemas used with `orgProcedure` / `projectProcedure` — those are injected by the procedure middleware
+
+### Pattern (canonical: `src/lib/validations/project.ts`)
+
+```ts
+import { z } from "zod";
+
+export const createProjectSchema = z.object({
+  name: z.string().min(1, "Project name is required").max(100).trim(),
+  template: z.enum(["BLANK"]).default("BLANK").optional(),
+});
+
+export type CreateProjectInput = z.infer<typeof createProjectSchema>;
+```
+
+### Composing schemas
+
+```ts
+// Update = partial create + required id
+export const updateFeatureSchema = createFeatureSchema
+  .partial()
+  .extend({ id: z.string().cuid() })
+  .strict();
+
+export type UpdateFeatureInput = z.infer<typeof updateFeatureSchema>;
+
+// Summary = pick fields from create
+export const featureSummarySchema = createFeatureSchema.pick({ name: true, status: true });
+```
+
+---
+
+## 5. Prisma Query Rules
+
+### Tenant scoping — ALWAYS required
+
+```ts
+// orgProcedure — scope to organization
+await ctx.db.model.findMany({
+  where: { organizationId: ctx.organization.id },
+});
+
+// projectProcedure — scope to project
+await ctx.db.model.findMany({
+  where: { projectId: ctx.project.id },
+});
+```
+
+### findUnique over findFirst
+
+Use `findUnique` on uniquely-constrained columns — it's faster and semantically correct:
+
+```ts
+// ✅ Correct — compound unique key
+await ctx.db.membership.findUnique({
+  where: { userId_organizationId: { userId, organizationId } },
+});
+
+// ❌ Wrong — findFirst on a unique constraint
+await ctx.db.membership.findFirst({
+  where: { userId, organizationId },
+});
+```
+
+### Select only what you need
+
+```ts
+// ✅ Explicit select
+await ctx.db.user.findMany({
+  select: { id: true, name: true, email: true },
+});
+
+// ❌ Fetching entire model when only 3 fields are needed
+await ctx.db.user.findMany();
+```
+
+### Parallel queries with Promise.all
+
+```ts
+const [tasks, members, documents] = await Promise.all([
+  ctx.db.task.findMany({ where: { projectId } }),
+  ctx.db.projectMember.findMany({ where: { projectId } }),
+  ctx.db.document.findMany({ where: { projectId } }),
+]);
+```
+
+### Transactions for multi-table writes
+
+```ts
+await ctx.db.$transaction(async (tx) => {
+  const item = await tx.model.create({ data: { ... } });
+  await tx.otherModel.update({ where: { id }, data: { ... } });
+  return item;
+});
+```
+
+---
+
+## 6. Helper Functions
+
+**File location:** `src/server/api/helpers/`
+
+Always accept `db: PrismaClient` as the first parameter so the helper works with both the global `db` and a transaction client `tx`:
+
+```ts
+import type { PrismaClient } from "@prisma/client";
+
+export async function resolveActiveProject(db: PrismaClient, organizationId: string) {
+  // use db param, not the global import
+}
+```
+
+Call from a router:
+```ts
+// With global db
+await resolveActiveProject(ctx.db, orgId);
+
+// Inside a transaction
+await ctx.db.$transaction(async (tx) => {
+  await resolveActiveProject(tx, orgId);
+});
+```
+
+---
+
+## 7. Frontend Data Fetching
+
+### Server Components (`src/trpc/server.ts`)
+
+```ts
+import { api } from "@/trpc/server";
+
+// Direct call — no hooks
+const projects = await api.project.list({ organizationId });
+```
+
+### Client Components (`src/trpc/react`)
+
+```ts
+'use client';
+import { api } from "@/trpc/react";
+
+// Queries
+const { data: items = [], isLoading } = api.feature.list.useQuery(
+  { organizationId },
+  { retry: false, enabled: !!organizationId },
+);
+
+// Mutations
+const utils = api.useUtils();
+const createMutation = api.feature.create.useMutation({
+  onSuccess: () => {
+    void utils.feature.list.invalidate();
+  },
+  onError: (error) => {
+    showSnackbar(error.message || "Failed to create", "error");
+  },
+});
+
+// Trigger mutation
+createMutation.mutate({ ...data, organizationId });
+```
+
+### Cache invalidation rules
+
+- Always fire-and-forget: `void utils.feature.list.invalidate()`
+- Invalidate specifically — not `utils.invalidate()` (which invalidates everything)
+- Invalidate all related queries after a mutation (e.g., list + getActive after create)
+
+---
+
+## 8. Forms (react-hook-form + Zod + MUI)
+
+Canonical example: `src/components/projects/AddProjectDialog.tsx`
+
+```tsx
+'use client';
+
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { TextField, Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
+import { api } from '@/trpc/react';
+import { createFeatureSchema, type CreateFeatureInput } from '@/lib/validations/feature';
+
+export default function CreateFeatureDialog({ open, onOpenChange }: Props) {
+  const utils = api.useUtils();
+
+  const { control, handleSubmit, reset, formState: { errors } } = useForm<CreateFeatureInput>({
+    resolver: zodResolver(createFeatureSchema),
+    defaultValues: { name: '' },
+  });
+
+  const createMutation = api.feature.create.useMutation({
+    onSuccess: () => {
+      void utils.feature.list.invalidate();
+      reset();
+      onOpenChange(false);
+    },
+  });
+
+  return (
+    <Dialog open={open} onClose={() => onOpenChange(false)} maxWidth="sm" fullWidth>
+      <form onSubmit={handleSubmit((data) => createMutation.mutate(data))}>
+        <DialogTitle>Create Feature</DialogTitle>
+        <DialogContent>
+          <Controller
+            name="name"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Name"
+                fullWidth
+                error={!!errors.name}
+                helperText={errors.name?.message}
+              />
+            )}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button variant="contained" type="submit" disabled={createMutation.isPending}>
+            Create
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}
+```
+
+### Key rules
+
+- Import the Zod schema AND its inferred type from `src/lib/validations/`
+- Use `zodResolver(schema)` — single source of truth for validation
+- Wrap MUI inputs with `Controller`, spread `{...field}`
+- Show errors via `error={!!errors.fieldName}` and `helperText={errors.fieldName?.message}`
+- `reset()` form on successful mutation
+
+---
+
+## 9. Testing tRPC Components
+
+**Stack:** Vitest + React Testing Library
+
+### Mocking tRPC hooks
+
+```tsx
+import { vi } from 'vitest';
+
+vi.mock('@/trpc/react', () => ({
+  api: {
+    feature: {
+      list: { useQuery: vi.fn(() => ({ data: [], isLoading: false })) },
+      create: { useMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })) },
+    },
+    useUtils: vi.fn(() => ({
+      feature: { list: { invalidate: vi.fn() } },
+    })),
+  },
+}));
+```
+
+### Selector priority
+
+```ts
+// ✅ Preferred (accessibility-first)
+screen.getByRole('button', { name: /create/i });
+screen.getByLabelText(/email/i);
+screen.getByText(/loading/i);
+
+// ❌ Avoid
+screen.getByTestId('submit-btn');
+```
+
+---
+
+## 10. Anti-Patterns — Do NOT
+
+| Don't | Do instead |
+|-------|-----------|
+| Redeclare `organizationId` in `.input()` on `orgProcedure` | It's already injected — use `input.organizationId` or `ctx.organization.id` |
+| Redeclare `projectId` in `.input()` on `projectProcedure` | It's already injected — use `input.projectId` or `ctx.project.id` |
+| `throw new Error("...")` in a router | `throw new TRPCError({ code: "NOT_FOUND", message: "..." })` |
+| Import `db` directly in a helper | Accept `db: PrismaClient` as parameter |
+| `findFirst` on a unique constraint | `findUnique` with compound key |
+| `findMany` without `select` when only a few fields needed | Always `select` or `include` only what's used |
+| `utils.invalidate()` (invalidates everything) | `void utils.feature.list.invalidate()` (specific) |
+| Write type shapes manually | `z.infer<typeof schema>` |
+| `z.any()` | `z.unknown()` — forces explicit narrowing |
+| Duplicate Zod field definitions across create/update | Compose: `createSchema.partial().extend({ id })` |
+| Fetch data in client components via `fetch()` | Use tRPC hooks: `api.feature.list.useQuery()` |
+| Module-level variables for caching in server code | `React.cache()` for per-request deduplication |
+| `memberRole: string` | Use `Role` from `src/lib/permissions.ts` |
+
+---
+
+## 11. File Location Quick Reference
+
+| What | Where |
+|------|-------|
+| Procedure definitions | `src/server/api/trpc.ts` |
+| Router registration | `src/server/api/root.ts` |
+| Routers | `src/server/api/routers/<feature>.ts` |
+| Helpers | `src/server/api/helpers/<helper>.ts` |
+| Zod schemas | `src/lib/validations/<feature>.ts` |
+| Permissions | `src/lib/permissions.ts` |
+| Domain constants | `src/lib/constants/<feature>.ts` |
+| Components | `src/components/<feature>/` |
+| Pages (org-scoped) | `src/app/(app)/[orgSlug]/<feature>/page.tsx` |
+| Pages (project-scoped) | `src/app/(app)/[orgSlug]/projects/[projectSlug]/<feature>/page.tsx` |
+| tRPC client hooks | `src/trpc/react.tsx` — import `{ api }` |
+| tRPC server caller | `src/trpc/server.ts` — import `{ api }` |
+| Type inference helpers | `src/trpc/react.tsx` — `RouterInputs`, `RouterOutputs` |

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "setup": "[[ \"$CONDUCTOR_PORT\" =~ ^[0-9]+$ ]] || exit 1 && vercel link --project construction-web --scope celn --yes && vercel env pull .env.local --environment development --scope celn --yes && (grep -q '^APP_URL=' .env.local && sed -i '' \"s|^APP_URL=.*|APP_URL=\\\"http://localhost:$CONDUCTOR_PORT\\\"|\" .env.local || echo \"APP_URL=\\\"http://localhost:$CONDUCTOR_PORT\\\"\" >> .env.local) && sed -i '' \"s|^construction_POSTGRES_PRISMA_URL=.*|construction_POSTGRES_PRISMA_URL=\\\"postgresql://$USER@localhost:5432/construction\\\"|\" .env.local && sed -i '' \"s|^construction_POSTGRES_URL_NON_POOLING=.*|construction_POSTGRES_URL_NON_POOLING=\\\"postgresql://$USER@localhost:5432/construction\\\"|\" .env.local && sed -i '' 's|\\\\n\"|\"| ' .env.local && (grep -q '^NODE_OPTIONS=' .env.local || echo 'NODE_OPTIONS=\"--max-old-space-size=8192\"' >> .env.local) && npm install",
-    "run": "PORT=$CONDUCTOR_PORT npm run dev",
+    "run": "(grep -q '^APP_URL=' .env.local && sed -i '' \"s|^APP_URL=.*|APP_URL=\\\"http://localhost:$CONDUCTOR_PORT\\\"|\" .env.local || echo \"APP_URL=\\\"http://localhost:$CONDUCTOR_PORT\\\"\" >> .env.local) && PORT=$CONDUCTOR_PORT npm run dev",
     "archive": "rm -f .env.local && rm -rf .vercel && rm -rf node_modules && rm -rf .next"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -257,6 +257,7 @@ model GanttTask {
     cls                String?
     iconCls            String?
     note               String?
+    csiCode            String?
     baselines          Json?
     coverImageUrl      String?
     version            Int       @default(1)

--- a/src/lib/constants/csiCodes.ts
+++ b/src/lib/constants/csiCodes.ts
@@ -1,0 +1,51 @@
+export interface CsiDivision {
+  code: string;
+  name: string;
+}
+
+export const CSI_DIVISIONS: CsiDivision[] = [
+  { code: "00", name: "Procurement and Contracting Requirements" },
+  { code: "01", name: "General Requirements" },
+  { code: "02", name: "Existing Conditions" },
+  { code: "03", name: "Concrete" },
+  { code: "04", name: "Masonry" },
+  { code: "05", name: "Metals" },
+  { code: "06", name: "Wood, Plastics, and Composites" },
+  { code: "07", name: "Thermal and Moisture Protection" },
+  { code: "08", name: "Openings" },
+  { code: "09", name: "Finishes" },
+  { code: "10", name: "Specialties" },
+  { code: "11", name: "Equipment" },
+  { code: "12", name: "Furnishings" },
+  { code: "13", name: "Special Construction" },
+  { code: "14", name: "Conveying Equipment" },
+  { code: "21", name: "Fire Suppression" },
+  { code: "22", name: "Plumbing" },
+  { code: "23", name: "Heating, Ventilating, and Air Conditioning (HVAC)" },
+  { code: "25", name: "Integrated Automation" },
+  { code: "26", name: "Electrical" },
+  { code: "27", name: "Communications" },
+  { code: "28", name: "Electronic Safety and Security" },
+  { code: "31", name: "Earthwork" },
+  { code: "32", name: "Exterior Improvements" },
+  { code: "33", name: "Utilities" },
+  { code: "34", name: "Transportation" },
+  { code: "35", name: "Waterway and Marine Construction" },
+  { code: "40", name: "Process Interconnections" },
+  { code: "41", name: "Material Processing and Handling Equipment" },
+  { code: "42", name: "Process Heating, Cooling, and Drying Equipment" },
+  { code: "43", name: "Process Gas and Liquid Handling, Purification, and Storage Equipment" },
+  { code: "44", name: "Pollution and Waste Control Equipment" },
+  { code: "45", name: "Industry-Specific Manufacturing Equipment" },
+  { code: "46", name: "Water and Wastewater Equipment" },
+  { code: "48", name: "Electrical Power Generation" },
+];
+
+export const CSI_DIVISION_MAP = new Map(
+  CSI_DIVISIONS.map((d) => [d.code, d]),
+);
+
+export function formatCsiCode(code: string): string {
+  const division = CSI_DIVISION_MAP.get(code);
+  return division ? `${code} - ${division.name}` : code;
+}

--- a/src/lib/validations/gantt.ts
+++ b/src/lib/validations/gantt.ts
@@ -29,6 +29,7 @@ const taskRecordSchema = z.object({
   cls: z.string().nullable().optional(),
   iconCls: z.string().nullable().optional(),
   note: z.string().nullable().optional(),
+  csiCode: z.string().nullable().optional(),
   baselines: z.any().optional(),
 });
 

--- a/src/server/api/helpers/ganttSync.ts
+++ b/src/server/api/helpers/ganttSync.ts
@@ -115,6 +115,7 @@ export async function syncTasks(
           cls: task.cls ?? null,
           iconCls: task.iconCls ?? null,
           note: task.note ?? null,
+          csiCode: task.csiCode ?? null,
           baselines: task.baselines ?? null,
         },
       });
@@ -149,6 +150,7 @@ export async function syncTasks(
       if (task.cls !== undefined) updateData.cls = task.cls;
       if (task.iconCls !== undefined) updateData.iconCls = task.iconCls;
       if (task.note !== undefined) updateData.note = task.note;
+      if (task.csiCode !== undefined) updateData.csiCode = task.csiCode;
       if (task.baselines !== undefined) updateData.baselines = task.baselines;
 
       // Resolve parent phantom ID if needed (any phantom format, not just "$"-prefixed)

--- a/src/server/api/helpers/ganttTree.ts
+++ b/src/server/api/helpers/ganttTree.ts
@@ -20,6 +20,7 @@ type GanttTaskSelect = {
   cls: string | null;
   iconCls: string | null;
   note: string | null;
+  csiCode: string | null;
   baselines: unknown;
   orderIndex: number;
   version: number;
@@ -46,6 +47,7 @@ export function mapTaskToGantt(task: GanttTaskSelect): Record<string, unknown> {
     cls: task.cls,
     iconCls: task.iconCls,
     note: task.note,
+    csiCode: task.csiCode,
     baselines: task.baselines,
     version: task.version,
   };

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -62,6 +62,7 @@ export const ganttRouter = createTRPCRouter({
           duration: true,
           durationUnit: true,
           coverImageUrl: true,
+          csiCode: true,
           parentId: true,
           parent: {
             select: { name: true },
@@ -82,6 +83,7 @@ export const ganttRouter = createTRPCRouter({
         duration: task.duration,
         durationUnit: task.durationUnit,
         coverImageUrl: task.coverImageUrl,
+        csiCode: task.csiCode,
         group: task.parent?.name ?? null,
       };
     }),
@@ -131,6 +133,7 @@ export const ganttRouter = createTRPCRouter({
             cls: true,
             iconCls: true,
             note: true,
+            csiCode: true,
             baselines: true,
             orderIndex: true,
             version: true,


### PR DESCRIPTION
## Summary
- Add CSI MasterFormat division codes to Gantt tasks
- Sync APP_URL with Conductor port on every dev server start (prevents port mismatch)
- Add tRPC guide and Gantt slash command docs
- Various auth, env, and dev setup improvements from prior commits

## Test plan
- [ ] Verify Gantt tasks display CSI division codes correctly
- [ ] Start a new Conductor workspace and confirm APP_URL matches the assigned port
- [ ] Sign in and confirm no redirect loops