### PR TITLE
Redesign upload document modal to compact single-column layout

### DIFF
--- a/src/components/documents/UploadDialog.tsx
+++ b/src/components/documents/UploadDialog.tsx
@@ -2,11 +2,17 @@
 
 import { useCallback, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
-import { UploadSimple, X, ChatCircle } from '@phosphor-icons/react';
-import { Box, Dialog, Typography, Divider } from '@mui/material';
+import { UploadSimple, X } from '@phosphor-icons/react';
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogActions,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import { Button } from '@/components/ui/button';
-import { alpha } from '@mui/material/styles';
-import type { Theme } from '@mui/material/styles';
 import UploadOverlay from '@/components/ui/UploadOverlay';
 import FileDropzone from '@/components/ui/FileDropzone';
 import { useSnackbar } from '@/hooks/useSnackbar';
@@ -36,6 +42,7 @@ export default function UploadDialog({
   const [notes, setNotes] = useState('');
   const [isUploading, setIsUploading] = useState(false);
   const { showSnackbar } = useSnackbar();
+  const theme = useTheme();
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
     const f = acceptedFiles[0];
@@ -112,6 +119,29 @@ export default function UploadDialog({
     }
   };
 
+  const inputSx = {
+    width: '100%',
+    borderRadius: '10px',
+    bgcolor: alpha(theme.palette.divider, 0.08),
+    border: '1.5px solid transparent',
+    p: '10px 14px',
+    color: 'text.primary',
+    outline: 'none',
+    transition: 'all 0.15s ease',
+    '&::placeholder': {
+      color: alpha(theme.palette.text.secondary, 0.5),
+      opacity: 1,
+    },
+    '&:hover': {
+      borderColor: alpha(theme.palette.primary.main, 0.3),
+    },
+    '&:focus': {
+      borderColor: theme.palette.primary.main,
+      bgcolor: 'background.paper',
+      boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
+    },
+  };
+
   return (
     <Dialog
       open={open}
@@ -119,266 +149,255 @@ export default function UploadDialog({
       maxWidth={false}
       PaperProps={{
         sx: {
-          width: 720,
+          width: 460,
           borderRadius: '16px',
-          border: '1px solid',
-          borderColor: 'divider',
-          boxShadow: '0 16px 48px -8px rgba(0,0,0,0.19), 0 4px 12px -4px rgba(0,0,0,0.05)',
           overflow: 'hidden',
+          boxShadow: `0 24px 64px -16px ${alpha('#000', 0.2)}, 0 8px 20px -8px ${alpha('#000', 0.08)}`,
         },
       }}
     >
+      {/* Accent bar */}
+      <Box
+        sx={{
+          height: 3,
+          background: `linear-gradient(90deg, ${theme.palette.primary.main}, ${alpha(theme.palette.primary.main, 0.3)})`,
+        }}
+      />
+
       {/* Header */}
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 3, py: 2.5 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+      <Box sx={{ p: 3.5, pb: 0 }}>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 1.5 }}>
           <Box
             sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '10px',
-              bgcolor: 'background.default',
-              border: '1px solid',
-              borderColor: 'divider',
+              width: 44,
+              height: 44,
+              borderRadius: '12px',
+              bgcolor: alpha(theme.palette.primary.main, 0.08),
+              border: `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
+              flexShrink: 0,
             }}
           >
-            <UploadSimple size={18} color="var(--mui-palette-text-primary)" />
+            <UploadSimple size={22} style={{ color: theme.palette.primary.main }} />
           </Box>
-          <Box>
-            <Typography sx={{ fontSize: 16, fontWeight: 700, color: 'text.primary', lineHeight: 1.3 }}>
+          <Box sx={{ pt: 0.25 }}>
+            <Typography
+              sx={{
+                fontSize: '1.125rem',
+                fontWeight: 700,
+                color: 'text.primary',
+                letterSpacing: '-0.01em',
+                lineHeight: 1.3,
+              }}
+            >
               Upload Document
             </Typography>
-            <Typography sx={{ fontSize: 13, fontWeight: 400, color: 'text.secondary' }}>
-              Add a file to your project
+            <Typography
+              sx={{
+                fontSize: '0.8125rem',
+                color: 'text.secondary',
+                mt: 0.25,
+                lineHeight: 1.4,
+              }}
+            >
+              Add a file to {folderName}
             </Typography>
           </Box>
-        </Box>
-        <Box
-          onClick={handleClose}
-          sx={{
-            width: 28,
-            height: 28,
-            borderRadius: '8px',
-            border: '1px solid',
-            borderColor: 'divider',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            cursor: 'pointer',
-            '&:hover': { bgcolor: 'background.default' },
-          }}
-        >
-          <X size={14} color="var(--mui-palette-text-secondary)" />
         </Box>
       </Box>
 
-      <Divider />
-
-      {/* Body — Two panels */}
-      <Box sx={{ display: 'flex', minHeight: 340, position: 'relative' }}>
-        {/* Upload overlay */}
+      {/* Body */}
+      <DialogContent sx={{ px: 3.5, pt: 2.5, pb: 1, position: 'relative' }}>
         {isUploading && (
           <Box sx={{ position: 'absolute', inset: 0, zIndex: 2 }}>
-            <UploadOverlay variant="light" text="Uploading document\u2026" size={28} />
+            <UploadOverlay variant="light" text="Uploading document…" size={28} />
           </Box>
         )}
 
-        {/* Left: Drop Zone Panel */}
-        <Box
-          sx={{
-            width: 280,
-            flexShrink: 0,
-            bgcolor: 'background.default',
-            p: 3,
-            borderRight: '1px solid',
-            borderRightColor: 'divider',
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-        >
-          <FileDropzone
-            getRootProps={getRootProps}
-            getInputProps={getInputProps}
-            isDragActive={isDragActive}
-            disabled={isUploading}
-            hintText="PDF, JPG, PNG, DWG up to 50 MB"
-          />
-        </Box>
-
-        {/* Right: Form Panel */}
-        <Box sx={{ flex: 1, p: '20px 24px', display: 'flex', flexDirection: 'column', gap: 2 }}>
-          {/* File Attached Card */}
-          {file && (
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1.25,
-                p: 1.5,
-                borderRadius: '10px',
-                border: '1px solid',
-                borderColor: 'divider',
-                bgcolor: 'background.paper',
-              }}
-            >
-              <Box
-                sx={{
-                  width: 34,
-                  height: 34,
-                  borderRadius: '8px',
-                  bgcolor: (theme: Theme) => alpha(theme.palette.success.main, 0.1),
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  flexShrink: 0,
-                }}
-              >
-                <UploadSimple size={16} color="var(--mui-palette-success-main)" />
-              </Box>
-              <Box sx={{ flex: 1, minWidth: 0 }}>
-                <Typography sx={{ fontSize: 13, fontWeight: 600, color: 'text.primary', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {file.name}
-                </Typography>
-                <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>
-                  {formatFileSize(file.size)}
-                </Typography>
-              </Box>
-              <Box
-                onClick={handleRemoveFile}
-                sx={{
-                  width: 24,
-                  height: 24,
-                  borderRadius: '6px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  cursor: 'pointer',
-                  flexShrink: 0,
-                  '&:hover': { bgcolor: 'background.default' },
-                }}
-              >
-                <X size={14} color="var(--mui-palette-text-secondary)" />
-              </Box>
-            </Box>
-          )}
-
-          {/* Document Title */}
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-            <Typography sx={{ fontSize: 13, fontWeight: 600, color: 'text.primary' }}>
-              Document Title
-            </Typography>
-            <Box
-              component="input"
-              value={title}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
-              placeholder="Enter a title for this document"
-              sx={{
-                width: '100%',
-                borderRadius: '10px',
-                border: '1px solid',
-                borderColor: 'divider',
-                bgcolor: 'background.paper',
-                p: '10px 14px',
-                fontSize: 13,
-                fontFamily: 'Inter, sans-serif',
-                color: 'text.primary',
-                outline: 'none',
-                '&::placeholder': { color: 'text.secondary' },
-                '&:focus': { borderColor: 'text.secondary' },
-              }}
+        {/* Dropzone ↔ File card swap */}
+        {!file ? (
+          <Box sx={{ mb: 2.5 }}>
+            <FileDropzone
+              getRootProps={getRootProps}
+              getInputProps={getInputProps}
+              isDragActive={isDragActive}
+              disabled={isUploading}
+              hintText="PDF, JPG, PNG, DWG up to 50 MB"
+              sx={{ py: 4 }}
             />
           </Box>
-
-          {/* Notes */}
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75, flex: 1 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-                <ChatCircle size={13} color="var(--mui-palette-text-primary)" />
-                <Typography sx={{ fontSize: 13, fontWeight: 600, color: 'text.primary' }}>
-                  Notes
-                </Typography>
-              </Box>
-              <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>
-                Optional
+        ) : (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.25,
+              p: 1.5,
+              mb: 2.5,
+              borderRadius: '10px',
+              bgcolor: alpha(theme.palette.success.main, 0.06),
+              border: `1px solid ${alpha(theme.palette.success.main, 0.15)}`,
+            }}
+          >
+            <Box
+              sx={{
+                width: 34,
+                height: 34,
+                borderRadius: '8px',
+                bgcolor: alpha(theme.palette.success.main, 0.1),
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <UploadSimple size={16} style={{ color: theme.palette.success.main }} />
+            </Box>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                sx={{
+                  fontSize: '0.8125rem',
+                  fontWeight: 600,
+                  color: 'text.primary',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {file.name}
+              </Typography>
+              <Typography sx={{ fontSize: '0.6875rem', color: 'text.secondary' }}>
+                {formatFileSize(file.size)}
               </Typography>
             </Box>
             <Box
-              component="textarea"
-              value={notes}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setNotes(e.target.value)}
-              placeholder="Add notes about this document..."
+              onClick={handleRemoveFile}
               sx={{
-                width: '100%',
-                flex: 1,
-                minHeight: 80,
-                borderRadius: '10px',
-                border: '1px solid',
-                borderColor: 'divider',
-                bgcolor: 'background.paper',
-                p: '12px 14px',
-                fontSize: 12,
-                fontFamily: 'Inter, sans-serif',
-                lineHeight: 1.6,
-                color: 'text.primary',
-                outline: 'none',
-                resize: 'none',
-                '&::placeholder': { color: 'text.secondary' },
-                '&:focus': { borderColor: 'text.secondary' },
+                width: 24,
+                height: 24,
+                borderRadius: '6px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+                flexShrink: 0,
+                '&:hover': { bgcolor: alpha(theme.palette.text.primary, 0.06) },
               }}
-            />
+            >
+              <X size={14} style={{ color: theme.palette.text.secondary }} />
+            </Box>
           </Box>
-        </Box>
-      </Box>
+        )}
 
-      <Divider />
+        {/* Document Title */}
+        <Box sx={{ mb: 2 }}>
+          <Typography
+            component="label"
+            htmlFor="doc-title-input"
+            sx={{
+              display: 'block',
+              fontSize: '0.75rem',
+              fontWeight: 600,
+              color: 'text.secondary',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              mb: 0.75,
+            }}
+          >
+            Document Title
+          </Typography>
+          <Box
+            component="input"
+            id="doc-title-input"
+            value={title}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
+            placeholder="Enter a title for this document"
+            sx={{ ...inputSx, fontSize: '0.9375rem' }}
+          />
+        </Box>
+
+        {/* Notes */}
+        <Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.75 }}>
+            <Typography
+              component="label"
+              htmlFor="doc-notes-input"
+              sx={{
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                color: 'text.secondary',
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+              }}
+            >
+              Notes
+            </Typography>
+            <Typography sx={{ fontSize: '0.6875rem', color: 'text.secondary', fontWeight: 400 }}>
+              Optional
+            </Typography>
+          </Box>
+          <Box
+            component="textarea"
+            id="doc-notes-input"
+            value={notes}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setNotes(e.target.value)}
+            placeholder="Add notes about this document..."
+            rows={3}
+            sx={{
+              ...inputSx,
+              fontSize: '0.8125rem',
+              lineHeight: 1.6,
+              minHeight: 72,
+              resize: 'none',
+            }}
+          />
+        </Box>
+      </DialogContent>
 
       {/* Footer */}
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 1, px: 3, py: 1.75 }}>
-        <Box
+      <DialogActions sx={{ px: 3.5, py: 2.5, gap: 1 }}>
+        <Button
+          variant="text"
           onClick={handleClose}
           sx={{
-            borderRadius: 999,
-            border: '1px solid',
-            borderColor: 'divider',
-            px: 2.5,
-            py: 1.25,
-            cursor: 'pointer',
-            '&:hover': { bgcolor: 'background.default' },
+            color: 'text.secondary',
+            fontWeight: 500,
+            fontSize: '0.8125rem',
+            px: 2,
+            borderRadius: '8px',
+            '&:hover': {
+              bgcolor: alpha(theme.palette.divider, 0.12),
+              color: 'text.primary',
+            },
           }}
         >
-          <Typography sx={{ fontSize: 13, fontWeight: 500, color: 'text.primary' }}>Cancel</Typography>
-        </Box>
+          Cancel
+        </Button>
         <Button
+          variant="contained"
           onClick={handleUpload}
           loading={isUploading}
           loadingPosition="start"
           disabled={!file}
-          startIcon={<UploadSimple size={15} />}
+          startIcon={<UploadSimple size={16} />}
           sx={{
-            borderRadius: 999,
-            bgcolor: file && !isUploading ? 'text.primary' : 'background.default',
-            color: file && !isUploading ? 'background.paper' : 'text.secondary',
-            px: 3,
-            py: 1.25,
-            fontSize: 13,
+            borderRadius: '8px',
             fontWeight: 600,
-            letterSpacing: 0.3,
-            opacity: file && !isUploading ? 1 : 0.5,
-            boxShadow: file && !isUploading ? '0 1px 4px rgba(0,0,0,0.13)' : 'none',
-            transition: 'all 0.2s',
-            '&:hover': file && !isUploading ? { opacity: 0.88, bgcolor: 'text.primary' } : {},
-            '&.Mui-disabled': {
-              bgcolor: file ? 'text.primary' : 'background.default',
-              color: file ? 'background.paper' : 'text.secondary',
-              opacity: isUploading ? 0.8 : 0.5,
+            fontSize: '0.8125rem',
+            px: 2.5,
+            py: 1,
+            textTransform: 'none',
+            boxShadow: `0 1px 3px ${alpha(theme.palette.primary.main, 0.3)}`,
+            '&:hover': {
+              boxShadow: `0 4px 12px ${alpha(theme.palette.primary.main, 0.35)}`,
             },
           }}
         >
           {isUploading ? 'Uploading...' : 'Upload Document'}
         </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 }

--- a/src/components/ui/FileDropzone.tsx
+++ b/src/components/ui/FileDropzone.tsx
@@ -71,7 +71,6 @@ export default function FileDropzone({
           fontSize: isStandalone ? 14 : '0.7rem',
           fontWeight: isStandalone ? 600 : 400,
           color: 'text.primary',
-          fontFamily: 'Inter, sans-serif',
         }}
       >
         {primaryText}

--- a/src/components/ui/UploadOverlay.tsx
+++ b/src/components/ui/UploadOverlay.tsx
@@ -58,7 +58,6 @@ export default function UploadOverlay({
             sx={{
               fontSize: 12,
               color: isDark ? 'white' : 'text.secondary',
-              fontFamily: 'Inter, sans-serif',
               fontWeight: 500,
             }}
           >


### PR DESCRIPTION
Redesigns the Upload Document dialog from a wide 720px two-panel layout to a compact 460px single-column stacked layout matching the AddProjectDialog pattern. The dropzone and file card now swap conditionally (no wasted space), form labels use uppercase micro-labels, inputs get theme-aware focus rings, and buttons use consistent 8px radius instead of pill shapes. Also removes hardcoded `fontFamily: 'Inter, sans-serif'` from FileDropzone and UploadOverlay components.