### PR TITLE
Redesign sidebar, project tree, and detail panel

### DIFF
--- a/.claude/commands/style.md
+++ b/.claude/commands/style.md
@@ -1,0 +1,260 @@
+---
+name: style
+description: "Project-aware UI development with automatic design system enforcement and component pattern guidance"
+category: workflow
+complexity: standard
+---
+
+# /style - Project Design System Development
+
+> **Context Framework Note**: This behavioral instruction activates when users type `/style` patterns. It ensures all UI work follows the established design system — theme tokens, typography, spacing, icon conventions, and component patterns — producing consistent, production-grade interfaces.
+
+## Triggers
+- Any new UI component, page, or feature development
+- Styling changes or visual refinements
+- Layout modifications (sidebar, drawers, panels, dialogs)
+- Component creation or restructuring
+- Dark mode implementation or theme token usage
+
+## Context Trigger Pattern
+```
+/style [task-description] [--scope sidebar|dialog|page|card|form|table|tree] [--review-only]
+```
+
+## Behavioral Flow
+
+### Step 1: Read the Design System (MANDATORY)
+Before making ANY UI changes, you MUST review these files:
+
+1. **Theme tokens**: `src/theme/theme.ts` — MUI light/dark palettes with custom extensions
+2. **CSS variables**: `src/styles/globals.css` — CSS custom properties for both themes
+3. **Component guide**: `claudedocs/components-guide.md` — conventions, naming, structure
+4. **Reference implementation**: `src/components/layout/Sidebar.tsx` — canonical compact density
+
+### Step 2: Apply the Design System
+
+#### Color Palette
+
+**Light Theme Core**
+| Token | Value | Usage |
+|-------|-------|-------|
+| `primary.main` | `#2B2D42` | Primary actions, active indicators |
+| `background.default` | `#F0F0F3` | Page background |
+| `background.paper` | `#FFFFFF` | Cards, panels |
+| `text.primary` | `#1A1A2E` | Body text, headings |
+| `text.secondary` | `#8D99AE` | Secondary/muted text |
+| `text.disabled` | `#B0B8C4` | Disabled, section labels |
+| `divider` | `#D9DBE1` | Borders, separators |
+| `error.main` | `#D93C15` | Destructive actions |
+
+**Dark Theme Core**
+| Token | Value | Usage |
+|-------|-------|-------|
+| `primary.main` | `#4A90D9` | Primary actions |
+| `background.default` | `#111111` | Page background |
+| `background.paper` | `#1A1A1A` | Cards, panels |
+| `text.primary` | `#FFFFFF` | Body text |
+| `text.secondary` | `#B8B9B6` | Secondary text |
+| `divider` | `#2E2E2E` | Borders |
+
+**Custom Palette Extensions** — always access via `theme.palette.*`:
+- `sidebar.*` — background, border, indicator, activeBg, hoverBg, activeItemBg
+- `status.*` — active, inProgress, onHold, completed, archived (+ bg/text variants)
+- `accent.*` — dark, gradientEnd (used for avatar gradients)
+- `warm.*` — main, dark (amber accent)
+- `docExplorer.*` — destructive variants, linkedGreen, badgeBg, aiPurple
+- `card.background`, `input.background`
+
+**CSS Variables** (use in non-MUI contexts or raw CSS):
+```css
+--accent-primary    --text-primary    --bg-primary
+--sidebar-border    --sidebar-indicator    --sidebar-active-bg
+--status-green      --status-amber    --status-red    --status-blue
+--border-color      --border-light    --focus-ring
+```
+
+#### Typography
+
+**Font**: `var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif` — set in MUI theme. Never use Inter, Arial, Roboto, or other fonts directly.
+
+**Scale** (compact density — used across sidebar, drawers, trees, panels):
+
+| Role | fontSize | fontWeight | lineHeight | Notes |
+|------|----------|------------|------------|-------|
+| Section label (ALL CAPS) | `0.5625rem` (9px) | 600 | — | `letterSpacing: '0.12em'`, `textTransform: 'uppercase'`, `userSelect: 'none'` |
+| Nav/tree item | `0.8125rem` (13px) | 400–500 | 1 | Active: `fontWeight: 550`, `letterSpacing: '-0.005em'` |
+| Secondary/meta text | `0.6875rem` (11px) | 400–500 | 1.2 | Task counts, email, status labels |
+| Document filename | `0.75rem`–`0.8rem` | 400 | — | Always truncate |
+
+**Critical**: Always set `lineHeight` explicitly. MUI's default `1.5` breaks compact rows.
+
+#### Spacing
+
+```tsx
+// Nav item row
+sx={{ px: 1.25, py: 0.875, borderRadius: '8px' }}  // 10px / 7px
+
+// Tree item label
+sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.375 }}  // 3px vertical
+
+// Gap between sibling nav rows
+gap: '1px'
+
+// Icon-to-label gaps
+gap: 1       // 8px — tree items
+gap: 1.25    // 10px — sidebar nav items
+```
+
+#### Icons
+
+| Context | Library | Size | Notes |
+|---------|---------|------|-------|
+| Sidebar nav | Phosphor (`@phosphor-icons/react`) | `size={17}` | `weight={isActive ? 'fill' : 'regular'}` |
+| Tree folders/tasks | Lucide (`lucide-react`) | `size={14}` | |
+| Tree documents | Lucide | `size={12}` | |
+| Utility (refresh, add) | Lucide | `size={14}` | |
+| Chevrons/indicators | Lucide | `style={{ width: 13, height: 13 }}` | |
+| MUI Button icons | Auto-sized by theme | 16px (default), 18px (lg), 14px (sm) | |
+
+Lucide icons use `style={{ width: N, height: N }}` (not `sx`). Phosphor icons use the `size` prop.
+
+#### Border Radius
+- Interactive row backgrounds: `borderRadius: '8px'`
+- Avatars: `borderRadius: '10px'`
+- Buttons: `borderRadius: 4` (set in MUI theme)
+- Global shape: `borderRadius: 8` (MUI theme default)
+
+#### Active State Indicator (Sidebar Pattern)
+```tsx
+<Box sx={{
+  position: 'absolute',
+  left: 0,
+  top: '50%',
+  transform: 'translateY(-50%)',
+  width: '2.5px',
+  height: 16,
+  borderRadius: '0 2px 2px 0',
+  bgcolor: 'sidebar.indicator',
+}} />
+```
+
+#### Text Overflow (Always Apply on Long Text)
+```tsx
+sx={{
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}}
+// Parent flex container needs: minWidth: 0
+```
+
+### Step 3: Follow Component Conventions
+
+**Styling**: MUI `sx` prop is primary. Use theme tokens (`theme.palette.*`, `'text.primary'`, `'divider'`). CSS variables for one-off non-MUI elements. No CSS modules, no Tailwind on MUI components, no hardcoded hex colors.
+
+**UI Primitives** (from `src/components/ui/`):
+| Component | When to use |
+|-----------|-------------|
+| `Button` | Actions — variants: `default`, `outline`, `ghost`, `destructive`; `loading` prop |
+| `DropdownMenu` | Action menus with `asChild` support |
+| `Sheet` | Slide-in panels |
+| `Label` | Accessible form labels |
+| `LoadingSpinner` | Loading states — `size="lg" fullScreen` for page-level |
+| `ImageWithFallback` / `OptimizedImage` | Always use over bare `<img>` |
+| `FileDropzone` | File upload areas |
+| `UploadOverlay` | Upload progress — variants: `dark` (image), `light` (form) |
+| `OtpInput` | OTP verification input |
+
+For MUI components without a `ui/` wrapper, use MUI directly. Don't create wrappers unless used in 3+ places.
+
+**Forms**: `react-hook-form` + `zodResolver` + Zod schema from `src/lib/validations/`. Wrap MUI inputs with `Controller`.
+
+**Data fetching**: tRPC hooks (`api.feature.list.useQuery()`). Never `fetch()` in client components.
+
+### Step 4: Validate Your Work
+
+After implementing UI changes:
+- [ ] All colors use theme tokens or CSS variables (no hardcoded hex)
+- [ ] Typography uses Geist Sans via theme (never set `fontFamily` directly)
+- [ ] `lineHeight` is set explicitly on compact rows
+- [ ] Long text has overflow/ellipsis handling
+- [ ] Icons use correct library (Phosphor for nav, Lucide for utility)
+- [ ] Both light and dark themes work (test with `.dark` class)
+- [ ] `'use client'` only where needed (hooks, events, browser APIs)
+- [ ] No MUI default `minHeight` on ListItem/MenuItem in compact areas
+- [ ] Interactive rows have `borderRadius: '8px'`
+
+## Anti-Patterns — Do NOT
+
+| Don't | Do instead |
+|-------|-----------|
+| Hardcoded hex colors (`#fff`, `#333`) | Theme tokens (`'background.paper'`, `'text.primary'`) |
+| `fontFamily: 'Inter'` or any direct font | Let theme handle it (already set to Geist Sans) |
+| MUI default `minHeight` on list items | Override or use plain `Box` rows |
+| Omit `lineHeight` on compact text | Always set `lineHeight: 1` or `1.2` |
+| CSS modules or Tailwind on MUI | `sx` prop with theme tokens |
+| `<img>` tags | `ImageWithFallback` or `OptimizedImage` |
+| New providers for feature state | Zustand stores in `src/store/` |
+| Icons without correct sizing | Follow icon size table above |
+| Random aesthetic choices | Follow established patterns from Sidebar, MobileDrawer, ProjectsTree |
+| Purple gradients, Inter font, generic AI aesthetics | Project's navy (`#2B2D42`) / blue (`#4A90D9`) palette with Geist Sans |
+
+## Key Reference Files
+
+| File | What it provides |
+|------|------------------|
+| `src/theme/theme.ts` | Complete MUI light + dark theme with all custom palette extensions |
+| `src/styles/globals.css` | CSS custom properties for both themes, Gantt/Bryntum overrides |
+| `src/components/layout/Sidebar.tsx` | Canonical compact density: spacing, typography, active states |
+| `src/components/layout/MobileDrawer.tsx` | Same density at 300px width |
+| `src/components/projects/ProjectsTree.tsx` | SimpleTreeView with compact TreeItem labels |
+| `src/components/ui/` | Shared design primitives |
+| `claudedocs/components-guide.md` | Full component conventions, naming, directory structure |
+
+## Examples
+
+### Build a New Settings Page
+```
+/style create an organization settings page with profile, billing, and danger zone sections
+# 1. Read theme.ts and components-guide.md
+# 2. Use MUI sx with theme tokens throughout
+# 3. Follow page layout patterns from existing pages
+# 4. Use ui/Button destructive variant for danger zone
+# 5. Validate dark mode support
+```
+
+### Add a Status Badge Component
+```
+/style create a reusable status badge for project cards
+# 1. Read status tokens from theme.ts (status.active, status.activeBg, etc.)
+# 2. Use compact typography (0.6875rem, fontWeight 500)
+# 3. Follow existing badge patterns in the codebase
+# 4. Support all 5 statuses: active, inProgress, onHold, completed, archived
+```
+
+### Redesign a Dialog
+```
+/style improve the invite member dialog styling --scope dialog
+# 1. Read existing dialog implementations
+# 2. Follow form patterns (react-hook-form + zodResolver)
+# 3. Use ui/Button variants, MUI TextField with Controller
+# 4. Ensure consistent border radius, spacing, and typography
+```
+
+## Boundaries
+
+**Will:**
+- Always read theme.ts and globals.css before making UI changes
+- Follow the existing design system exactly
+- Use theme tokens for all colors and the established typography scale
+- Match compact density patterns for sidebar/drawer/tree contexts
+- Support both light and dark themes
+- Follow `claudedocs/components-guide.md` directory and naming conventions
+
+**Will Not:**
+- Introduce new fonts, color palettes, or design aesthetics
+- Use hardcoded colors, CSS modules, or Tailwind on MUI components
+- Create new context providers for feature-scoped state
+- Add UI primitives to `ui/` unless used in 3+ places
+- Make bold/creative/unexpected design choices that deviate from the established system
+- Ignore dark mode support

