### PR TITLE
Add delete project, manage page, and account settings modal

### DIFF
--- a/.github/workflows/neon-branch.yml
+++ b/.github/workflows/neon-branch.yml
@@ -2,7 +2,7 @@ name: Neon Branch
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, closed]
+    types: [opened, reopened, closed]
 
 concurrency:
   group: neon-${{ github.event.number }}

--- a/.github/workflows/neon-branch.yml
+++ b/.github/workflows/neon-branch.yml
@@ -1,0 +1,39 @@
+name: Neon Branch
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+concurrency:
+  group: neon-${{ github.event.number }}
+  cancel-in-progress: false
+
+jobs:
+  create_neon_branch:
+    name: Create Neon Branch
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set expiration date
+        id: expiry
+        run: echo "date=$(date -u --date '+14 days' +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Create Neon Branch
+        uses: neondatabase/create-branch-action@v6
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: preview/pr-${{ github.event.number }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          expires_at: ${{ steps.expiry.outputs.date }}
+
+  delete_neon_branch:
+    name: Delete Neon Branch
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Neon Branch
+        uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch: preview/pr-${{ github.event.number }}
+          api_key: ${{ secrets.NEON_API_KEY }}

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/manage/page.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/manage/page.tsx
@@ -1,20 +1,27 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { UserPlus } from 'lucide-react';
+import { UserPlus, Trash2, AlertTriangle } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Box, Typography, Tabs, Tab, Paper, Button } from '@mui/material';
+import { useTheme, alpha } from '@mui/material/styles';
 import { api } from '@/trpc/react';
-import { canInviteMembers } from '@/lib/permissions';
+import { canInviteMembers, canDeleteProjects } from '@/lib/permissions';
 import InviteDialog from '@/components/team/InviteDialog';
 import MembersList from '@/components/team/MembersList';
 import PendingInvitesList from '@/components/team/PendingInvitesList';
+import DeleteProjectDialog from '@/components/projects/DeleteProjectDialog';
+import { Button as LoadingButton } from '@/components/ui/button';
 import { useProjectContext } from '@/components/providers/ProjectProvider';
 import { useOrgContext } from '@/components/providers/OrgProvider';
 
