### PR TITLE
Fix onboarding redirect loop and hardcode port to 3000

### DIFF
--- a/claudedocs/environment-setup.md
+++ b/claudedocs/environment-setup.md
@@ -9,15 +9,15 @@ Construction project management SaaS (BuildTrack Pro) built on the T3 stack: Nex
 | `construction_POSTGRES_PRISMA_URL` | PostgreSQL connection string (local in dev, Neon on Vercel) | Yes | `postgresql://USER@localhost:5432/construction` |
 | `construction_POSTGRES_URL_NON_POOLING` | Direct (non-pooled) PostgreSQL connection for Prisma migrations | Yes | `postgresql://USER@localhost:5432/construction` |
 | `BETTER_AUTH_SECRET` | Signing secret for Better Auth sessions | Yes | Any strong random string |
-| `APP_URL` | Base URL for Better Auth callbacks, trusted origins, invite links, and password reset links. Must be set per-environment — see `claudedocs/vercel.md`. | Yes (defaults to `http://localhost:5050`) | `https://celn.app` |
+| `APP_URL` | Base URL for Better Auth callbacks, trusted origins, invite links, and password reset links. Must be set per-environment — see `claudedocs/vercel.md`. | Yes (defaults to `http://localhost:3000`) | `https://celn.app` |
 | `RESEND_API_KEY` | Resend transactional email API key | Optional | `re_...` (omit for dev console logging) |
 | `BLOB_READ_WRITE_TOKEN` | Vercel Blob storage token for file uploads | Optional | Provided by Vercel integration |
 | `OPENAI_API_KEY` | OpenAI API key for semantic search embeddings | Optional | `sk-proj-...` (get from platform.openai.com) |
 | `ANTHROPIC_API_KEY` | Anthropic API key for AI document analysis (image + PDF descriptions) | Optional | `sk-ant-...` (get from console.anthropic.com) |
 | `BETA_ACCESS_CODE` | Beta access code required on sign-up form. Omit to disable the gate. | Optional | `buildtrack-beta-2026` |
-| `NEXT_PUBLIC_APP_URL` | Client-side base URL | Optional | `http://localhost:5050` |
+| `NEXT_PUBLIC_APP_URL` | Client-side base URL | Optional | `http://localhost:3000` |
 | `NODE_ENV` | Runtime environment | Auto | `development` / `production` / `test` |
-| `PORT` | Dev server port | Auto (defaults to `5050`) | `5050` |
+| `PORT` | Dev server port | Auto (defaults to `3000`) | `3000` |
 | `SKIP_ENV_VALIDATION` | Skip T3 env validation (useful for Docker) | No | `1` |
 
 Validation is defined in `src/env.js` using `@t3-oss/env-nextjs` and Zod. The build will fail if required variables are missing or malformed.
@@ -51,13 +51,13 @@ sed -i '' "s|^construction_POSTGRES_PRISMA_URL=.*|construction_POSTGRES_PRISMA_U
 sed -i '' "s|^construction_POSTGRES_URL_NON_POOLING=.*|construction_POSTGRES_URL_NON_POOLING=\"postgresql://$USER@localhost:5432/construction\"|" .env.local
 
 # APP_URL must be set manually since it depends on your local port:
-echo 'APP_URL="http://localhost:5050"' >> .env.local
+echo 'APP_URL="http://localhost:3000"' >> .env.local
 
 # 5. Apply database migrations
 npx prisma db push
 
 # 6. Start dev server (Turbopack)
