### PR TITLE
Fix Ably ChannelProvider error and dedupe import-in-the-middle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1417,18 +1417,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@fastify/otel/node_modules/import-in-the-middle": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
-      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-import-attributes": "^1.9.5",
-        "cjs-module-lexer": "^2.2.0",
-        "module-details-from-path": "^1.0.4"
-      }
-    },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
@@ -3143,18 +3131,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
-      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-import-attributes": "^1.9.5",
-        "cjs-module-lexer": "^2.2.0",
-        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
   "ct3aMetadata": {
     "initVersion": "7.40.0"
   },
-  "packageManager": "npm@11.3.0"
+  "packageManager": "npm@11.3.0",
+  "overrides": {
+    "import-in-the-middle": "3.0.0"
+  }
 }

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -16,6 +16,7 @@ import { useTaskPopover } from './hooks/useTaskPopover';
 import { useGanttControls } from './hooks/useGanttControls';
 import type { BryntumTaskRecord, BryntumGanttInstance } from './types';
 import { validateParentDuration } from './utils/ganttValidation';
+import { ChannelProvider } from 'ably/react';
 import { useGanttRealtime } from './hooks/useGanttRealtime';
 import GanttPresence from './components/GanttPresence';
 import GanttLoadingSpinner from './components/GanttLoadingSpinner';
@@ -66,7 +67,7 @@ interface BryntumGanttCoreProps extends BryntumGanttWrapperProps {
 
 // ─── Realtime wrapper — only mounted inside AblyProvider ────────────────────
 
-function BryntumGanttRealtimeWrapper({
+function BryntumGanttRealtimeInner({
   ganttControls,
   ...props
 }: BryntumGanttWrapperProps & { ganttControls: ReturnType<typeof useGanttControls> }) {
@@ -85,6 +86,17 @@ function BryntumGanttRealtimeWrapper({
       isApplyingRemoteRef={isApplyingRemoteRef}
       presenceData={presenceData}
     />
+  );
+}
+
+function BryntumGanttRealtimeWrapper(
+  props: BryntumGanttWrapperProps & { ganttControls: ReturnType<typeof useGanttControls> },
+) {
+  const channelName = `project:${props.projectId}:gantt`;
+  return (
+    <ChannelProvider channelName={channelName}>
+      <BryntumGanttRealtimeInner {...props} />
+    </ChannelProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- Wrap Ably realtime hooks with `ChannelProvider` to fix "Could not find a parent ChannelProvider" crash on preview/production Gantt pages
- Add npm `overrides` to deduplicate `import-in-the-middle` (3.0.0) and eliminate OpenTelemetry version mismatch warnings during builds
- Fixed mismatched `ABLY_API_KEY` in Vercel preview environment

## Test plan
- [ ] Verify Gantt page loads without ChannelProvider errors on preview
- [ ] Verify real-time presence and sync work on the Gantt chart
- [ ] Verify build has no `import-in-the-middle` version warnings