-export default function ProjectTeamPage() {
+type ManageTab = 'members' | 'pending' | 'settings';
+
+export default function ManagePage() {
+  const theme = useTheme();
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<'members' | 'pending'>('members');
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<ManageTab>('members');
 
   const { projectId, projectName, organizationId } = useProjectContext();
   const { orgId } = useOrgContext();
@@ -33,6 +40,7 @@ export default function ProjectTeamPage() {
     (m) => m.user.id === currentUser?.id
   );
   const canManage = currentMembership ? canInviteMembers(currentMembership.role) : false;
+  const canDelete = currentMembership ? canDeleteProjects(currentMembership.role) : false;
 
   const pendingCount = invitations.filter((inv) => inv.status === 'pending').length;
 
@@ -65,13 +73,13 @@ export default function ProjectTeamPage() {
       >
         <Box>
           <Typography variant="h5" sx={{ fontWeight: 600, color: 'text.primary' }}>
-            Team
+            Manage
           </Typography>
           <Typography variant="body2" sx={{ color: 'text.disabled', mt: 0.5 }}>
             {projectName}
           </Typography>
         </Box>
-        {canManage && (
+        {canManage && activeTab !== 'settings' && (
           <Button
             variant="contained"
             onClick={() => setInviteDialogOpen(true)}
@@ -101,12 +109,13 @@ export default function ProjectTeamPage() {
           {pendingCount > 0 && (
             <Tab label={`Pending (${pendingCount})`} value="pending" />
           )}
+          <Tab label="Settings" value="settings" />
         </Tabs>
       </Box>
 
       {/* Tab Content */}
       <AnimatePresence mode="wait">
-        {activeTab === 'members' ? (
+        {activeTab === 'members' && (
           <Paper
             component={motion.div}
             key="members"
@@ -124,7 +133,9 @@ export default function ProjectTeamPage() {
           >
             <MembersList members={members} isLoading={membersLoading} />
           </Paper>
-        ) : (
+        )}
+
+        {activeTab === 'pending' && (
           <Paper
             component={motion.div}
             key="pending"
@@ -160,6 +171,109 @@ export default function ProjectTeamPage() {
             )}
           </Paper>
         )}
+
+        {activeTab === 'settings' && (
+          <Box
+            component={motion.div}
+            key="settings"
+            initial={{ opacity: 0, x: -20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: 20 }}
+            transition={{ duration: 0.2 }}
+          >
+            {canDelete ? (
+              <Paper
+                elevation={0}
+                sx={{
+                  border: '1px solid',
+                  borderColor: alpha(theme.palette.error.main, 0.3),
+                  borderRadius: 2,
+                  overflow: 'hidden',
+                }}
+              >
+                {/* Danger Zone header */}
+                <Box
+                  sx={{
+                    px: 3,
+                    py: 1.5,
+                    bgcolor: alpha(theme.palette.error.main, 0.04),
+                    borderBottom: '1px solid',
+                    borderColor: alpha(theme.palette.error.main, 0.15),
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                  }}
+                >
+                  <AlertTriangle size={14} style={{ color: theme.palette.error.main }} />
+                  <Typography
+                    sx={{
+                      fontSize: '0.75rem',
+                      fontWeight: 600,
+                      color: 'error.main',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.05em',
+                    }}
+                  >
+                    Danger Zone
+                  </Typography>
+                </Box>
+
+                {/* Delete project row */}
+                <Box
+                  sx={{
+                    px: 3,
+                    py: 2.5,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 2,
+                  }}
+                >
+                  <Box>
+                    <Typography
+                      sx={{
+                        fontSize: '0.875rem',
+                        fontWeight: 600,
+                        color: 'text.primary',
+                        mb: 0.25,
+                      }}
+                    >
+                      Delete this project
+                    </Typography>
+                    <Typography
+                      sx={{
+                        fontSize: '0.8125rem',
+                        color: 'text.secondary',
+                        lineHeight: 1.5,
+                      }}
+                    >
+                      Permanently delete this project and all its data. This cannot be undone.
+                    </Typography>
+                  </Box>
+                  <LoadingButton
+                    variant="outlined"
+                    color="error"
+                    onClick={() => setDeleteDialogOpen(true)}
+                    startIcon={<Trash2 size={14} />}
+                    sx={{
+                      flexShrink: 0,
+                      borderRadius: '8px',
+                      fontWeight: 600,
+                      fontSize: '0.8125rem',
+                      textTransform: 'none',
+                    }}
+                  >
+                    Delete
+                  </LoadingButton>
+                </Box>
+              </Paper>
+            ) : (
+              <Typography sx={{ color: 'text.disabled', fontSize: '0.875rem' }}>
+                Only project owners and admins can manage project settings.
+              </Typography>
+            )}
+          </Box>
+        )}
       </AnimatePresence>
 
       {/* Invite Dialog */}
@@ -171,6 +285,13 @@ export default function ProjectTeamPage() {
           projectId={projectId}
         />
       )}
+
+      {/* Delete Project Dialog */}
+      <DeleteProjectDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        project={projectId ? { id: projectId, name: projectName } : null}
+      />
     </Box>
   );
 }

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -503,8 +503,6 @@ export default function BryntumGanttWrapper({ projectId, isVisible = true }: Bry
     <div style={WRAPPER_STYLE}>
       <GanttToolbar
         onAddTask={handleAddTask}
-        onIndent={handleIndent}
-        onOutdent={handleOutdent}
         onPresetChange={handlePresetChange}
         onZoomIn={handleZoomIn}
         onZoomOut={handleZoomOut}

--- a/src/components/bryntum/components/GanttToolbar.tsx
+++ b/src/components/bryntum/components/GanttToolbar.tsx
@@ -21,8 +21,6 @@ import {
   MoreVertical,
   Plus,
   CheckCircle,
-  IndentIncrease,
-  IndentDecrease,
 } from 'lucide-react';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -129,8 +127,6 @@ const switchSx = {
 // ─── Props ────────────────────────────────────────────────────────────────────
 type GanttToolbarProps = {
   onAddTask?: () => void;
-  onIndent?: () => void;
-  onOutdent?: () => void;
   onPresetChange?: (preset: string) => void;
   onZoomIn?: () => void;
   onZoomOut?: () => void;
@@ -151,8 +147,6 @@ type GanttToolbarProps = {
 // ─── Component ────────────────────────────────────────────────────────────────
 export default function GanttToolbar({
   onAddTask,
-  onIndent,
-  onOutdent,
   onPresetChange,
   onZoomIn,
   onZoomOut,
@@ -223,14 +217,6 @@ export default function GanttToolbar({
           <ChevronsRight style={{ width: ICON_SIZE, height: ICON_SIZE }} />
         </IconButton>
 
-        <Divider orientation="vertical" flexItem sx={{ mx: 0.5, my: 'auto', height: 18, alignSelf: 'center' }} />
-
-        <IconButton size="small" sx={iconBtnSx} onClick={onOutdent} title="Outdent selected task">
-          <IndentDecrease style={{ width: ICON_SIZE, height: ICON_SIZE }} />
-        </IconButton>
-        <IconButton size="small" sx={iconBtnSx} onClick={onIndent} title="Indent selected task">
-          <IndentIncrease style={{ width: ICON_SIZE, height: ICON_SIZE }} />
-        </IconButton>
       </Stack>
 
       {/* ── Spacer ─────────────────────────────────────────────────────── */}

--- a/src/components/layout/AccountSettingsModal.tsx
+++ b/src/components/layout/AccountSettingsModal.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState } from 'react';
+import { X, User, Settings, CreditCard, LifeBuoy } from 'lucide-react';
+import { Dialog, Box, IconButton, Typography } from '@mui/material';
+
+const tabs = [
+  { id: 'profile', label: 'Profile', icon: User },
+  { id: 'account', label: 'Account', icon: Settings },
+  { id: 'billing', label: 'Billing', icon: CreditCard },
+  { id: 'help', label: 'Help & Support', icon: LifeBuoy },
+] as const;
+
+type TabId = (typeof tabs)[number]['id'];
+
+interface AccountSettingsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function AccountSettingsModal({ open, onOpenChange }: AccountSettingsModalProps) {
+  const [activeTab, setActiveTab] = useState<TabId>('profile');
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth={false}
+      PaperProps={{
+        sx: {
+          width: 720,
+          height: 520,
+          borderRadius: '16px',
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'row',
+        },
+      }}
+    >
+      {/* Left sidebar */}
+      <Box
+        sx={{
+          width: 200,
+          bgcolor: 'background.default',
+          borderRight: '1px solid',
+          borderColor: 'divider',
+          display: 'flex',
+          flexDirection: 'column',
+          py: 2,
+          px: 1,
+          flexShrink: 0,
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: '0.6875rem',
+            fontWeight: 600,
+            color: 'text.disabled',
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            px: 1,
+            pb: 1,
+            userSelect: 'none',
+          }}
+        >
+          Settings
+        </Typography>
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+          {tabs.map((tab) => {
+            const isActive = activeTab === tab.id;
+            return (
+              <Box
+                key={tab.id}
+                component="button"
+                onClick={() => setActiveTab(tab.id)}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1.25,
+                  px: 1.25,
+                  py: 0.875,
+                  borderRadius: '8px',
+                  border: 'none',
+                  bgcolor: isActive ? 'action.selected' : 'transparent',
+                  color: isActive ? 'text.primary' : 'text.secondary',
+                  cursor: 'pointer',
+                  transition: 'all 0.15s',
+                  '&:hover': {
+                    bgcolor: isActive ? 'action.selected' : 'action.hover',
+                    color: 'text.primary',
+                  },
+                }}
+              >
+                <tab.icon style={{ width: 15, height: 15 }} />
+                <Typography
+                  sx={{
+                    fontSize: '0.8125rem',
+                    fontWeight: isActive ? 550 : 400,
+                    lineHeight: 1,
+                  }}
+                >
+                  {tab.label}
+                </Typography>
+              </Box>
+            );
+          })}
+        </Box>
+      </Box>
+
+      {/* Right content */}
+      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        {/* Header */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            px: 3,
+            py: 2,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Typography sx={{ fontSize: '1.1rem', fontWeight: 600 }}>
+            {tabs.find((t) => t.id === activeTab)?.label}
+          </Typography>
+          <IconButton
+            onClick={handleClose}
+            size="small"
+            sx={{ color: 'text.secondary', '&:hover': { color: 'text.primary' } }}
+          >
+            <X style={{ width: 18, height: 18 }} />
+          </IconButton>
+        </Box>
+
+        {/* Content */}
+        <Box sx={{ flex: 1, px: 3, py: 3, overflow: 'auto' }}>
+          <Typography sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
+            {tabs.find((t) => t.id === activeTab)?.label} settings will appear here.
+          </Typography>
+        </Box>
+      </Box>
+    </Dialog>
+  );
+}

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { usePathname, useParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { X, User, Settings, CreditCard, LifeBuoy, LogOut, ChevronRight } from 'lucide-react';
-import { ChartBar, FolderSimple, FileMagnifyingGlass, Users, type Icon } from '@phosphor-icons/react';
+import { ChartBar, FolderSimple, FileMagnifyingGlass, GearSix, type Icon } from '@phosphor-icons/react';
 import { Drawer, Box, IconButton, Typography } from '@mui/material';
 import {
   DropdownMenu,
@@ -18,12 +18,13 @@ import ProjectSwitcher from './ProjectSwitcher';
 import { authClient, signOut } from '@/lib/auth-client';
 import { getInitials } from '@/lib/utils/formatting';
 import LoadingSpinner from '@/components/ui/loading-spinner';
+import AccountSettingsModal from './AccountSettingsModal';
 
 const iconMap: Record<string, Icon> = {
   ChartBar,
   FolderSimple,
   FileMagnifyingGlass,
-  Users,
+  GearSix,
 };
 
 interface MobileDrawerProps {
@@ -49,6 +50,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
 
   const [profileOpen, setProfileOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   useEffect(() => {
     onClose();
@@ -367,7 +369,12 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
               <Box
                 key={item.label}
                 component="button"
-                onClick={() => setProfileOpen(false)}
+                onClick={() => {
+                  setProfileOpen(false);
+                  if (item.label === 'Account Settings') {
+                    setSettingsOpen(true);
+                  }
+                }}
                 sx={{
                   display: 'flex',
                   alignItems: 'center',
@@ -423,6 +430,8 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
       </DropdownMenu>
 
       {isLoggingOut && <LoadingSpinner size="lg" fullScreen text="Logging out..." />}
+
+      <AccountSettingsModal open={settingsOpen} onOpenChange={setSettingsOpen} />
     </Drawer>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { usePathname, useParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { ChevronsUpDown, User, Settings, CreditCard, LifeBuoy, LogOut } from 'lucide-react';
-import { ChartBar, FolderSimple, FileMagnifyingGlass, Users, type Icon } from '@phosphor-icons/react';
+import { ChartBar, FolderSimple, FileMagnifyingGlass, GearSix, type Icon } from '@phosphor-icons/react';
 import { Box, List, ListItemButton, ListItemIcon, ListItemText, Typography } from '@mui/material';
 import {
   DropdownMenu,
@@ -18,12 +18,13 @@ import ProjectSwitcher from './ProjectSwitcher';
 import { authClient, signOut } from '@/lib/auth-client';
 import { getInitials } from '@/lib/utils/formatting';
 import LoadingSpinner from '@/components/ui/loading-spinner';
+import AccountSettingsModal from './AccountSettingsModal';
 
 const iconMap: Record<string, Icon> = {
   ChartBar,
   FolderSimple,
   FileMagnifyingGlass,
-  Users,
+  GearSix,
 };
 
 const profileMenuItems = [
@@ -44,6 +45,7 @@ export default function Sidebar() {
 
   const [profileOpen, setProfileOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const handleLogout = async () => {
     setIsLoggingOut(true);
@@ -291,7 +293,12 @@ export default function Sidebar() {
               <Box
                 key={item.label}
                 component="button"
-                onClick={() => setProfileOpen(false)}
+                onClick={() => {
+                  setProfileOpen(false);
+                  if (item.label === 'Account Settings') {
+                    setSettingsOpen(true);
+                  }
+                }}
                 sx={{
                   display: 'flex',
                   alignItems: 'center',
@@ -348,6 +355,8 @@ export default function Sidebar() {
       </DropdownMenu>
 
       {isLoggingOut && <LoadingSpinner size="lg" fullScreen text="Logging out..." />}
+
+      <AccountSettingsModal open={settingsOpen} onOpenChange={setSettingsOpen} />
     </Box>
   );
 }

--- a/src/components/layout/navItems.ts
+++ b/src/components/layout/navItems.ts
@@ -13,7 +13,7 @@ export const projectNavItems: NavItem[] = [
   { id: 'gantt', label: 'Gantt', icon: 'ChartBar', segment: 'gantt' },
   { id: 'files', label: 'File Tree', icon: 'FolderSimple', segment: 'files' },
   { id: 'document-explorer', label: 'Document Explorer', icon: 'FileMagnifyingGlass', segment: 'document-explorer' },
-  { id: 'team', label: 'Team', icon: 'Users', segment: 'team' },
+  { id: 'manage', label: 'Manage', icon: 'GearSix', segment: 'manage' },
 ];
 
 // Helper to build org-level URLs

--- a/src/components/projects/DeleteProjectDialog.tsx
+++ b/src/components/projects/DeleteProjectDialog.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import { useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import { api } from '@/trpc/react';
+import { useRouter } from 'next/navigation';
+import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
+import { Button } from '@/components/ui/button';
+import { useSnackbar } from '@/hooks/useSnackbar';
+
+interface DeleteProjectDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  project: { id: string; name: string } | null;
+}
+
+export default function DeleteProjectDialog({
+  open,
+  onOpenChange,
+  project,
+}: DeleteProjectDialogProps) {
+  const utils = api.useUtils();
+  const router = useRouter();
+  const theme = useTheme();
+  const { showSnackbar } = useSnackbar();
+  const { orgSlug } = useOrgFromUrl();
+  const [confirmName, setConfirmName] = useState('');
+
+  const nameMatches =
+    !!project && confirmName.trim().toLowerCase() === project.name.trim().toLowerCase();
+
+  const deleteMutation = api.project.delete.useMutation({
+    onSuccess: () => {
+      showSnackbar('Project deleted', 'success');
+      void utils.project.list.invalidate();
+      void utils.project.getActive.invalidate();
+      handleClose();
+      router.push(`/${orgSlug}`);
+    },
+    onError: (error) => {
+      showSnackbar(error.message || 'Failed to delete project', 'error');
+    },
+  });
+
+  const handleClose = () => {
+    setConfirmName('');
+    onOpenChange(false);
+  };
+
+  const handleDelete = () => {
+    if (!project || !nameMatches) return;
+    deleteMutation.mutate({
+      projectId: project.id,
+      confirmName,
+    });
+  };
+
+  if (!project) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth={false}
+      PaperProps={{
+        sx: {
+          width: 440,
+          borderRadius: '16px',
+          overflow: 'hidden',
+          boxShadow: `0 24px 64px -16px ${alpha('#000', 0.2)}, 0 8px 20px -8px ${alpha('#000', 0.08)}`,
+        },
+      }}
+    >
+      {/* Red accent bar */}
+      <Box
+        sx={{
+          height: 3,
+          background: `linear-gradient(90deg, ${theme.palette.error.main}, ${alpha(theme.palette.error.main, 0.3)})`,
+        }}
+      />
+
+      <Box sx={{ p: 3.5, pb: 0 }}>
+        {/* Icon + Title block */}
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 1.5 }}>
+          <Box
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: '12px',
+              bgcolor: alpha(theme.palette.error.main, 0.08),
+              border: `1px solid ${alpha(theme.palette.error.main, 0.12)}`,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >
+            <Trash2 size={22} style={{ color: theme.palette.error.main }} />
+          </Box>
+          <Box sx={{ pt: 0.25 }}>
+            <Typography
+              sx={{
+                fontSize: '1.125rem',
+                fontWeight: 700,
+                color: 'text.primary',
+                letterSpacing: '-0.01em',
+                lineHeight: 1.3,
+              }}
+            >
+              Delete Project
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: '0.8125rem',
+                color: 'text.secondary',
+                mt: 0.25,
+                lineHeight: 1.4,
+              }}
+            >
+              This action cannot be undone
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+
+      <DialogContent sx={{ px: 3.5, pt: 2, pb: 1 }}>
+        <Typography
+          sx={{
+            fontSize: '0.8125rem',
+            color: 'text.secondary',
+            lineHeight: 1.6,
+            mb: 2.5,
+          }}
+        >
+          This will permanently delete{' '}
+          <Typography component="span" sx={{ fontWeight: 700, color: 'text.primary', fontSize: 'inherit' }}>
+            {project.name}
+          </Typography>{' '}
+          and all its data including tasks, documents, schedules, and resources.
+        </Typography>
+
+        <Typography
+          component="label"
+          htmlFor="confirm-project-name"
+          sx={{
+            display: 'block',
+            fontSize: '0.75rem',
+            fontWeight: 600,
+            color: 'text.secondary',
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+            mb: 0.75,
+          }}
+        >
+          Type <strong>{project.name}</strong> to confirm
+        </Typography>
+        <TextField
+          id="confirm-project-name"
+          value={confirmName}
+          onChange={(e) => setConfirmName(e.target.value)}
+          placeholder={project.name}
+          fullWidth
+          autoFocus
+          autoComplete="off"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && nameMatches && !deleteMutation.isPending) {
+              handleDelete();
+            }
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              borderRadius: '10px',
+              fontSize: '0.9375rem',
+              bgcolor: alpha(theme.palette.divider, 0.08),
+              transition: 'all 0.15s ease',
+              '& fieldset': {
+                borderColor: 'transparent',
+              },
+              '&:hover fieldset': {
+                borderColor: alpha(theme.palette.error.main, 0.3),
+              },
+              '&.Mui-focused fieldset': {
+                borderColor: theme.palette.error.main,
+                borderWidth: '1.5px',
+              },
+              '&.Mui-focused': {
+                bgcolor: 'background.paper',
+                boxShadow: `0 0 0 3px ${alpha(theme.palette.error.main, 0.08)}`,
+              },
+            },
+            '& .MuiOutlinedInput-input': {
+              py: 1.5,
+              px: 1.75,
+              '&::placeholder': {
+                color: alpha(theme.palette.text.secondary, 0.5),
+                opacity: 1,
+              },
+            },
+          }}
+        />
+      </DialogContent>
+
+      <DialogActions
+        sx={{
+          px: 3.5,
+          py: 2.5,
+          gap: 1,
+        }}
+      >
+        <Button
+          variant="text"
+          onClick={handleClose}
+          sx={{
+            color: 'text.secondary',
+            fontWeight: 500,
+            fontSize: '0.8125rem',
+            px: 2,
+            borderRadius: '8px',
+            '&:hover': {
+              bgcolor: alpha(theme.palette.divider, 0.12),
+              color: 'text.primary',
+            },
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="error"
+          loading={deleteMutation.isPending}
+          disabled={!nameMatches}
+          onClick={handleDelete}
+          sx={{
+            borderRadius: '8px',
+            fontWeight: 600,
+            fontSize: '0.8125rem',
+            px: 2.5,
+            py: 1,
+            textTransform: 'none',
+            boxShadow: `0 1px 3px ${alpha(theme.palette.error.main, 0.3)}`,
+            '&:hover': {
+              boxShadow: `0 4px 12px ${alpha(theme.palette.error.main, 0.35)}`,
+            },
+            '&.Mui-disabled': {
+              bgcolor: alpha(theme.palette.error.main, 0.12),
+              color: alpha(theme.palette.error.main, 0.4),
+            },
+          }}
+        >
+          Delete Project
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -65,6 +65,10 @@ export function canManageOrganization(role: string): boolean {
   return hasPermission(role, "MANAGE_ORGANIZATION");
 }
 
+export function canDeleteProjects(role: string): boolean {
+  return hasPermission(role, "DELETE_PROJECTS");
+}
+
 // Role rank for hierarchy enforcement (higher = more privileged)
 const ROLE_RANK: Record<Role, number> = {
   owner: 4,

--- a/src/lib/validations/project.ts
+++ b/src/lib/validations/project.ts
@@ -6,3 +6,9 @@ export const createProjectSchema = z.object({
 });
 
 export type CreateProjectInput = z.infer<typeof createProjectSchema>;
+
+export const deleteProjectSchema = z.object({
+  confirmName: z.string().min(1, "Please type the project name to confirm"),
+});
+
+export type DeleteProjectInput = z.infer<typeof deleteProjectSchema>;

--- a/src/server/api/routers/project.ts
+++ b/src/server/api/routers/project.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
-import { createProjectSchema } from "@/lib/validations/project";
+import { del } from "@vercel/blob";
+import { createTRPCRouter, protectedProcedure, projectProcedure } from "@/server/api/trpc";
+import { createProjectSchema, deleteProjectSchema } from "@/lib/validations/project";
+import { canDeleteProjects } from "@/lib/permissions";
 import { getActiveOrganizationId } from "@/server/api/helpers/getActiveOrganization";
 import { getActiveProjectId } from "@/server/api/helpers/getActiveProject";
 import { getTemplateData } from "@/server/gantt/templates";
@@ -321,5 +323,50 @@ export const projectRouter = createTRPCRouter({
       });
 
       return project;
+    }),
+
+  delete: projectProcedure
+    .input(deleteProjectSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!canDeleteProjects(ctx.projectMember.role)) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Insufficient permissions to delete projects" });
+      }
+
+      // Verify confirmation name matches
+      if (input.confirmName.trim().toLowerCase() !== ctx.project.name.trim().toLowerCase()) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Project name does not match" });
+      }
+
+      // Collect blob URLs for cleanup (documents + task cover images)
+      const [documents, tasksWithCovers] = await Promise.all([
+        ctx.db.document.findMany({
+          where: { projectId: ctx.project.id },
+          select: { blobUrl: true },
+        }),
+        ctx.db.ganttTask.findMany({
+          where: { projectId: ctx.project.id, coverImageUrl: { not: null } },
+          select: { coverImageUrl: true },
+        }),
+      ]);
+
+      const blobUrls = [
+        ...documents.map((d) => d.blobUrl),
+        ...tasksWithCovers.map((t) => t.coverImageUrl).filter((url): url is string => !!url),
+      ];
+
+      // Best-effort blob cleanup
+      if (blobUrls.length > 0) {
+        try {
+          await del(blobUrls);
+        } catch (e) {
+          console.error("Blob cleanup failed for project", ctx.project.id, e);
+        }
+      }
+
+      // Delete project — cascade handles all child records,
+      // onDelete: SetNull handles User.activeProjectId
+      await ctx.db.project.delete({ where: { id: ctx.project.id } });
+
+      return { success: true, organizationId: ctx.organization.id };
     }),
 });


### PR DESCRIPTION
## Summary
- Add delete project functionality with confirmation dialog and `project.delete` tRPC procedure
- Rename team page to manage page with tabbed layout (Members, Pending, Settings)
- Add account settings modal (skeleton) triggered from sidebar/mobile user menu
- Add `DELETE_PROJECTS` permission for owner and admin roles
- Clean up unused Gantt toolbar indent/outdent props

## Test plan
- [ ] Click "Account Settings" in the sidebar user menu — modal opens with tabbed navigation
- [ ] Verify tabs switch content area in the settings modal
- [ ] Navigate to project manage page and verify tabs work
- [ ] Delete a project from the settings tab and confirm redirect
- [ ] Verify mobile drawer "Account Settings" also opens the modal