### PR TITLE
Add row actions menu and subtask UX for Gantt

### DIFF
--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -14,6 +14,7 @@ import { useSnackbar } from '@/hooks/useSnackbar';
 import { useBryntumThemeAssets } from './hooks/useBryntumThemeAssets';
 import { useTaskPopover } from './hooks/useTaskPopover';
 import { useGanttControls } from './hooks/useGanttControls';
+import type { BryntumTaskRecord, BryntumGanttInstance } from './types';
 import { validateParentDuration } from './utils/ganttValidation';
 
 const WRAPPER_STYLE: CSSProperties = {
@@ -45,6 +46,7 @@ interface BryntumGanttWrapperProps {
 
 export default function BryntumGanttWrapper({ projectId, isVisible = true }: BryntumGanttWrapperProps) {
   const theme = useThemeStore((state) => state.theme);
+  const errorColor = theme === 'dark' ? '#FF5C33' : '#D93C15';
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -83,6 +85,8 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
     ganttRef,
     getGanttInstance,
     handleAddTask,
+    handleIndent,
+    handleOutdent,
     handleZoomIn,
     handleZoomOut,
     handleZoomToFit,
@@ -424,10 +428,65 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
     return () => { detach?.(); };
   }, [isLoading, getGanttInstance, handleTaskClick]);
 
+  // Attach the row action menu handler on the Gantt instance.
+  // The WidgetColumn menu items use `onItem: 'up.onRowActionClick'` which
+  // resolves to this method on the Gantt widget.
+  useEffect(() => {
+    if (isLoading) return;
+    const gantt = getGanttInstance();
+    if (!gantt) return;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    (gantt as any).onRowActionClick = ({ source }: { source: { ref: string; up: (type: string) => { cellInfo: { record: unknown } } | null } }) => {
+      // Walk up to the button widget to get the cellInfo injected by WidgetColumn
+      const button = source.up('button');
+      if (!button) return;
+      const record = button.cellInfo?.record as BryntumTaskRecord | undefined;
+      if (!record) return;
+      const g = gantt as unknown as BryntumGanttInstance;
+
+      switch (source.ref) {
+        case 'addSubtask':
+          record.appendChild({ name: 'New Subtask', duration: 1, startDate: new Date() });
+          // Expand the parent so the new subtask is visible
+          if (!record.isExpanded) {
+            g.expand(record);
+          }
+          break;
+        case 'indent':
+          g.indent([record]);
+          break;
+        case 'outdent':
+          g.outdent([record]);
+          break;
+        case 'unlinkTask': {
+          // Remove all dependencies (both incoming and outgoing) for this task
+          const deps = [
+            ...(record.predecessors ?? []),
+            ...(record.successors ?? []),
+          ];
+          if (deps.length > 0) g.dependencyStore.remove(deps);
+          break;
+        }
+        case 'deleteTask':
+          record.remove();
+          break;
+      }
+    };
+
+    return () => {
+      const g = getGanttInstance();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      if (g) delete (g as any).onRowActionClick;
+    };
+  }, [isLoading, getGanttInstance]);
+
   return (
     <div style={WRAPPER_STYLE}>
       <GanttToolbar
         onAddTask={handleAddTask}
+        onIndent={handleIndent}
+        onOutdent={handleOutdent}
         onPresetChange={handlePresetChange}
         onZoomIn={handleZoomIn}
         onZoomOut={handleZoomOut}
@@ -454,6 +513,58 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
           0% { box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.6); }
           50% { box-shadow: inset 0 0 6px rgba(255, 255, 255, 0.3); }
           100% { box-shadow: none; }
+        }
+        /* Row actions ⋮ button */
+        .gantt-row-actions-btn {
+          opacity: 0.4;
+          transition: opacity 0.15s;
+          background: none !important;
+          border: none !important;
+          box-shadow: none !important;
+          min-width: 0 !important;
+        }
+        .b-grid-row:hover .gantt-row-actions-btn,
+        .gantt-row-actions-btn:focus,
+        .gantt-row-actions-btn[aria-expanded="true"] {
+          opacity: 1;
+        }
+        /* Row actions dropdown menu — clean card style */
+        .gantt-row-actions-btn + .b-menu,
+        .b-menu:has(.gantt-action-danger) {
+          border-radius: 10px !important;
+          box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25) !important;
+          border: 1px solid var(--border-color, rgba(0, 0, 0, 0.08)) !important;
+          padding: 4px 0 !important;
+          overflow: hidden;
+        }
+        .gantt-row-actions-btn + .b-menu .b-menuitem,
+        .b-menu:has(.gantt-action-danger) .b-menuitem {
+          padding: 8px 16px !important;
+          font-size: 13px !important;
+          font-weight: 500 !important;
+          border-radius: 0 !important;
+          gap: 10px !important;
+        }
+        .gantt-row-actions-btn + .b-menu .b-menuitem:hover,
+        .b-menu:has(.gantt-action-danger) .b-menuitem:hover {
+          background: var(--hover-bg, rgba(0, 0, 0, 0.04)) !important;
+        }
+        .gantt-row-actions-btn + .b-menu .b-menuitem .b-icon,
+        .b-menu:has(.gantt-action-danger) .b-menuitem .b-icon {
+          font-size: 14px !important;
+          width: 18px !important;
+          text-align: center;
+        }
+        .gantt-row-actions-btn + .b-menu .b-menu-separator,
+        .b-menu:has(.gantt-action-danger) .b-menu-separator {
+          margin: 4px 0 !important;
+        }
+        /* Delete action red text */
+        .gantt-action-danger {
+          color: ${errorColor} !important;
+        }
+        .gantt-action-danger .b-icon {
+          color: ${errorColor} !important;
         }
       `}</style>
 

--- a/src/components/bryntum/components/GanttToolbar.tsx
+++ b/src/components/bryntum/components/GanttToolbar.tsx
@@ -21,6 +21,8 @@ import {
   MoreVertical,
   Plus,
   CheckCircle,
+  IndentIncrease,
+  IndentDecrease,
 } from 'lucide-react';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -127,6 +129,8 @@ const switchSx = {
 // ─── Props ────────────────────────────────────────────────────────────────────
 type GanttToolbarProps = {
   onAddTask?: () => void;
+  onIndent?: () => void;
+  onOutdent?: () => void;
   onPresetChange?: (preset: string) => void;
   onZoomIn?: () => void;
   onZoomOut?: () => void;
@@ -147,6 +151,8 @@ type GanttToolbarProps = {
 // ─── Component ────────────────────────────────────────────────────────────────
 export default function GanttToolbar({
   onAddTask,
+  onIndent,
+  onOutdent,
   onPresetChange,
   onZoomIn,
   onZoomOut,
@@ -215,6 +221,15 @@ export default function GanttToolbar({
         </IconButton>
         <IconButton size="small" sx={iconBtnSx} onClick={onShiftNext} title="Next time span">
           <ChevronsRight style={{ width: ICON_SIZE, height: ICON_SIZE }} />
+        </IconButton>
+
+        <Divider orientation="vertical" flexItem sx={{ mx: 0.5, my: 'auto', height: 18, alignSelf: 'center' }} />
+
+        <IconButton size="small" sx={iconBtnSx} onClick={onOutdent} title="Outdent selected task">
+          <IndentDecrease style={{ width: ICON_SIZE, height: ICON_SIZE }} />
+        </IconButton>
+        <IconButton size="small" sx={iconBtnSx} onClick={onIndent} title="Indent selected task">
+          <IndentIncrease style={{ width: ICON_SIZE, height: ICON_SIZE }} />
         </IconButton>
       </Stack>
 

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -111,6 +111,57 @@ export function createGanttConfig(
         width: 100,
         resizable: true,
       },
+      {
+        type: 'widget',
+        width: 40,
+        resizable: false,
+        sortable: false,
+        filterable: false,
+        text: '',
+        widgets: [
+          {
+            type: 'button',
+            menuIcon: false,
+            icon: 'b-icon b-icon-menu-vertical',
+            cls: 'gantt-row-actions-btn',
+            menu: {
+              items: {
+                addSubtask: {
+                  text: 'Add Subtask',
+                  icon: 'b-icon b-icon-add',
+                  weight: 100,
+                  onItem: 'up.onRowActionClick',
+                },
+                indent: {
+                  text: 'Indent',
+                  icon: 'b-icon b-icon-indent',
+                  weight: 200,
+                  onItem: 'up.onRowActionClick',
+                },
+                outdent: {
+                  text: 'Outdent',
+                  icon: 'b-icon b-icon-outdent',
+                  weight: 300,
+                  onItem: 'up.onRowActionClick',
+                },
+                unlinkTask: {
+                  text: 'Unlink',
+                  icon: 'b-icon b-icon-unlink',
+                  weight: 500,
+                  onItem: 'up.onRowActionClick',
+                },
+                deleteTask: {
+                  text: 'Delete',
+                  icon: 'b-icon b-icon-trash',
+                  cls: 'gantt-action-danger',
+                  weight: 600,
+                  onItem: 'up.onRowActionClick',
+                },
+              },
+            },
+          },
+        ],
+      },
     ],
     features: {
       columnLines: true,

--- a/src/components/bryntum/hooks/useGanttControls.ts
+++ b/src/components/bryntum/hooks/useGanttControls.ts
@@ -36,6 +36,24 @@ export function useGanttControls() {
     });
   }, [getGanttInstance]);
 
+  const handleIndent = useCallback(() => {
+    const gantt = getGanttInstance();
+    if (!gantt) return;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const selected = gantt.selectedRecords as unknown[];
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    if (selected?.length) gantt.indent(selected);
+  }, [getGanttInstance]);
+
+  const handleOutdent = useCallback(() => {
+    const gantt = getGanttInstance();
+    if (!gantt) return;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const selected = gantt.selectedRecords as unknown[];
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    if (selected?.length) gantt.outdent(selected);
+  }, [getGanttInstance]);
+
   const handleZoomIn = useCallback(() => getGanttInstance()?.zoomIn(), [getGanttInstance]);
   const handleZoomOut = useCallback(() => getGanttInstance()?.zoomOut(), [getGanttInstance]);
   const handleZoomToFit = useCallback(() => {
@@ -82,6 +100,8 @@ export function useGanttControls() {
     ganttRef,
     getGanttInstance,
     handleAddTask,
+    handleIndent,
+    handleOutdent,
     handleZoomIn,
     handleZoomOut,
     handleZoomToFit,

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -35,6 +35,10 @@ type GanttColumnConfig = {
   minWidth?: number;
   width?: number;
   resizable?: boolean;
+  sortable?: boolean;
+  filterable?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  widgets?: Record<string, unknown>[];
 };
 
 type TooltipRendererArgs = {
@@ -43,6 +47,28 @@ type TooltipRendererArgs = {
     field?: string;
   };
 };
+
+/** Minimal interface for Bryntum task record methods used in row actions. */
+export interface BryntumTaskRecord {
+  id: string | number;
+  name?: string;
+  isExpanded: boolean;
+  predecessors: unknown[];
+  successors: unknown[];
+  appendChild(data: Record<string, unknown>): void;
+  remove(): void;
+}
+
+/** Minimal interface for Gantt instance methods used in row action handlers. */
+export interface BryntumGanttInstance {
+  expand(record: BryntumTaskRecord): void;
+  indent(records: BryntumTaskRecord[]): void;
+  outdent(records: BryntumTaskRecord[]): void;
+  selectedRecords: BryntumTaskRecord[];
+  dependencyStore: {
+    remove(records: unknown[]): void;
+  };
+}
 
 export type GanttConfig = {
   height?: string;


### PR DESCRIPTION
## Summary
- Add per-row ⋮ actions menu with Add Subtask, Indent, Outdent, Unlink, and Delete actions
- Add indent/outdent toolbar buttons for selected tasks
- Add typed `BryntumTaskRecord` and `BryntumGanttInstance` interfaces to replace `any` propagation in row action handlers
- Use theme-aware error color for the delete action instead of hardcoded hex fallback
- Extend `GanttColumnConfig` type with `sortable`, `filterable`, and `widgets` fields

## Test plan
- [ ] Open Gantt view, hover a row — ⋮ button appears
- [ ] Click ⋮ — menu shows 5 items (Add Subtask, Indent, Outdent, Unlink, Delete)
- [ ] Each action works correctly (subtask created and parent expanded, indent/outdent re-parents, unlink removes deps, delete removes task)
- [ ] Toolbar indent/outdent buttons work on selected tasks
- [ ] Delete action text is red matching the MUI theme error color
- [ ] Toggle dark mode — delete action color updates to dark theme error color
- [ ] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)