### PR TITLE
Add CSI code selector to task popover

### DIFF
--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -18,13 +18,15 @@ import {
   TreeStructure,
   CalendarBlank,
   Timer,
+  Tag,
   SquaresFour,
   List,
   ImageSquare,
   DownloadSimple,
   ArrowsOut,
+  MagnifyingGlass,
 } from '@phosphor-icons/react';
-import { Box, Popover, IconButton, Typography, CircularProgress, Divider } from '@mui/material';
+import { Box, Popover, IconButton, Typography, CircularProgress, Divider, Menu, MenuItem, TextField, InputAdornment } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
 import UploadOverlay from '@/components/ui/UploadOverlay';
@@ -37,6 +39,7 @@ import { useProjectContext } from '@/components/providers/ProjectProvider';
 import UploadDialog from '@/components/documents/UploadDialog';
 import { api } from '@/trpc/react';
 import { useSnackbar } from '@/hooks/useSnackbar';
+import { formatCsiCode, CSI_DIVISIONS } from '@/lib/constants/csiCodes';
 
 function getStatusInfo(percentDone: number, palette: Theme['palette']) {
   if (percentDone >= 100) {
@@ -95,7 +98,25 @@ export function TaskDetailsPopover({
     uploadedBy: { name: string | null } | null;
   } | null>(null);
 
+  const [csiAnchorEl, setCsiAnchorEl] = useState<HTMLElement | null>(null);
+  const [csiSearch, setCsiSearch] = useState('');
+
   const utils = api.useUtils();
+
+  const updateCsiCode = api.gantt.updateCsiCode.useMutation({
+    onSuccess: () => {
+      void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId: taskId! });
+    },
+    onError: (error) => {
+      showSnackbar(error.message || 'Failed to update CSI code', 'error');
+    },
+  });
+
+  const filteredCsiDivisions = CSI_DIVISIONS.filter((d) => {
+    if (!csiSearch) return true;
+    const q = csiSearch.toLowerCase();
+    return d.code.includes(q) || d.name.toLowerCase().includes(q);
+  });
 
   const { data: taskDetail } = api.gantt.taskDetail.useQuery(
     { organizationId, projectId, taskId: taskId! },
@@ -536,6 +557,43 @@ export function TaskDetailsPopover({
                         </Typography>
                       </Box>
                     )}
+                    <Box
+                      component="button"
+                      onClick={(e) => {
+                        setCsiAnchorEl(e.currentTarget as HTMLElement);
+                        setCsiSearch('');
+                      }}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '5px',
+                        border: 'none',
+                        bgcolor: 'transparent',
+                        cursor: 'pointer',
+                        p: 0,
+                        borderRadius: 1,
+                        '&:hover': { bgcolor: 'action.hover' },
+                        px: 0.5,
+                        mx: -0.5,
+                        transition: 'background-color 0.15s',
+                      }}
+                    >
+                      <Tag
+                        size={12}
+                        color="var(--mui-palette-text-secondary)"
+                        style={{ flexShrink: 0 }}
+                      />
+                      <Typography
+                        sx={{
+                          fontSize: 11,
+                          fontWeight: 500,
+                          color: taskDetail?.csiCode ? 'text.secondary' : 'text.disabled',
+                          fontFamily: 'Inter, sans-serif',
+                        }}
+                      >
+                        {taskDetail?.csiCode ? formatCsiCode(taskDetail.csiCode) : 'Add CSI Code'}
+                      </Typography>
+                    </Box>
                   </Box>
                 )}
               </Box>
@@ -1408,6 +1466,107 @@ export function TaskDetailsPopover({
           onUploadComplete={handleUploadComplete}
         />
       )}
