### PR TITLE
Add missing GanttTask.csiCode migration

### DIFF
--- a/prisma/migrations/20260320000000_add_gantt_task_csi_code/migration.sql
+++ b/prisma/migrations/20260320000000_add_gantt_task_csi_code/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "GanttTask" ADD COLUMN "csiCode" TEXT;


### PR DESCRIPTION
Adds the missing database migration for the `csiCode` column on the `GanttTask` table. The field was defined in the Prisma schema but the corresponding migration was never created, causing P2022 errors when the Gantt router tried to query the table on the preview environment.

This migration adds `csiCode` as a nullable TEXT column, resolving the schema mismatch and allowing Gantt queries to execute successfully after deployment.