--- a/claudedocs/components-guide.md
+++ b/claudedocs/components-guide.md
@@ -265,10 +265,10 @@ gap: 1.25    // 10px — sidebar nav items
 | Context | Library | Size | Notes |
 |---|---|---|---|
 | Sidebar nav | Phosphor | `size={17}` | `weight={isActive ? 'fill' : 'regular'}` |
-| Tree folders / tasks | Lucide | `size={14}` | |
-| Tree documents | Lucide | `size={12}` | |
-| Utility (refresh, add) | Lucide | `size={14}` | |
-| Chevrons / small indicators | Lucide | `style={{ width: 13, height: 13 }}` | |
+| Tree folders / tasks | Phosphor | `size={14}` | |
+| Tree documents | Phosphor | `size={12}` | |
+| Utility (refresh, add) | Phosphor | `size={14}` | `weight="bold"` for action buttons |
+| Chevrons / small indicators | Phosphor | `style={{ width: 13, height: 13 }}` | |
 
 ### Active-state indicator (left bar)
 

--- a/claudedocs/components-guide.md
+++ b/claudedocs/components-guide.md
@@ -226,6 +226,81 @@ Follow this sub-structure if adding more Gantt-related code. Do not add Gantt lo
 
 ---
 
+## Tight Typography & Spacing (Sidebar Density Pattern)
+
+The sidebar, mobile drawer, and project tree use a deliberate **compact density** that differs from MUI's loose defaults. Apply these exact values whenever building sidebar-style navigation, trees, or any panel that needs to show a lot of content without scrolling.
+
+### Typography scale
+
+| Role | `fontSize` | `fontWeight` | Notes |
+|---|---|---|---|
+| Section label (ALL CAPS) | `0.5625rem` (9px) | 600 | `letterSpacing: '0.12em'`, `textTransform: 'uppercase'`, `userSelect: 'none'` |
+| Nav item / tree item | `0.8125rem` (13px) | 400–500 | Active items: `fontWeight: 550`, `letterSpacing: '-0.005em'` |
+| Secondary / meta text | `0.6875rem` (11px) | 400–500 | Task counts, email, status labels |
+| Document filename | `0.75rem`–`0.8rem` | 400 | Always truncate — see text overflow rule below |
+
+Always set `lineHeight` explicitly — MUI's default (1.5) is too loose:
+- Single-line rows: `lineHeight: 1`
+- Stacked name + secondary (e.g. user profile): `lineHeight: 1.2`
+
+### Spacing
+
+```tsx
+// Nav item row
+sx={{ px: 1.25, py: 0.875, borderRadius: '8px' }}  // 10px / 7px
+
+// Tree item label Box (the inner label wrapper)
+sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.375 }}  // 3px vertical
+
+// Gap between sibling nav rows
+gap: '1px'
+
+// Icon-to-label gap
+gap: 1       // 8px — tree items
+gap: 1.25    // 10px — sidebar nav items
+```
+
+### Icons
+
+| Context | Library | Size | Notes |
+|---|---|---|---|
+| Sidebar nav | Phosphor | `size={17}` | `weight={isActive ? 'fill' : 'regular'}` |
+| Tree folders / tasks | Lucide | `size={14}` | |
+| Tree documents | Lucide | `size={12}` | |
+| Utility (refresh, add) | Lucide | `size={14}` | |
+| Chevrons / small indicators | Lucide | `style={{ width: 13, height: 13 }}` | |
+
+### Active-state indicator (left bar)
+
+```tsx
+<Box sx={{
+  position: 'absolute',
+  left: 0,
+  top: '50%',
+  transform: 'translateY(-50%)',
+  width: '2.5px',
+  height: 16,
+  borderRadius: '0 2px 2px 0',
+  bgcolor: 'sidebar.indicator',
+}} />
+```
+
+### Key rules
+
+- **Never rely on MUI's default `minHeight`** on `ListItem` / `MenuItem` — it adds ~48px. Override explicitly or avoid those components in favour of plain `Box` rows.
+- **Set `lineHeight` every time.** Omitting it inherits 1.5 from the theme and breaks compact rows.
+- **Truncate long text** — always add `overflow: 'hidden'`, `textOverflow: 'ellipsis'`, `whiteSpace: 'nowrap'` on the text `Box`, and `minWidth: 0` on its flex parent so it can actually shrink.
+- **`borderRadius: '8px'`** on all interactive row backgrounds for consistency (avatars use `10px`).
+- **`userSelect: 'none'`** on non-interactive labels (section headers, group names).
+
+### Reference implementations
+
+- `src/components/layout/Sidebar.tsx` — nav items, section labels, user profile footer
+- `src/components/layout/MobileDrawer.tsx` — identical density at 300px width
+- `src/components/projects/ProjectsTree.tsx` — MUI `SimpleTreeView` with compact `TreeItem` labels
+
+---
+
 ## Adding a New Feature Slice
 
 1. Create `src/components/<feature>/` directory.

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -41,6 +41,9 @@ export function createGanttConfig(
   return {
     detectCSSCompatibilityIssues: false,
 
+    // Disable Bryntum's built-in loading mask — we use our own overlay in BryntumGanttWrapper
+    loadMask: null,
+
     // Performance optimizations
     autoHeight: false,
     rowHeight: 45, // Consistent row height for better performance

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -77,6 +77,7 @@ export type GanttConfig = {
   infiniteScroll?: boolean;
   bufferCoef?: number;
   detectCSSCompatibilityIssues: boolean;
+  loadMask?: string | null | Record<string, unknown>;
   rowHeight?: number;
   animateTreeNodeToggle?: boolean;
   toggleParentTasksOnClick?: boolean;

--- a/src/components/files/FilesContent.tsx
+++ b/src/components/files/FilesContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState } from 'react';
 import { Box } from '@mui/material';
 import { useProjectContext } from '@/components/providers/ProjectProvider';
 import ProjectsTree, { type Selection } from '@/components/projects/ProjectsTree';
@@ -9,50 +9,22 @@ import { ProjectDetailPanel } from '@/components/projects/ProjectDetailPanel';
 export default function FilesContent() {
   const { projectId, organizationId } = useProjectContext();
   const [selection, setSelection] = useState<Selection | null>(null);
-  const [treeWidth, setTreeWidth] = useState(320);
-  const [isDragging, setIsDragging] = useState(false);
-
-  const handleMouseDown = useCallback(() => {
-    setIsDragging(true);
-  }, []);
-
-  useEffect(() => {
-    if (!isDragging) return;
-
-    const handleMouseMove = (e: MouseEvent) => {
-      const newWidth = Math.min(Math.max(e.clientX, 200), 500);
-      setTreeWidth(newWidth);
-    };
-
-    const handleMouseUp = () => {
-      setIsDragging(false);
-    };
-
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
-
-    return () => {
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-    };
-  }, [isDragging]);
 
   return (
     <Box
       sx={{
         display: 'flex',
+        width: '100%',
         height: '100%',
         overflow: 'hidden',
-        userSelect: isDragging ? 'none' : 'auto',
       }}
     >
       {/* Left Panel - Tree */}
       <Box
         sx={{
-          width: { xs: selection ? 0 : '100%', lg: treeWidth },
+          width: { xs: 220, sm: 280, lg: 320 },
           flexShrink: 0,
           overflow: 'auto',
-          display: { xs: selection ? 'none' : 'block', lg: 'block' },
         }}
       >
         <ProjectsTree
@@ -63,19 +35,12 @@ export default function FilesContent() {
         />
       </Box>
 
-      {/* Draggable Divider */}
+      {/* Divider */}
       <Box
-        onMouseDown={handleMouseDown}
         sx={{
-          display: { xs: 'none', lg: 'block' },
-          width: 4,
+          width: '1px',
           flexShrink: 0,
-          cursor: 'col-resize',
-          bgcolor: isDragging ? 'primary.main' : 'divider',
-          transition: isDragging ? 'none' : 'background-color 0.2s',
-          '&:hover': {
-            bgcolor: 'primary.main',
-          },
+          bgcolor: 'divider',
         }}
       />
 
@@ -83,13 +48,13 @@ export default function FilesContent() {
       <Box
         sx={{
           flex: 1,
+          minWidth: 0,
+          height: '100%',
           overflow: 'auto',
-          display: { xs: selection ? 'block' : 'none', lg: 'block' },
         }}
       >
         <ProjectDetailPanel
           selection={selection}
-          onBack={() => setSelection(null)}
           projectId={projectId}
           organizationId={organizationId}
         />

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -70,7 +70,6 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           component="main"
           sx={{
             flex: 1,
-            p: 2,
             overflowX: 'hidden',
             overflowY: 'auto',
           }}

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -4,9 +4,9 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname, useParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
-import { X, ChevronsUpDown, User, Settings, CreditCard, LifeBuoy, LogOut } from 'lucide-react';
+import { X, User, Settings, CreditCard, LifeBuoy, LogOut, ChevronRight } from 'lucide-react';
 import { ChartBar, FolderSimple, FileMagnifyingGlass, Users, type Icon } from '@phosphor-icons/react';
-import { Drawer, Box, IconButton, Typography, List, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+import { Drawer, Box, IconButton, Typography } from '@mui/material';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -79,7 +79,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
       onClose={onClose}
       PaperProps={{
         sx: {
-          width: 288,
+          width: 300,
           bgcolor: 'sidebar.background',
           borderRight: '1px solid',
           borderColor: 'sidebar.border',
@@ -114,68 +114,118 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
           flex: 1,
           display: 'flex',
           flexDirection: 'column',
+          pt: 2,
           px: 1.5,
-          py: 1,
           overflow: 'hidden',
         }}
       >
-        <List sx={{ p: 0, display: 'flex', flexDirection: 'column', gap: '2px' }}>
+        {/* Section Label */}
+        <Typography
+          sx={{
+            fontSize: '0.5625rem',
+            fontWeight: 600,
+            color: 'text.disabled',
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            px: 1,
+            pb: 1,
+            userSelect: 'none',
+          }}
+        >
+          Navigation
+        </Typography>
+
+        {/* Nav Items */}
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1px' }}>
           {projectNavItems.map((item) => {
-            const Icon = iconMap[item.icon] ?? ChartBar;
+            const NavIcon = iconMap[item.icon] ?? ChartBar;
             const href = getProjectNavHref(item.segment, orgSlug, projectSlug);
             const isActive = !!(projectSlug && pathname.includes(`/projects/${projectSlug}/${item.segment}`));
             const isDisabled = !projectSlug;
 
-            return (
-              <ListItemButton
-                key={item.id}
-                component={isDisabled ? 'div' : Link}
-                href={href}
-                disabled={isDisabled}
+            const content = (
+              <Box
                 sx={{
                   display: 'flex',
                   alignItems: 'center',
                   gap: 1.25,
-                  px: 1.5,
-                  py: 1,
-                  borderRadius: 1,
-                  transition: 'all 0.15s',
-                  border: '1px solid',
-                  borderColor: isActive ? 'sidebar.border' : 'transparent',
+                  px: 1.25,
+                  py: 0.875,
+                  borderRadius: '8px',
+                  position: 'relative',
+                  transition: 'all 0.15s ease',
                   bgcolor: isActive ? 'sidebar.activeItemBg' : 'transparent',
                   color: isActive ? 'text.primary' : 'text.secondary',
-                  opacity: isDisabled ? 0.4 : 1,
+                  opacity: isDisabled ? 0.35 : 1,
                   cursor: isDisabled ? 'default' : 'pointer',
-                  '&:hover': {
-                    bgcolor: isDisabled ? 'transparent' : (isActive ? 'sidebar.activeItemBg' : 'sidebar.hoverBg'),
-                    color: isDisabled ? 'text.secondary' : 'text.primary',
-                    borderColor: isActive ? 'sidebar.border' : 'transparent',
+                  overflow: 'hidden',
+                  '&:hover': isDisabled ? {} : {
+                    bgcolor: isActive ? 'sidebar.activeItemBg' : 'sidebar.hoverBg',
+                    color: 'text.primary',
                   },
                 }}
               >
+                {/* Active Indicator — thin left accent */}
                 {isActive && (
                   <Box
-                    sx={{ width: 3, height: 18, borderRadius: '2px', bgcolor: 'sidebar.indicator', flexShrink: 0 }}
+                    sx={{
+                      position: 'absolute',
+                      left: 0,
+                      top: '50%',
+                      transform: 'translateY(-50%)',
+                      width: '2.5px',
+                      height: 16,
+                      borderRadius: '0 2px 2px 0',
+                      bgcolor: 'sidebar.indicator',
+                    }}
                     aria-hidden="true"
                   />
                 )}
-                <ListItemIcon sx={{ minWidth: 18, color: 'inherit' }}>
-                  <Icon style={{ width: 18, height: 18 }} />
-                </ListItemIcon>
-                <ListItemText
-                  primary={item.label}
-                  primaryTypographyProps={{
-                    fontSize: '0.875rem',
-                    fontWeight: isActive ? 500 : 400,
+
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 20, height: 20, flexShrink: 0 }}>
+                  <NavIcon size={17} weight={isActive ? 'fill' : 'regular'} />
+                </Box>
+
+                <Typography
+                  sx={{
+                    fontSize: '0.8125rem',
+                    fontWeight: isActive ? 550 : 400,
+                    letterSpacing: isActive ? '-0.005em' : '0',
+                    lineHeight: 1,
+                    flex: 1,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
                   }}
-                />
-              </ListItemButton>
+                >
+                  {item.label}
+                </Typography>
+
+                {/* Subtle arrow for active item */}
+                {isActive && (
+                  <ChevronRight style={{ width: 13, height: 13, opacity: 0.4, flexShrink: 0 }} />
+                )}
+              </Box>
+            );
+
+            if (isDisabled) {
+              return <Box key={item.id}>{content}</Box>;
+            }
+
+            return (
+              <Link
+                key={item.id}
+                href={href}
+                style={{ textDecoration: 'none', color: 'inherit' }}
+              >
+                {content}
+              </Link>
             );
           })}
-        </List>
+        </Box>
       </Box>
 
-      {/* User Row with Profile Dropdown */}
+      {/* User Profile */}
       <DropdownMenu open={profileOpen} onOpenChange={setProfileOpen}>
         <DropdownMenuTrigger asChild>
           <Box
@@ -193,33 +243,38 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
               border: 'none',
               cursor: 'pointer',
               color: 'text.secondary',
-              transition: 'background-color 0.15s',
-              '&:hover': { bgcolor: 'action.hover' },
+              transition: 'background-color 0.15s ease',
+              '&:hover': {
+                bgcolor: 'sidebar.hoverBg',
+              },
             }}
           >
+            {/* Avatar with accent ring */}
             <Box
               sx={{
-                width: 30,
-                height: 30,
-                borderRadius: '999px',
-                bgcolor: 'secondary.main',
+                width: 32,
+                height: 32,
+                borderRadius: '10px',
+                background: (theme) =>
+                  `linear-gradient(135deg, ${theme.palette.accent.dark}, ${theme.palette.accent.gradientEnd})`,
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
                 flexShrink: 0,
                 fontSize: '0.6875rem',
                 fontWeight: 600,
-                color: 'text.primary',
+                color: 'common.white',
+                letterSpacing: '0.02em',
               }}
             >
               {getInitials(user?.name)}
             </Box>
 
-            <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1, gap: '1px' }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1, gap: '2px' }}>
               <Typography
                 sx={{
                   fontSize: '0.8125rem',
-                  fontWeight: 500,
+                  fontWeight: 550,
                   color: 'text.primary',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
@@ -233,7 +288,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
               <Typography
                 sx={{
                   fontSize: '0.6875rem',
-                  color: 'text.secondary',
+                  color: 'text.disabled',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
@@ -244,8 +299,6 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
                 {user?.email ?? ''}
               </Typography>
             </Box>
-
-            <ChevronsUpDown style={{ width: 14, height: 14, flexShrink: 0, color: 'inherit' }} />
           </Box>
         </DropdownMenuTrigger>
 
@@ -257,20 +310,21 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
           style={{ width: 240, padding: 0, overflow: 'hidden', borderRadius: 12 }}
         >
           {/* Profile Header */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px', p: '14px' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, p: '14px' }}>
             <Box
               sx={{
-                width: 34,
-                height: 34,
-                borderRadius: '999px',
-                bgcolor: 'secondary.main',
+                width: 36,
+                height: 36,
+                borderRadius: '10px',
+                background: (theme) =>
+                  `linear-gradient(135deg, ${theme.palette.accent.dark}, ${theme.palette.accent.gradientEnd})`,
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
                 flexShrink: 0,
                 fontSize: '0.75rem',
                 fontWeight: 600,
-                color: 'text.primary',
+                color: 'common.white',
               }}
             >
               {getInitials(user?.name)}
@@ -305,7 +359,6 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
             </Box>
           </Box>
 
-          {/* Divider */}
           <Box sx={{ height: '1px', bgcolor: 'divider' }} />
 
           {/* Menu Items */}
@@ -338,7 +391,6 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
             ))}
           </Box>
 
-          {/* Divider */}
           <Box sx={{ height: '1px', bgcolor: 'divider' }} />
 
           {/* Log Out */}

--- a/src/components/layout/ProjectShell.tsx
+++ b/src/components/layout/ProjectShell.tsx
@@ -68,6 +68,7 @@ export default function ProjectShell({ children, projectId, projectName }: Proje
           sx={{
             flex: 1,
             minHeight: 0,
+            width: '100%',
             overflow: 'hidden',
             display: isFilesRoute ? 'flex' : 'none',
           }}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,9 +4,9 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
-import { ChevronsUpDown, User, Settings, CreditCard, LifeBuoy, LogOut } from 'lucide-react';
+import { User, Settings, CreditCard, LifeBuoy, LogOut, ChevronRight } from 'lucide-react';
 import { ChartBar, FolderSimple, FileMagnifyingGlass, Users, type Icon } from '@phosphor-icons/react';
-import { Box, List, ListItemButton, ListItemIcon, ListItemText, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -68,18 +68,18 @@ export default function Sidebar() {
       component="aside"
       sx={{
         height: '100vh',
-        width: 220,
+        width: 240,
         bgcolor: 'sidebar.background',
         display: 'flex',
         flexDirection: 'column',
         position: 'sticky',
         top: 0,
-        transition: 'background-color 0.15s',
+        transition: 'background-color 0.2s ease',
         borderRight: '1px solid',
         borderColor: 'sidebar.border',
       }}
     >
-      {/* Org Header */}
+      {/* Org + Project Header */}
       <Box sx={{ borderBottom: '1px solid', borderColor: 'divider' }}>
         <OrgSwitcher />
         <ProjectSwitcher />
@@ -92,71 +92,118 @@ export default function Sidebar() {
           flex: 1,
           display: 'flex',
           flexDirection: 'column',
+          pt: 2,
           px: 1.5,
-          py: 1,
           overflow: 'hidden',
         }}
       >
-        <List sx={{ p: 0, display: 'flex', flexDirection: 'column', gap: '2px' }}>
+        {/* Section Label */}
+        <Typography
+          sx={{
+            fontSize: '0.5625rem',
+            fontWeight: 600,
+            color: 'text.disabled',
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            px: 1,
+            pb: 1,
+            userSelect: 'none',
+          }}
+        >
+          Navigation
+        </Typography>
+
+        {/* Nav Items */}
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1px' }}>
           {projectNavItems.map((item) => {
-            const Icon = iconMap[item.icon] ?? ChartBar;
+            const NavIcon = iconMap[item.icon] ?? ChartBar;
             const href = getProjectNavHref(item.segment, orgSlug, projectSlug);
             const isActive = !!(projectSlug && pathname.includes(`/projects/${projectSlug}/${item.segment}`));
             const isDisabled = !projectSlug;
 
-            return (
-              <ListItemButton
-                key={item.id}
-                component={isDisabled ? 'div' : Link}
-                href={href}
-                disabled={isDisabled}
+            const content = (
+              <Box
                 sx={{
                   display: 'flex',
                   alignItems: 'center',
                   gap: 1.25,
-                  px: 1.5,
-                  py: 1,
-                  borderRadius: 1,
-                  transition: 'all 0.15s',
-                  border: '1px solid',
-                  borderColor: isActive ? 'sidebar.border' : 'transparent',
+                  px: 1.25,
+                  py: 0.875,
+                  borderRadius: '8px',
+                  position: 'relative',
+                  transition: 'all 0.15s ease',
                   bgcolor: isActive ? 'sidebar.activeItemBg' : 'transparent',
                   color: isActive ? 'text.primary' : 'text.secondary',
-                  opacity: isDisabled ? 0.4 : 1,
+                  opacity: isDisabled ? 0.35 : 1,
                   cursor: isDisabled ? 'default' : 'pointer',
-                  '&:hover': {
-                    bgcolor: isDisabled ? 'transparent' : (isActive ? 'sidebar.activeItemBg' : 'sidebar.hoverBg'),
-                    color: isDisabled ? 'text.secondary' : 'text.primary',
-                    borderColor: isActive ? 'sidebar.border' : 'transparent',
-                  },
-                  '&.MuiListItemButton-root:hover': {
-                    bgcolor: isDisabled ? 'transparent' : (isActive ? 'sidebar.activeItemBg' : 'sidebar.hoverBg'),
+                  overflow: 'hidden',
+                  '&:hover': isDisabled ? {} : {
+                    bgcolor: isActive ? 'sidebar.activeItemBg' : 'sidebar.hoverBg',
+                    color: 'text.primary',
                   },
                 }}
               >
+                {/* Active Indicator — thin left accent */}
                 {isActive && (
                   <Box
-                    sx={{ width: 3, height: 18, borderRadius: '2px', bgcolor: 'sidebar.indicator', flexShrink: 0 }}
+                    sx={{
+                      position: 'absolute',
+                      left: 0,
+                      top: '50%',
+                      transform: 'translateY(-50%)',
+                      width: '2.5px',
+                      height: 16,
+                      borderRadius: '0 2px 2px 0',
+                      bgcolor: 'sidebar.indicator',
+                    }}
                     aria-hidden="true"
                   />
                 )}
-                <ListItemIcon sx={{ minWidth: 18, color: 'inherit' }}>
-                  <Icon size={18} />
-                </ListItemIcon>
-                <ListItemText
-                  primary={item.label}
-                  primaryTypographyProps={{
-                    fontSize: '0.875rem',
-                    fontWeight: isActive ? 500 : 400,
+
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 20, height: 20, flexShrink: 0 }}>
+                  <NavIcon size={17} weight={isActive ? 'fill' : 'regular'} />
+                </Box>
+
+                <Typography
+                  sx={{
+                    fontSize: '0.8125rem',
+                    fontWeight: isActive ? 550 : 400,
+                    letterSpacing: isActive ? '-0.005em' : '0',
+                    lineHeight: 1,
+                    flex: 1,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
                   }}
-                />
-              </ListItemButton>
+                >
+                  {item.label}
+                </Typography>
+
+                {/* Subtle arrow for active item */}
+                {isActive && (
+                  <ChevronRight style={{ width: 13, height: 13, opacity: 0.4, flexShrink: 0 }} />
+                )}
+              </Box>
+            );
+
+            if (isDisabled) {
+              return <Box key={item.id}>{content}</Box>;
+            }
+
+            return (
+              <Link
+                key={item.id}
+                href={href}
+                style={{ textDecoration: 'none', color: 'inherit' }}
+              >
+                {content}
+              </Link>
             );
           })}
-        </List>
+        </Box>
       </Box>
 
-      {/* User Row with Profile Dropdown */}
+      {/* User Profile */}
       <DropdownMenu open={profileOpen} onOpenChange={setProfileOpen}>
         <DropdownMenuTrigger asChild>
           <Box
@@ -174,33 +221,38 @@ export default function Sidebar() {
               border: 'none',
               cursor: 'pointer',
               color: 'text.secondary',
-              transition: 'background-color 0.15s',
-              '&:hover': { bgcolor: 'action.hover' },
+              transition: 'background-color 0.15s ease',
+              '&:hover': {
+                bgcolor: 'sidebar.hoverBg',
+              },
             }}
           >
+            {/* Avatar with gradient */}
             <Box
               sx={{
-                width: 30,
-                height: 30,
-                borderRadius: '999px',
-                bgcolor: 'secondary.main',
+                width: 32,
+                height: 32,
+                borderRadius: '10px',
+                background: (theme) =>
+                  `linear-gradient(135deg, ${theme.palette.accent.dark}, ${theme.palette.accent.gradientEnd})`,
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
                 flexShrink: 0,
                 fontSize: '0.6875rem',
                 fontWeight: 600,
-                color: 'text.primary',
+                color: 'common.white',
+                letterSpacing: '0.02em',
               }}
             >
               {getInitials(user?.name)}
             </Box>
 
-            <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1, gap: '1px' }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1, gap: '2px' }}>
               <Typography
                 sx={{
                   fontSize: '0.8125rem',
-                  fontWeight: 500,
+                  fontWeight: 550,
                   color: 'text.primary',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
@@ -214,7 +266,7 @@ export default function Sidebar() {
               <Typography
                 sx={{
                   fontSize: '0.6875rem',
-                  color: 'text.secondary',
+                  color: 'text.disabled',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
@@ -225,8 +277,6 @@ export default function Sidebar() {
                 {user?.email ?? ''}
               </Typography>
             </Box>
-
-            <ChevronsUpDown style={{ width: 14, height: 14, flexShrink: 0, color: 'inherit' }} />
           </Box>
         </DropdownMenuTrigger>
 
@@ -238,20 +288,21 @@ export default function Sidebar() {
           style={{ width: 240, padding: 0, overflow: 'hidden', borderRadius: 12 }}
         >
           {/* Profile Header */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px', p: '14px' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, p: '14px' }}>
             <Box
               sx={{
-                width: 34,
-                height: 34,
-                borderRadius: '999px',
-                bgcolor: 'secondary.main',
+                width: 36,
+                height: 36,
+                borderRadius: '10px',
+                background: (theme) =>
+                  `linear-gradient(135deg, ${theme.palette.accent.dark}, ${theme.palette.accent.gradientEnd})`,
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
                 flexShrink: 0,
                 fontSize: '0.75rem',
                 fontWeight: 600,
-                color: 'text.primary',
+                color: 'common.white',
               }}
             >
               {getInitials(user?.name)}
@@ -286,7 +337,6 @@ export default function Sidebar() {
             </Box>
           </Box>
 
-          {/* Divider */}
           <Box sx={{ height: '1px', bgcolor: 'divider' }} />
 
           {/* Menu Items */}
@@ -319,7 +369,6 @@ export default function Sidebar() {
             ))}
           </Box>
 
-          {/* Divider */}
           <Box sx={{ height: '1px', bgcolor: 'divider' }} />
 
           {/* Log Out */}

--- a/src/components/projects/ProjectDetailPanel.tsx
+++ b/src/components/projects/ProjectDetailPanel.tsx
@@ -1,24 +1,95 @@
 'use client';
 
 import { skipToken } from '@tanstack/react-query';
-import { Folder, FileText, ArrowLeft, Download } from 'lucide-react';
+import { Folder, FileText, Download, Calendar, BarChart2, FolderOpen } from 'lucide-react';
 import { format } from 'date-fns';
 import { FileDropzone } from '@/components/documents/FileDropzone';
 import { DocumentList } from '@/components/documents/DocumentList';
 import { api } from '@/trpc/react';
-import { Box, Typography, IconButton, LinearProgress, Paper } from '@mui/material';
+import { Box, Typography, IconButton, LinearProgress, Paper, Chip } from '@mui/material';
 import { type Selection, deriveStatus } from '@/lib/utils/gantt';
 
 export type { Selection };
 
 interface ProjectDetailPanelProps {
   selection: Selection | null;
-  onBack?: () => void;
   projectId?: string;
   organizationId?: string;
 }
 
-export function ProjectDetailPanel({ selection, onBack, projectId, organizationId }: ProjectDetailPanelProps) {
+// Blueprint dot-grid SVG background
+function DotGridBackground() {
+  return (
+    <svg
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none',
+      }}
+    >
+      <defs>
+        <pattern id="dotgrid" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+          <circle cx="1" cy="1" r="1" fill="var(--accent-primary)" opacity="0.08" />
+        </pattern>
+      </defs>
+      <rect width="100%" height="100%" fill="url(#dotgrid)" />
+    </svg>
+  );
+}
+
+// Gantt-chart SVG illustration for empty state
+function GanttIllustration() {
+  return (
+    <svg width="180" height="96" viewBox="0 0 180 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* Row lines */}
+      <line x1="0" y1="24" x2="180" y2="24" stroke="var(--accent-primary)" strokeOpacity="0.08" strokeWidth="1" />
+      <line x1="0" y1="48" x2="180" y2="48" stroke="var(--accent-primary)" strokeOpacity="0.08" strokeWidth="1" />
+      <line x1="0" y1="72" x2="180" y2="72" stroke="var(--accent-primary)" strokeOpacity="0.08" strokeWidth="1" />
+
+      {/* Column lines */}
+      <line x1="45" y1="0" x2="45" y2="96" stroke="var(--accent-primary)" strokeOpacity="0.06" strokeWidth="1" strokeDasharray="2 3" />
+      <line x1="90" y1="0" x2="90" y2="96" stroke="var(--accent-primary)" strokeOpacity="0.06" strokeWidth="1" strokeDasharray="2 3" />
+      <line x1="135" y1="0" x2="135" y2="96" stroke="var(--accent-primary)" strokeOpacity="0.06" strokeWidth="1" strokeDasharray="2 3" />
+
+      {/* Task label area */}
+      <rect x="0" y="0" width="44" height="96" fill="var(--accent-primary)" fillOpacity="0.03" />
+
+      {/* Task label lines */}
+      <rect x="4" y="10" width="28" height="5" rx="2.5" fill="var(--accent-primary)" fillOpacity="0.18" />
+      <rect x="4" y="34" width="22" height="5" rx="2.5" fill="var(--accent-primary)" fillOpacity="0.13" />
+      <rect x="4" y="58" width="32" height="5" rx="2.5" fill="var(--accent-primary)" fillOpacity="0.13" />
+      <rect x="4" y="82" width="18" height="5" rx="2.5" fill="var(--accent-primary)" fillOpacity="0.10" />
+
+      {/* Gantt bars — row 1 (wide, primary) */}
+      <rect x="48" y="8" width="84" height="12" rx="4" fill="var(--accent-primary)" fillOpacity="0.22" />
+      <rect x="48" y="8" width="52" height="12" rx="4" fill="var(--accent-primary)" fillOpacity="0.45" />
+
+      {/* Gantt bars — row 2 */}
+      <rect x="68" y="32" width="60" height="12" rx="4" fill="#2563eb" fillOpacity="0.22" />
+      <rect x="68" y="32" width="36" height="12" rx="4" fill="#2563eb" fillOpacity="0.45" />
+
+      {/* Gantt bars — row 3 (amber) */}
+      <rect x="96" y="56" width="72" height="12" rx="4" fill="#d97706" fillOpacity="0.22" />
+      <rect x="96" y="56" width="40" height="12" rx="4" fill="#d97706" fillOpacity="0.45" />
+
+      {/* Milestone diamond — row 4 */}
+      <rect
+        x="150"
+        y="79"
+        width="10"
+        height="10"
+        rx="1"
+        fill="#d97706"
+        fillOpacity="0.75"
+        style={{ transform: 'rotate(45deg)', transformOrigin: '155px 84px' }}
+      />
+    </svg>
+  );
+}
+
+export function ProjectDetailPanel({ selection, projectId, organizationId }: ProjectDetailPanelProps) {
   const utils = api.useUtils();
 
   const { data: taskData } = api.gantt.taskDetail.useQuery(
@@ -27,7 +98,6 @@ export function ProjectDetailPanel({ selection, onBack, projectId, organizationI
       : skipToken
   );
 
-  // Fetch document data when a document is selected
   const { data: documentData } = api.document.listByTask.useQuery(
     {
       organizationId: organizationId!,
@@ -66,253 +136,290 @@ export function ProjectDetailPanel({ selection, onBack, projectId, organizationI
     }
   };
 
-  // Empty state - nothing selected
+  // ─── Empty state ──────────────────────────────────────────────────────────
   if (!selection) {
     return (
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-        <Box sx={{ textAlign: 'center' }}>
-          <FileText size={48} style={{ color: 'var(--text-disabled)', margin: '0 auto 12px' }} />
-          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-            Select a task or folder to view details
-          </Typography>
-        </Box>
-      </Box>
-    );
-  }
+      <Box sx={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+        <DotGridBackground />
 
-  // Task selected
-  if (selection.type === 'task' && task) {
-    return (
-      <Box sx={{ height: '100%', overflow: 'auto', p: 3 }}>
-        {/* Mobile back button */}
-        {onBack && (
-          <IconButton
-            onClick={onBack}
-            sx={{
-              display: { lg: 'none' },
-              mb: 2,
-              color: 'text.secondary',
-              '&:hover': { color: 'text.primary' },
-            }}
-          >
-            <ArrowLeft size={16} />
-            <Typography variant="body2" sx={{ ml: 1 }}>
-              Back to tree
-            </Typography>
-          </IconButton>
-        )}
-
-        {/* Group label */}
-        <Typography
-          variant="caption"
-          sx={{
-            fontWeight: 500,
-            color: 'text.disabled',
-            textTransform: 'uppercase',
-            letterSpacing: '0.05em',
-            display: 'block',
-            mb: 1,
-          }}
-        >
-          {task.group}
-        </Typography>
-
-        {/* Task name */}
-        <Typography variant="h5" sx={{ fontWeight: 600, color: 'text.primary', mb: 2 }}>
-          {task.name}
-        </Typography>
-
-        {/* Status badge */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+        {/* Central content */}
+        <Box sx={{ position: 'relative', zIndex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', px: 4, maxWidth: 320, textAlign: 'center' }}>
+          {/* Illustration card */}
           <Box
             sx={{
-              width: 10,
-              height: 10,
-              borderRadius: '50%',
-              bgcolor: task.status.color,
+              mb: 3,
+              p: 3,
+              borderRadius: 3,
+              bgcolor: 'background.paper',
+              border: '1px solid',
+              borderColor: 'divider',
+              boxShadow: '0 2px 12px rgba(0,0,0,0.06), 0 1px 4px rgba(0,0,0,0.04)',
+              display: 'inline-flex',
             }}
-          />
+          >
+            <GanttIllustration />
+          </Box>
+
+          <Typography
+            variant="subtitle1"
+            sx={{
+              fontWeight: 600,
+              color: 'text.primary',
+              mb: 0.75,
+              letterSpacing: '-0.01em',
+            }}
+          >
+            Nothing selected yet
+          </Typography>
+
           <Typography
             variant="body2"
-            sx={{ fontWeight: 500, color: task.status.color }}
+            sx={{ color: 'text.secondary', mb: 3, lineHeight: 1.6 }}
           >
-            {task.status.name}
+            Click a task or folder in the project tree to view details, track progress, and manage documents.
           </Typography>
-        </Box>
 
-        {/* Progress bar */}
-        {task.progress !== undefined && (
-          <Box sx={{ mb: 3 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-              <Typography variant="body2" sx={{ fontWeight: 500, color: 'text.primary' }}>
-                Progress
-              </Typography>
-              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                {task.progress}%
-              </Typography>
-            </Box>
-            <LinearProgress
-              variant="determinate"
-              value={task.progress}
-              sx={{
-                height: 8,
-                borderRadius: 1,
-                bgcolor: 'action.hover',
-                '& .MuiLinearProgress-bar': {
-                  bgcolor: task.status.color,
-                  borderRadius: 1,
-                },
-              }}
-            />
-          </Box>
-        )}
-
-        {/* Dates */}
-        <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2, mb: 3 }}>
-          <Box>
-            <Typography
-              variant="caption"
-              sx={{
-                fontWeight: 500,
-                color: 'text.disabled',
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-                display: 'block',
-                mb: 0.5,
-              }}
-            >
-              Start Date
-            </Typography>
-            <Typography variant="body2" sx={{ color: 'text.primary' }}>
-              {task.startAt ? format(new Date(task.startAt), 'MMM d, yyyy') : 'Not set'}
-            </Typography>
-          </Box>
-          <Box>
-            <Typography
-              variant="caption"
-              sx={{
-                fontWeight: 500,
-                color: 'text.disabled',
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-                display: 'block',
-                mb: 0.5,
-              }}
-            >
-              End Date
-            </Typography>
-            <Typography variant="body2" sx={{ color: 'text.primary' }}>
-              {task.endAt ? format(new Date(task.endAt), 'MMM d, yyyy') : 'Not set'}
-            </Typography>
+          {/* Hint chips */}
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+            {[
+              { icon: <BarChart2 size={12} />, label: 'Track progress' },
+              { icon: <FolderOpen size={12} />, label: 'Browse documents' },
+              { icon: <FileText size={12} />, label: 'Preview files' },
+            ].map(({ icon, label }) => (
+              <Chip
+                key={label}
+                icon={icon}
+                label={label}
+                size="small"
+                variant="outlined"
+                sx={{
+                  height: 26,
+                  fontSize: '11px',
+                  fontWeight: 500,
+                  color: 'text.secondary',
+                  borderColor: 'divider',
+                  bgcolor: 'background.paper',
+                  '& .MuiChip-icon': {
+                    color: 'text.disabled',
+                    ml: '8px',
+                  },
+                  '& .MuiChip-label': {
+                    px: 1,
+                  },
+                }}
+              />
+            ))}
           </Box>
         </Box>
-
       </Box>
     );
   }
 
-  // Folder selected
-  if (selection.type === 'folder') {
+  // ─── Task selected ────────────────────────────────────────────────────────
+  if (selection.type === 'task' && task) {
     return (
-      <Box sx={{ height: '100%', overflow: 'auto', p: 3 }}>
-        {/* Mobile back button */}
-        {onBack && (
-          <IconButton
-            onClick={onBack}
-            sx={{
-              display: { lg: 'none' },
-              mb: 2,
-              color: 'text.secondary',
-              '&:hover': { color: 'text.primary' },
-            }}
-          >
-            <ArrowLeft size={16} />
-            <Typography variant="body2" sx={{ ml: 1 }}>
-              Back to tree
-            </Typography>
-          </IconButton>
-        )}
-
-        {/* Folder icon and name */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 3 }}>
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 48,
-              height: 48,
-              borderRadius: 2,
-              bgcolor: 'rgb(245, 158, 11, 0.1)',
-              border: '1px solid rgb(245, 158, 11, 0.3)',
-            }}
-          >
-            <Folder size={24} style={{ color: 'rgb(245, 158, 11)' }} />
+      <Box sx={{ height: '100%', overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
+        {/* Colored accent header strip */}
+        <Box
+          sx={{
+            flexShrink: 0,
+            borderLeft: `3px solid ${task.status.color}`,
+            px: 3,
+            pt: 3,
+            pb: 2.5,
+            borderBottom: '1px solid',
+            borderBottomColor: 'divider',
+          }}
+        >
+          {/* Group badge */}
+          <Box sx={{ mb: 1 }}>
+            <Box
+              component="span"
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                px: 1.25,
+                py: 0.25,
+                borderRadius: 1,
+                bgcolor: 'action.hover',
+                fontSize: '10px',
+                fontWeight: 600,
+                color: 'text.disabled',
+                textTransform: 'uppercase',
+                letterSpacing: '0.07em',
+              }}
+            >
+              {task.group}
+            </Box>
           </Box>
-          <Typography variant="h5" sx={{ fontWeight: 600, color: 'text.primary' }}>
-            {selection.folderName}
+
+          {/* Task name */}
+          <Typography variant="h6" sx={{ fontWeight: 700, color: 'text.primary', lineHeight: 1.3, letterSpacing: '-0.01em' }}>
+            {task.name}
           </Typography>
+
+          {/* Status */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 1.25 }}>
+            <Box sx={{ width: 7, height: 7, borderRadius: '50%', bgcolor: task.status.color, flexShrink: 0 }} />
+            <Typography variant="caption" sx={{ fontWeight: 600, color: task.status.color, letterSpacing: '0.02em' }}>
+              {task.status.name}
+            </Typography>
+          </Box>
         </Box>
 
-        {/* Parent folder context */}
-        {selection.parentFolderName && (
-          <Box sx={{ mb: 2 }}>
-            <Typography
-              variant="caption"
+        {/* Body */}
+        <Box sx={{ flex: 1, p: 3, display: 'flex', flexDirection: 'column', gap: 2.5 }}>
+          {/* Progress card */}
+          {task.progress !== undefined && (
+            <Paper
+              elevation={0}
               sx={{
-                fontWeight: 500,
-                color: 'text.disabled',
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-                display: 'block',
-                mb: 0.5,
+                p: 2.5,
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 2,
+                bgcolor: 'background.paper',
               }}
             >
-              Parent Folder
-            </Typography>
-            <Typography variant="body2" sx={{ color: 'text.primary' }}>
-              {selection.parentFolderName}
-            </Typography>
-          </Box>
-        )}
-
-        {/* Parent task reference */}
-        {task && (
-          <Box sx={{ mb: 3 }}>
-            <Typography
-              variant="caption"
-              sx={{
-                fontWeight: 500,
-                color: 'text.disabled',
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-                display: 'block',
-                mb: 0.5,
-              }}
-            >
-              Task
-            </Typography>
-            <Typography variant="body2" sx={{ color: 'text.primary' }}>
-              {task.name}
-            </Typography>
-          </Box>
-        )}
-
-        {/* Document upload and list */}
-        {organizationId && projectId && selection.folderId && (
-          <Box sx={{ mt: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <Box>
-              <Typography
-                variant="caption"
+              <Box sx={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', mb: 1.5 }}>
+                <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                  Progress
+                </Typography>
+                <Typography
+                  sx={{
+                    fontSize: '26px',
+                    fontWeight: 700,
+                    color: task.status.color,
+                    lineHeight: 1,
+                    letterSpacing: '-0.02em',
+                  }}
+                >
+                  {task.progress}
+                  <Typography component="span" variant="caption" sx={{ fontWeight: 600, color: 'text.disabled', ml: 0.25 }}>
+                    %
+                  </Typography>
+                </Typography>
+              </Box>
+              <LinearProgress
+                variant="determinate"
+                value={task.progress}
                 sx={{
-                  fontWeight: 500,
-                  color: 'text.disabled',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.05em',
-                  display: 'block',
-                  mb: 1,
+                  height: 6,
+                  borderRadius: '3px',
+                  bgcolor: 'action.hover',
+                  '& .MuiLinearProgress-bar': {
+                    bgcolor: task.status.color,
+                    borderRadius: '3px',
+                  },
+                }}
+              />
+            </Paper>
+          )}
+
+          {/* Date cards */}
+          <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.5 }}>
+            {[
+              { label: 'Start Date', value: task.startAt },
+              { label: 'End Date', value: task.endAt },
+            ].map(({ label, value }) => (
+              <Paper
+                key={label}
+                elevation={0}
+                sx={{
+                  p: 2,
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  borderRadius: 2,
+                  bgcolor: 'background.paper',
                 }}
               >
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.75 }}>
+                  <Calendar size={11} style={{ color: 'var(--text-muted)' }} />
+                  <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.06em', fontSize: '10px' }}>
+                    {label}
+                  </Typography>
+                </Box>
+                <Typography variant="body2" sx={{ fontWeight: 500, color: value ? 'text.primary' : 'text.disabled', fontSize: '13px' }}>
+                  {value ? format(new Date(value), 'MMM d, yyyy') : '—'}
+                </Typography>
+              </Paper>
+            ))}
+          </Box>
+        </Box>
+      </Box>
+    );
+  }
+
+  // ─── Folder selected ──────────────────────────────────────────────────────
+  if (selection.type === 'folder') {
+    return (
+      <Box sx={{ height: '100%', overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
+        {/* Folder header */}
+        <Box
+          sx={{
+            flexShrink: 0,
+            px: 3,
+            pt: 3,
+            pb: 2.5,
+            borderBottom: '1px solid',
+            borderBottomColor: 'divider',
+            background: 'linear-gradient(135deg, rgba(245,158,11,0.06) 0%, transparent 70%)',
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 44,
+                height: 44,
+                borderRadius: 2,
+                background: 'linear-gradient(135deg, rgba(245,158,11,0.2) 0%, rgba(245,158,11,0.08) 100%)',
+                border: '1px solid rgba(245,158,11,0.25)',
+                flexShrink: 0,
+              }}
+            >
+              <Folder size={22} style={{ color: 'rgb(245, 158, 11)' }} />
+            </Box>
+            <Box sx={{ minWidth: 0 }}>
+              <Typography variant="h6" sx={{ fontWeight: 700, color: 'text.primary', lineHeight: 1.3, letterSpacing: '-0.01em', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {selection.folderName}
+              </Typography>
+              {selection.parentFolderName && (
+                <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '11px' }}>
+                  in {selection.parentFolderName}
+                </Typography>
+              )}
+            </Box>
+          </Box>
+
+          {/* Task reference */}
+          {task && (
+            <Box
+              sx={{
+                mt: 1.5,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.5,
+                px: 1.25,
+                py: 0.4,
+                borderRadius: 1,
+                bgcolor: 'action.hover',
+              }}
+            >
+              <Typography variant="caption" sx={{ fontWeight: 500, color: 'text.secondary', fontSize: '11px' }}>
+                {task.name}
+              </Typography>
+            </Box>
+          )}
+        </Box>
+
+        {/* Document section */}
+        {organizationId && projectId && selection.folderId && (
+          <Box sx={{ flex: 1, p: 3, display: 'flex', flexDirection: 'column', gap: 3 }}>
+            <Box>
+              <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.06em', display: 'block', mb: 1.25 }}>
                 Upload Documents
               </Typography>
               <FileDropzone
@@ -324,17 +431,7 @@ export function ProjectDetailPanel({ selection, onBack, projectId, organizationI
             </Box>
 
             <Box>
-              <Typography
-                variant="caption"
-                sx={{
-                  fontWeight: 500,
-                  color: 'text.disabled',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.05em',
-                  display: 'block',
-                  mb: 1,
-                }}
-              >
+              <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.06em', display: 'block', mb: 1.25 }}>
                 Documents
               </Typography>
               <DocumentList
@@ -350,65 +447,71 @@ export function ProjectDetailPanel({ selection, onBack, projectId, organizationI
     );
   }
 
-  // Document selected
+  // ─── Document selected ────────────────────────────────────────────────────
   if (selection.type === 'document' && selectedDocument) {
     const isPdf = selectedDocument.mimeType === 'application/pdf';
     const isImage = selectedDocument.mimeType.startsWith('image/');
+    const iconColor = isPdf ? '#dc2626' : isImage ? '#2563eb' : 'var(--accent-primary)';
 
     return (
       <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
         {/* Header */}
-        <Box sx={{ p: 2, borderBottom: '1px solid', borderColor: 'divider', flexShrink: 0 }}>
-          {onBack && (
-            <IconButton
-              onClick={onBack}
-              sx={{
-                display: { lg: 'none' },
-                mb: 1,
-                color: 'text.secondary',
-                '&:hover': { color: 'text.primary' },
-              }}
-            >
-              <ArrowLeft size={16} />
-              <Typography variant="body2" sx={{ ml: 1 }}>
-                Back to tree
-              </Typography>
-            </IconButton>
-          )}
+        <Box
+          sx={{
+            px: 2.5,
+            py: 2,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            flexShrink: 0,
+            bgcolor: 'background.paper',
+          }}
+        >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
             <Box
               sx={{
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                width: 40,
-                height: 40,
+                width: 38,
+                height: 38,
                 borderRadius: 1.5,
-                bgcolor: 'primary.main',
-                color: 'white',
+                bgcolor: `${iconColor}18`,
+                border: `1px solid ${iconColor}30`,
                 flexShrink: 0,
               }}
             >
-              <FileText size={20} />
+              <FileText size={18} style={{ color: iconColor }} />
             </Box>
+
             <Box sx={{ minWidth: 0, flex: 1 }}>
               <Typography
-                variant="subtitle1"
+                variant="subtitle2"
                 sx={{
                   fontWeight: 600,
                   color: 'text.primary',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
+                  fontSize: '13px',
                 }}
               >
                 {selectedDocument.name}
               </Typography>
-              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                {(selectedDocument.size / 1024).toFixed(1)} KB
-                {selectedDocument.uploadedBy?.name && ` · ${selectedDocument.uploadedBy.name}`}
-              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '11px' }}>
+                  {(selectedDocument.size / 1024).toFixed(1)} KB
+                </Typography>
+                {selectedDocument.uploadedBy?.name && (
+                  <>
+                    <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '11px' }}>·</Typography>
+                    <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '11px' }}>
+                      {selectedDocument.uploadedBy.name}
+                    </Typography>
+                  </>
+                )}
+              </Box>
             </Box>
+
             <IconButton
               component="a"
               href={selectedDocument.blobUrl}
@@ -416,9 +519,13 @@ export function ProjectDetailPanel({ selection, onBack, projectId, organizationI
               rel="noopener noreferrer"
               download={selectedDocument.name}
               size="small"
-              sx={{ color: 'text.secondary', '&:hover': { color: 'primary.main' } }}
+              sx={{
+                color: 'text.disabled',
+                '&:hover': { color: 'text.primary', bgcolor: 'action.hover' },
+                flexShrink: 0,
+              }}
             >
-              <Download size={18} />
+              <Download size={16} />
             </IconButton>
           </Box>
         </Box>
@@ -433,30 +540,17 @@ export function ProjectDetailPanel({ selection, onBack, projectId, organizationI
             />
           )}
           {isImage && (
-            <Box sx={{
-              flex: 1,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              p: 2,
-              overflow: 'auto',
-            }}>
+            <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', p: 2, overflow: 'auto', bgcolor: 'action.hover' }}>
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={selectedDocument.blobUrl}
                 alt={selectedDocument.name}
-                style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain', borderRadius: 8 }}
+                style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain', borderRadius: 8, boxShadow: '0 4px 24px rgba(0,0,0,0.10)' }}
               />
             </Box>
           )}
           {!isPdf && !isImage && (
-            <Box sx={{
-              flex: 1,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              p: 3,
-            }}>
+            <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', p: 3 }}>
               <Paper
                 elevation={0}
                 sx={{
@@ -464,18 +558,32 @@ export function ProjectDetailPanel({ selection, onBack, projectId, organizationI
                   textAlign: 'center',
                   border: '1px solid',
                   borderColor: 'divider',
-                  maxWidth: 360,
+                  borderRadius: 2,
+                  maxWidth: 300,
+                  bgcolor: 'background.paper',
                 }}
               >
-                <FileText size={48} style={{ color: 'var(--text-disabled)', margin: '0 auto 16px' }} />
-                <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
+                <Box
+                  sx={{
+                    width: 56,
+                    height: 56,
+                    borderRadius: 2,
+                    bgcolor: `${iconColor}12`,
+                    border: `1px solid ${iconColor}25`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    mx: 'auto',
+                    mb: 2,
+                  }}
+                >
+                  <FileText size={28} style={{ color: iconColor }} />
+                </Box>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
                   {selectedDocument.name}
                 </Typography>
-                <Typography variant="body2" sx={{ color: 'text.secondary', mb: 0.5 }}>
-                  {selectedDocument.mimeType}
-                </Typography>
-                <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
-                  {(selectedDocument.size / 1024).toFixed(1)} KB
+                <Typography variant="caption" sx={{ color: 'text.disabled', display: 'block', mb: 2 }}>
+                  {selectedDocument.mimeType} · {(selectedDocument.size / 1024).toFixed(1)} KB
                 </Typography>
                 <Typography
                   component="a"
@@ -487,7 +595,8 @@ export function ProjectDetailPanel({ selection, onBack, projectId, organizationI
                   sx={{
                     color: 'primary.main',
                     textDecoration: 'none',
-                    fontWeight: 500,
+                    fontWeight: 600,
+                    fontSize: '13px',
                     '&:hover': { textDecoration: 'underline' },
                   }}
                 >

--- a/src/components/projects/ProjectDetailPanel.tsx
+++ b/src/components/projects/ProjectDetailPanel.tsx
@@ -7,6 +7,7 @@ import { FileDropzone } from '@/components/documents/FileDropzone';
 import { DocumentList } from '@/components/documents/DocumentList';
 import { api } from '@/trpc/react';
 import { Box, Typography, IconButton, LinearProgress, Paper, Chip } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { type Selection, deriveStatus } from '@/lib/utils/gantt';
 
 export type { Selection };
@@ -67,12 +68,12 @@ function GanttIllustration() {
       <rect x="48" y="8" width="52" height="12" rx="4" fill="var(--accent-primary)" fillOpacity="0.45" />
 
       {/* Gantt bars — row 2 */}
-      <rect x="68" y="32" width="60" height="12" rx="4" fill="#2563eb" fillOpacity="0.22" />
-      <rect x="68" y="32" width="36" height="12" rx="4" fill="#2563eb" fillOpacity="0.45" />
+      <rect x="68" y="32" width="60" height="12" rx="4" fill="var(--accent-primary)" fillOpacity="0.22" />
+      <rect x="68" y="32" width="36" height="12" rx="4" fill="var(--accent-primary)" fillOpacity="0.45" />
 
       {/* Gantt bars — row 3 (amber) */}
-      <rect x="96" y="56" width="72" height="12" rx="4" fill="#d97706" fillOpacity="0.22" />
-      <rect x="96" y="56" width="40" height="12" rx="4" fill="#d97706" fillOpacity="0.45" />
+      <rect x="96" y="56" width="72" height="12" rx="4" fill="var(--accent-warm)" fillOpacity="0.22" />
+      <rect x="96" y="56" width="40" height="12" rx="4" fill="var(--accent-warm)" fillOpacity="0.45" />
 
       {/* Milestone diamond — row 4 */}
       <rect
@@ -81,7 +82,7 @@ function GanttIllustration() {
         width="10"
         height="10"
         rx="1"
-        fill="#d97706"
+        fill="var(--accent-warm)"
         fillOpacity="0.75"
         style={{ transform: 'rotate(45deg)', transformOrigin: '155px 84px' }}
       />
@@ -90,6 +91,7 @@ function GanttIllustration() {
 }
 
 export function ProjectDetailPanel({ selection, projectId, organizationId }: ProjectDetailPanelProps) {
+  const theme = useTheme();
   const utils = api.useUtils();
 
   const { data: taskData } = api.gantt.taskDetail.useQuery(
@@ -451,7 +453,7 @@ export function ProjectDetailPanel({ selection, projectId, organizationId }: Pro
   if (selection.type === 'document' && selectedDocument) {
     const isPdf = selectedDocument.mimeType === 'application/pdf';
     const isImage = selectedDocument.mimeType.startsWith('image/');
-    const iconColor = isPdf ? '#dc2626' : isImage ? '#2563eb' : 'var(--accent-primary)';
+    const iconColor = isPdf ? theme.palette.error.main : isImage ? theme.palette.status.completed : theme.palette.primary.main;
 
     return (
       <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>

--- a/src/components/projects/ProjectsTree.tsx
+++ b/src/components/projects/ProjectsTree.tsx
@@ -19,6 +19,7 @@ import {
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
 import { TreeItem } from '@mui/x-tree-view/TreeItem';
 import { Box, Chip, IconButton, Skeleton, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { api } from '@/trpc/react';
 import UploadDialog from '@/components/documents/UploadDialog';
 import { folderData } from '@/lib/folders';
@@ -63,6 +64,7 @@ interface FolderNodeProps {
 }
 
 function FolderNode({ folder, taskId, projectId, organizationId, expandedItems }: FolderNodeProps) {
+  const theme = useTheme();
   const folderId = `${taskId}-${folder.id}`;
   const isExpanded = expandedItems.includes(folderId);
   const utils = api.useUtils();
@@ -211,7 +213,7 @@ function FolderNode({ folder, taskId, projectId, organizationId, expandedItems }
                   itemId={`${taskId}-doc-${doc.id}`}
                   label={
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.2 }}>
-                      <FileText size={12} color="#3b82f6" />
+                      <FileText size={12} color={theme.palette.status.completed} />
                       <Box sx={{
                         flexGrow: 1,
                         fontSize: '0.75rem',
@@ -235,7 +237,7 @@ function FolderNode({ folder, taskId, projectId, organizationId, expandedItems }
           itemId={`${taskId}-doc-${doc.id}`}
           label={
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.25 }}>
-              <FileText size={12} style={{ color: '#3b82f6' }} />
+              <FileText size={12} style={{ color: theme.palette.status.completed }} />
               <Box sx={{
                 flexGrow: 1,
                 fontSize: '0.8rem',
@@ -266,13 +268,14 @@ function FolderNode({ folder, taskId, projectId, organizationId, expandedItems }
   );
 }
 
-function deriveStatus(percentDone: number) {
-  if (percentDone >= 100) return { name: 'Completed', color: '#10b981' };
-  if (percentDone > 0) return { name: 'In Progress', color: '#3b82f6' };
-  return { name: 'Planned', color: '#6b7280' };
+function deriveStatus(percentDone: number, theme: import('@mui/material/styles').Theme) {
+  if (percentDone >= 100) return { name: 'Completed', color: theme.palette.success.main };
+  if (percentDone > 0) return { name: 'In Progress', color: theme.palette.status.completed };
+  return { name: 'Planned', color: theme.palette.text.disabled };
 }
 
 export default function ProjectsTree({ selectedNodeId, onSelect, projectId, organizationId }: ProjectsTreeProps) {
+  const theme = useTheme();
   const utils = api.useUtils();
   const { data: tasks = [], isLoading, isFetching } = api.gantt.tasks.useQuery(
     { organizationId: organizationId!, projectId: projectId! },
@@ -296,7 +299,7 @@ export default function ProjectsTree({ selectedNodeId, onSelect, projectId, orga
       groupedMap[parent.id] = children.map((c) => ({
         id: c.id,
         name: c.name,
-        status: deriveStatus(c.percentDone),
+        status: deriveStatus(c.percentDone, theme),
         progress: Math.round(c.percentDone),
       }));
     }

--- a/src/components/projects/ProjectsTree.tsx
+++ b/src/components/projects/ProjectsTree.tsx
@@ -1,15 +1,37 @@
 'use client';
 
 import { useState, Fragment, useMemo, useEffect } from 'react';
-import { Folder, FileText, Plus, Calendar } from 'lucide-react';
+import {
+  FolderSimple,
+  FolderOpen,
+  FileText,
+  Plus,
+  CalendarBlank,
+  ArrowsClockwise,
+  Question,
+  PaperPlaneTilt,
+  PencilSimpleLine,
+  Camera,
+  ClipboardText,
+  Hammer,
+  type Icon as PhosphorIcon,
+} from '@phosphor-icons/react';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
 import { TreeItem } from '@mui/x-tree-view/TreeItem';
-import { Box, Chip, IconButton, Typography } from '@mui/material';
+import { Box, Chip, IconButton, Skeleton, Typography } from '@mui/material';
 import { api } from '@/trpc/react';
 import UploadDialog from '@/components/documents/UploadDialog';
 import { folderData } from '@/lib/folders';
 
 export { folderData };
+
+const folderIconMap: Record<string, PhosphorIcon> = {
+  rfi: Question,
+  submittals: PaperPlaneTilt,
+  'change-orders': PencilSimpleLine,
+  photos: Camera,
+  inspections: ClipboardText,
+};
 
 export interface Selection {
   type: 'task' | 'folder' | 'document';
@@ -37,10 +59,12 @@ interface FolderNodeProps {
   taskId: string;
   projectId: string | null;
   organizationId: string | undefined;
+  expandedItems: string[];
 }
 
-function FolderNode({ folder, taskId, projectId, organizationId }: FolderNodeProps) {
+function FolderNode({ folder, taskId, projectId, organizationId, expandedItems }: FolderNodeProps) {
   const folderId = `${taskId}-${folder.id}`;
+  const isExpanded = expandedItems.includes(folderId);
   const utils = api.useUtils();
   const [uploadOpen, setUploadOpen] = useState(false);
 
@@ -98,9 +122,12 @@ function FolderNode({ folder, taskId, projectId, organizationId }: FolderNodePro
       key={folderId}
       itemId={folderId}
       label={
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5 }}>
-          <Folder size={14} style={{ color: '#f59e0b' }} />
-          <Box sx={{ fontWeight: 500, flexGrow: 1 }}>{folder.name}</Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.375 }}>
+          {(() => {
+            const FolderIcon = folderIconMap[folder.id] ?? (isExpanded ? FolderOpen : FolderSimple);
+            return <FolderIcon size={14} color={folder.color} />;
+          })()}
+          <Box sx={{ fontWeight: 500, flexGrow: 1, fontSize: '0.8125rem' }}>{folder.name}</Box>
           {documentCount > 0 && (
             <Chip
               label={documentCount}
@@ -127,7 +154,7 @@ function FolderNode({ folder, taskId, projectId, organizationId }: FolderNodePro
               '&:hover': { color: 'primary.main', bgcolor: 'action.hover' },
             }}
           >
-            <Plus size={14} />
+            <Plus size={14} weight="bold" />
           </IconButton>
         </Box>
       }
@@ -144,9 +171,9 @@ function FolderNode({ folder, taskId, projectId, organizationId }: FolderNodePro
               key={childId}
               itemId={childId}
               label={
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5 }}>
-                  <FileText size={14} style={{ color: 'inherit', opacity: 0.6 }} />
-                  <Box sx={{ flexGrow: 1 }}>{child.name}</Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.375 }}>
+                  <FileText size={14} style={{ opacity: 0.6 }} />
+                  <Box sx={{ flexGrow: 1, fontSize: '0.8125rem' }}>{child.name}</Box>
                   {childDocCount > 0 && (
                     <Chip
                       label={childDocCount}
@@ -173,7 +200,7 @@ function FolderNode({ folder, taskId, projectId, organizationId }: FolderNodePro
                       '&:hover': { color: 'primary.main', bgcolor: 'action.hover' },
                     }}
                   >
-                    <Plus size={14} />
+                    <Plus size={14} weight="bold" />
                   </IconButton>
                 </Box>
               }
@@ -183,11 +210,11 @@ function FolderNode({ folder, taskId, projectId, organizationId }: FolderNodePro
                   key={`${taskId}-doc-${doc.id}`}
                   itemId={`${taskId}-doc-${doc.id}`}
                   label={
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.25 }}>
-                      <FileText size={12} style={{ color: '#3b82f6' }} />
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.2 }}>
+                      <FileText size={12} color="#3b82f6" />
                       <Box sx={{
                         flexGrow: 1,
-                        fontSize: '0.8rem',
+                        fontSize: '0.75rem',
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
                         whiteSpace: 'nowrap',
@@ -246,10 +273,17 @@ function deriveStatus(percentDone: number) {
 }
 
 export default function ProjectsTree({ selectedNodeId, onSelect, projectId, organizationId }: ProjectsTreeProps) {
-  const { data: tasks = [] } = api.gantt.tasks.useQuery(
+  const utils = api.useUtils();
+  const { data: tasks = [], isLoading, isFetching } = api.gantt.tasks.useQuery(
     { organizationId: organizationId!, projectId: projectId! },
     { enabled: !!projectId && !!organizationId }
   );
+
+  const handleRefresh = () => {
+    if (organizationId && projectId) {
+      void utils.gantt.tasks.invalidate({ organizationId, projectId });
+    }
+  };
 
   // Build grouped structure from database tasks:
   // Top-level tasks (no parentId) = groups, their children = tasks
@@ -364,20 +398,131 @@ export default function ProjectsTree({ selectedNodeId, onSelect, projectId, orga
     onSelect(null);
   };
 
+  const headerBar = (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        px: 2,
+        py: 1,
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: '0.8125rem',
+          fontWeight: 600,
+          color: 'text.primary',
+          letterSpacing: '-0.01em',
+        }}
+      >
+        File Tree
+      </Typography>
+      <IconButton
+        size="small"
+        onClick={handleRefresh}
+        disabled={isFetching}
+        aria-label="Refresh file tree"
+        sx={{
+          p: 0.5,
+          color: 'text.secondary',
+          '&:hover': { color: 'primary.main', bgcolor: 'action.hover' },
+          ...(isFetching && {
+            '@keyframes spin': {
+              from: { transform: 'rotate(0deg)' },
+              to: { transform: 'rotate(360deg)' },
+            },
+            '& svg': {
+              animation: 'spin 1s linear infinite',
+            },
+          }),
+        }}
+      >
+        <ArrowsClockwise size={14} />
+      </IconButton>
+    </Box>
+  );
+
+  // Skeleton loading state
+  if (isLoading) {
+    // Mimics: 2 groups, first with 2 tasks (first task has 3 folders), second with 2 tasks
+    const rows: Array<{ level: 0 | 1 | 2; width: number; hasCount?: boolean; hasStatus?: boolean }> = [
+      // Group 1
+      { level: 0, width: 140, hasCount: true },
+        // Task 1
+        { level: 1, width: 160, hasStatus: true },
+          // Folders under task 1
+          { level: 2, width: 50 },
+          { level: 2, width: 80 },
+          { level: 2, width: 110 },
+        // Task 2
+        { level: 1, width: 120, hasStatus: true },
+      // Group 2
+      { level: 0, width: 180, hasCount: true },
+        { level: 1, width: 100, hasStatus: true },
+        { level: 1, width: 140, hasStatus: true },
+    ];
+
+    return (
+      <Box sx={{ width: '100%' }}>
+        {headerBar}
+        <Box sx={{ py: 0.5 }}>
+          {rows.map((row, i) => (
+            <Box
+              key={i}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                py: 0.375,
+                px: 1.5,
+                ml: row.level * 2.5,
+              }}
+            >
+              {/* Chevron placeholder */}
+              {row.level < 2 && (
+                <Skeleton variant="circular" width={14} height={14} sx={{ flexShrink: 0 }} />
+              )}
+              {/* Icon placeholder */}
+              <Skeleton variant="rounded" width={14} height={14} sx={{ flexShrink: 0 }} />
+              {/* Name */}
+              <Skeleton variant="rounded" width={row.width} height={12} sx={{ flexShrink: 0 }} />
+              <Box sx={{ flexGrow: 1 }} />
+              {/* Count badge or status */}
+              {row.hasCount && (
+                <Skeleton variant="rounded" width={32} height={12} />
+              )}
+              {row.hasStatus && (
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                  <Skeleton variant="rounded" width={22} height={12} />
+                  <Skeleton variant="rounded" width={44} height={12} />
+                </Box>
+              )}
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    );
+  }
+
   // Empty state when no tasks exist
   if (groups.length === 0) {
     return (
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100%',
-          p: 4,
-          textAlign: 'center',
-        }}
-      >
+      <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        {headerBar}
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flex: 1,
+            p: 4,
+            textAlign: 'center',
+          }}
+        >
         <Box
           sx={{
             width: 64,
@@ -390,7 +535,7 @@ export default function ProjectsTree({ selectedNodeId, onSelect, projectId, orga
             mb: 2,
           }}
         >
-          <Calendar size={32} style={{ color: 'var(--text-disabled)' }} />
+          <CalendarBlank size={32} color="var(--text-disabled)" />
         </Box>
         <Typography variant="h6" sx={{ fontWeight: 600, mb: 1, color: 'text.primary' }}>
           No Tasks Yet
@@ -401,12 +546,14 @@ export default function ProjectsTree({ selectedNodeId, onSelect, projectId, orga
         <Typography variant="caption" sx={{ color: 'text.disabled', maxWidth: 300 }}>
           💡 Tasks you create in the Gantt chart will automatically appear here with folders for documents, photos, and submittals
         </Typography>
+        </Box>
       </Box>
     );
   }
 
   return (
     <Box sx={{ width: '100%' }}>
+      {headerBar}
       <SimpleTreeView
         expandedItems={expandedItems}
         onExpandedItemsChange={(_, items) => setExpandedItems(items)}
@@ -422,10 +569,14 @@ export default function ProjectsTree({ selectedNodeId, onSelect, projectId, orga
               key={groupId}
               itemId={groupId}
               label={
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5 }}>
-                  <Folder size={16} />
-                  <Box sx={{ fontWeight: 500, flexGrow: 1 }}>{group.name}</Box>
-                  <Box sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.375 }}>
+                  {expandedItems.includes(groupId) && tasks.length > 0 ? (
+                    <FolderOpen size={16} />
+                  ) : (
+                    <FolderSimple size={16} />
+                  )}
+                  <Box sx={{ fontWeight: 500, flexGrow: 1, fontSize: '0.8125rem' }}>{group.name}</Box>
+                  <Box sx={{ fontSize: '0.6875rem', color: 'text.secondary' }}>
                     {tasks.length} {tasks.length === 1 ? 'task' : 'tasks'}
                   </Box>
                 </Box>
@@ -439,16 +590,8 @@ export default function ProjectsTree({ selectedNodeId, onSelect, projectId, orga
                     key={taskId}
                     itemId={taskId}
                     label={
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5, minWidth: 0 }}>
-                        <Box
-                          sx={{
-                            width: 8,
-                            height: 8,
-                            borderRadius: '50%',
-                            bgcolor: task.status.color,
-                            flexShrink: 0,
-                          }}
-                        />
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.375, minWidth: 0 }}>
+                        <Hammer size={14} color={task.status.color} style={{ flexShrink: 0 }} />
                         <Box
                           sx={{
                             flexGrow: 1,
@@ -456,6 +599,7 @@ export default function ProjectsTree({ selectedNodeId, onSelect, projectId, orga
                             overflow: 'hidden',
                             textOverflow: 'ellipsis',
                             whiteSpace: 'nowrap',
+                            fontSize: '0.8125rem',
                           }}
                         >
                           {task.name}
@@ -465,7 +609,7 @@ export default function ProjectsTree({ selectedNodeId, onSelect, projectId, orga
                             display: 'flex',
                             alignItems: 'center',
                             gap: 1.5,
-                            fontSize: '0.75rem',
+                            fontSize: '0.6875rem',
                             flexShrink: 0,
                           }}
                         >
@@ -486,6 +630,7 @@ export default function ProjectsTree({ selectedNodeId, onSelect, projectId, orga
                         taskId={taskId}
                         projectId={activeProjectId}
                         organizationId={activeOrganizationId}
+                        expandedItems={expandedItems}
                       />
                     ))}
                   </TreeItem>


### PR DESCRIPTION
## Summary
- Redesigns sidebar and mobile drawer with compact density: Phosphor icons with fill/regular weight toggle, left accent bar for active state, gradient user avatar, tighter 13px typography
- Overhauls ProjectsTree with Phosphor folder/task icons, structured skeleton loading, refresh button, and expanded/collapsed folder icon states
- Rebuilds ProjectDetailPanel with colored accent headers, progress cards, date cards, dot-grid empty state with Gantt illustration, and type-colored document icons
- Replaces resizable divider in FilesContent with fixed responsive-width tree panel
- Documents the compact density pattern in components-guide.md

## Test plan
- [ ] Verify sidebar nav items highlight correctly with left accent bar
- [ ] Check mobile drawer matches sidebar density at 300px
- [ ] Expand/collapse folders in project tree and verify icon switching
- [ ] Select tasks, folders, and documents to verify detail panel states
- [ ] Test empty state rendering with dot-grid background
- [ ] Verify file tree panel layout on xs/sm/lg breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)