+
+      {/* CSI Code selector menu */}
+      <Menu
+        anchorEl={csiAnchorEl}
+        open={Boolean(csiAnchorEl)}
+        onClose={() => setCsiAnchorEl(null)}
+        slotProps={{
+          paper: {
+            sx: {
+              maxHeight: 320,
+              width: 340,
+              borderRadius: 2,
+              mt: 0.5,
+            },
+          },
+        }}
+      >
+        <Box sx={{ px: 1.5, py: 1, position: 'sticky', top: 0, bgcolor: 'background.paper', zIndex: 1 }}>
+          <TextField
+            size="small"
+            placeholder="Search divisions…"
+            value={csiSearch}
+            onChange={(e) => setCsiSearch(e.target.value)}
+            autoFocus
+            fullWidth
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <MagnifyingGlass size={14} />
+                  </InputAdornment>
+                ),
+                sx: { fontSize: 13, fontFamily: 'Inter, sans-serif' },
+              },
+            }}
+            onKeyDown={(e) => e.stopPropagation()}
+          />
+        </Box>
+        {taskDetail?.csiCode && (
+          <MenuItem
+            onClick={() => {
+              updateCsiCode.mutate({
+                organizationId,
+                projectId,
+                taskId: taskId!,
+                csiCode: null,
+              });
+              setCsiAnchorEl(null);
+            }}
+            sx={{
+              fontSize: 12,
+              fontFamily: 'Inter, sans-serif',
+              color: 'error.main',
+              fontStyle: 'italic',
+            }}
+          >
+            Remove CSI Code
+          </MenuItem>
+        )}
+        {filteredCsiDivisions.map((d) => (
+          <MenuItem
+            key={d.code}
+            selected={taskDetail?.csiCode === d.code}
+            onClick={() => {
+              updateCsiCode.mutate({
+                organizationId,
+                projectId,
+                taskId: taskId!,
+                csiCode: d.code,
+              });
+              setCsiAnchorEl(null);
+            }}
+            sx={{
+              fontSize: 12,
+              fontFamily: 'Inter, sans-serif',
+              gap: 1,
+            }}
+          >
+            <Typography
+              component="span"
+              sx={{
+                fontSize: 12,
+                fontWeight: 600,
+                fontFamily: 'Inter, sans-serif',
+                color: 'text.secondary',
+                minWidth: 24,
+              }}
+            >
+              {d.code}
+            </Typography>
+            {d.name}
+          </MenuItem>
+        ))}
+        {filteredCsiDivisions.length === 0 && (
+          <Box sx={{ px: 2, py: 1.5 }}>
+            <Typography sx={{ fontSize: 12, color: 'text.disabled', fontFamily: 'Inter, sans-serif' }}>
+              No divisions match &ldquo;{csiSearch}&rdquo;
+            </Typography>
+          </Box>
+        )}
+      </Menu>
     </>
   );
 }

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -41,12 +41,6 @@ export function createGanttConfig(
   return {
     detectCSSCompatibilityIssues: false,
 
-    // Infinite scroll extends the time axis automatically as the user
-    // scrolls near the edges.  bufferCoef controls the invisible buffer
-    // size (5 = 5× viewport width on each side).
-    infiniteScroll: true,
-    bufferCoef: 5,
-
     // Performance optimizations
     autoHeight: false,
     rowHeight: 45, // Consistent row height for better performance
@@ -180,10 +174,8 @@ export function createGanttConfig(
     },
     emptyText: 'No tasks yet — click "+ Add Task" above or double-click here to get started',
     viewPreset: 'weekAndDayLetter',
-    // Initial window just needs to fill the viewport on load.
-    // infiniteScroll extends the range automatically as the user scrolls.
-    startDate: new Date(new Date().getFullYear(), new Date().getMonth() - 6, 1),
-    endDate: new Date(new Date().getFullYear(), new Date().getMonth() + 6, 1),
+    startDate: new Date(new Date().getFullYear(), new Date().getMonth() - 3, 1),
+    endDate: new Date(new Date().getFullYear(), new Date().getMonth() + 24, 1),
     barMargin: 10,
     listeners: {
       // Bryntum blocks the duration cell editor for parent tasks before

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -258,4 +258,31 @@ export const ganttRouter = createTRPCRouter({
         throw error;
       }
     }),
+
+  /**
+   * Update a task's CSI code from the detail popover
+   */
+  updateCsiCode: orgProcedure
+    .input(z.object({
+      projectId: z.string(),
+      taskId: z.string(),
+      csiCode: z.string().nullable(),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      const { projectId, taskId, csiCode } = input;
+
+      const project = await ctx.db.project.findFirst({
+        where: { id: projectId, organizationId: ctx.organization.id },
+      });
+
+      if (!project) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Project not found or access denied" });
+      }
+
+      return ctx.db.ganttTask.update({
+        where: { id: taskId, projectId },
+        data: { csiCode },
+        select: { id: true, csiCode: true },
+      });
+    }),
 });


### PR DESCRIPTION
## Summary
- Adds a searchable CSI division code dropdown to the task details popover, allowing users to assign, change, or remove a CSI code directly from the modal
- Adds `updateCsiCode` tRPC mutation to the gantt router for persisting CSI code changes
- Fixes Bryntum Gantt crash ("Invalid time axis configuration") caused by `infiniteScroll` config conflicting with React double-mount in dev mode

## Test plan
- [ ] Open a task popover and click the "Add CSI Code" button in the metadata row
- [ ] Search for a division by code or name and select one
- [ ] Verify the CSI code persists after closing and reopening the popover
- [ ] Use "Remove CSI Code" to clear it
- [ ] Verify the Gantt chart loads without the time axis error