-npm run dev          # http://localhost:5050
+npm run dev          # http://localhost:3000
 ```
 
 **Notes**

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "setup": "[[ \"$CONDUCTOR_PORT\" =~ ^[0-9]+$ ]] || exit 1 && vercel link --project construction-web --scope celn --yes && vercel env pull .env.local --environment development --scope celn --yes && (grep -q '^APP_URL=' .env.local && sed -i '' \"s|^APP_URL=.*|APP_URL=\\\"http://localhost:$CONDUCTOR_PORT\\\"|\" .env.local || echo \"APP_URL=\\\"http://localhost:$CONDUCTOR_PORT\\\"\" >> .env.local) && sed -i '' \"s|^construction_POSTGRES_PRISMA_URL=.*|construction_POSTGRES_PRISMA_URL=\\\"postgresql://$USER@localhost:5432/construction\\\"|\" .env.local && sed -i '' \"s|^construction_POSTGRES_URL_NON_POOLING=.*|construction_POSTGRES_URL_NON_POOLING=\\\"postgresql://$USER@localhost:5432/construction\\\"|\" .env.local && sed -i '' 's|\\\\n\"|\"| ' .env.local && (grep -q '^NODE_OPTIONS=' .env.local || echo 'NODE_OPTIONS=\"--max-old-space-size=8192\"' >> .env.local) && npm install",
-    "run": "(grep -q '^APP_URL=' .env.local && sed -i '' \"s|^APP_URL=.*|APP_URL=\\\"http://localhost:$CONDUCTOR_PORT\\\"|\" .env.local || echo \"APP_URL=\\\"http://localhost:$CONDUCTOR_PORT\\\"\" >> .env.local) && PORT=$CONDUCTOR_PORT npm run dev",
+    "setup": "vercel link --project construction-web --scope celn --yes && vercel env pull .env.local --environment development --scope celn --yes && sed -i '' \"s|^construction_POSTGRES_PRISMA_URL=.*|construction_POSTGRES_PRISMA_URL=\\\"postgresql://$USER@localhost:5432/construction\\\"|\" .env.local && sed -i '' \"s|^construction_POSTGRES_URL_NON_POOLING=.*|construction_POSTGRES_URL_NON_POOLING=\\\"postgresql://$USER@localhost:5432/construction\\\"|\" .env.local && sed -i '' 's|\\\\n\"|\"| ' .env.local && (grep -q '^NODE_OPTIONS=' .env.local || echo 'NODE_OPTIONS=\"--max-old-space-size=8192\"' >> .env.local) && npm install",
+    "run": "npm run dev",
     "archive": "rm -f .env.local && rm -rf .vercel && rm -rf node_modules && rm -rf .next"
   }
 }

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -29,18 +29,19 @@ export default function VerifyEmailPage() {
   const [resendCooldown, setResendCooldown] = useState(0);
   const [sent, setSent] = useState(false);
   const setEmailVerified = api.user.setEmailVerified.useMutation();
+  const redirected = useRef(false);
 
   const email = session?.user?.email ?? '';
 
   useEffect(() => {
-    if (!isPending && session?.user?.emailVerified) {
+    if (!isPending && session?.user?.emailVerified && !redirected.current) {
+      redirected.current = true;
       void setEmailVerified.mutateAsync().then(() => {
         router.push('/onboarding');
-        router.refresh();
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session, isPending, router]);
+  }, [session, isPending]);
 
   const handleSendOtp = async () => {
     if (!email) return;

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';

--- a/src/env.js
+++ b/src/env.js
@@ -12,9 +12,9 @@ export const env = createEnv({
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
-    PORT: z.coerce.number().default(5050),
+    PORT: z.coerce.number().default(3000),
     RESEND_API_KEY: z.string().optional(),
-    APP_URL: z.string().url().default("http://localhost:5050"),
+    APP_URL: z.string().url().default("http://localhost:3000"),
     BLOB_READ_WRITE_TOKEN: z.string().optional(),
     OPENAI_API_KEY: z.string().optional(),
     ANTHROPIC_API_KEY: z.string().optional(),


### PR DESCRIPTION
## Summary
Fixes the onboarding redirect loop and standardizes the dev server port to 3000.

**Changes:**
- Prevents double-redirect in email verification by using a `redirected` ref guard
- Removes unnecessary `router.refresh()` call
- Updates default `PORT` and `APP_URL` from 5050 to 3000 across env config and docs
- Simplifies Conductor setup/run scripts (hardcodes port to 3000)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>