### PR TITLE
Add project location migration, redesign document explorer

### DIFF
--- a/prisma/migrations/20260326000000_add_project_location/migration.sql
+++ b/prisma/migrations/20260326000000_add_project_location/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN "location" TEXT NOT NULL DEFAULT '';

--- a/prisma/migrations/20260326000000_add_project_location/migration.sql
+++ b/prisma/migrations/20260326000000_add_project_location/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "Project" ADD COLUMN "location" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "Project" ADD COLUMN IF NOT EXISTS "location" TEXT NOT NULL DEFAULT '';

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/document-explorer/page.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/document-explorer/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Box, Typography, Skeleton, useTheme } from '@mui/material';
+import { Box, Typography, Skeleton, Tooltip, useTheme } from '@mui/material';
 import Pagination from '@/components/documents/Pagination';
-import { FileText, LayoutGrid, List, ChevronDown, Sparkles, Search } from 'lucide-react';
+import { FileText, ChevronDown, Sparkles, Search, AlignJustify, Table2 } from 'lucide-react';
 import { keepPreviousData } from '@tanstack/react-query';
 import { api } from '@/trpc/react';
 import { useProjectContext } from '@/components/providers/ProjectProvider';
@@ -12,8 +12,8 @@ import DocumentToolbar from '@/components/documents/DocumentToolbar';
 import DocumentFilterTabs from '@/components/documents/DocumentFilterTabs';
 import DocumentFilterPopup from '@/components/documents/DocumentFilterPopup';
 import type { LinkFilter } from '@/components/documents/DocumentFilterPopup';
-import DocumentCard from '@/components/documents/DocumentCard';
-import DocumentTable from '@/components/documents/DocumentTable';
+import DocumentCardCompact from '@/components/documents/DocumentCardCompact';
+import DocumentCardDetail from '@/components/documents/DocumentCardDetail';
 import type { DocumentResult } from '@/components/documents/types';
 
 const LIMIT = 20;
@@ -26,7 +26,7 @@ export default function DocumentExplorerPage() {
   const [page, setPage] = useState(1);
   const [aiEnabled, setAiEnabled] = useState(false);
   const [aiSearchQuery, setAiSearchQuery] = useState('');
-  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+  const [viewMode, setViewMode] = useState<'compact' | 'detail'>('compact');
 
   // Filter state
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
@@ -188,45 +188,34 @@ export default function DocumentExplorerPage() {
             </Box>
 
             {/* View toggle */}
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
-              <Box
-                component="button"
-                onClick={() => setViewMode('grid')}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  width: 32,
-                  height: 32,
-                  borderRadius: '6px',
-                  border: 'none',
-                  bgcolor: viewMode === 'grid' ? 'secondary.main' : 'transparent',
-                  color: viewMode === 'grid' ? 'text.primary' : 'text.secondary',
-                  cursor: 'pointer',
-                  '&:hover': { bgcolor: 'secondary.main' },
-                }}
-              >
-                <LayoutGrid size={16} />
-              </Box>
-              <Box
-                component="button"
-                onClick={() => setViewMode('list')}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  width: 32,
-                  height: 32,
-                  borderRadius: '6px',
-                  border: 'none',
-                  bgcolor: viewMode === 'list' ? 'secondary.main' : 'transparent',
-                  color: viewMode === 'list' ? 'text.primary' : 'text.secondary',
-                  cursor: 'pointer',
-                  '&:hover': { bgcolor: 'secondary.main' },
-                }}
-              >
-                <List size={16} />
-              </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '2px', bgcolor: 'background.paper', borderRadius: '8px', border: '1px solid', borderColor: 'divider', p: '2px' }}>
+              {([
+                { mode: 'compact' as const, icon: <AlignJustify size={14} />, label: 'Compact' },
+                { mode: 'detail' as const, icon: <Table2 size={14} />, label: 'Detail' },
+              ]).map(({ mode, icon, label }) => (
+                <Tooltip key={mode} title={label}>
+                  <Box
+                    component="button"
+                    onClick={() => setViewMode(mode)}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: 30,
+                      height: 28,
+                      borderRadius: '6px',
+                      border: 'none',
+                      bgcolor: viewMode === mode ? 'secondary.main' : 'transparent',
+                      color: viewMode === mode ? 'text.primary' : 'text.secondary',
+                      cursor: 'pointer',
+                      transition: 'background-color 0.12s',
+                      '&:hover': { bgcolor: viewMode === mode ? 'secondary.main' : 'action.hover' },
+                    }}
+                  >
+                    {icon}
+                  </Box>
+                </Tooltip>
+              ))}
             </Box>
           </Box>
         </Box>
@@ -239,56 +228,44 @@ export default function DocumentExplorerPage() {
 
         // Initial browse (no search query) → skeleton cards
         if (!activeSearchText) {
-          return viewMode === 'grid' ? (
-            <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, 280px)', gap: 2, alignItems: 'start' }}>
+          return viewMode === 'detail' ? (
+            <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, 260px)', gap: 2, alignItems: 'start' }}>
               {Array.from({ length: 8 }).map((_, i) => (
                 <Box key={i} sx={{ borderRadius: '12px', border: '1px solid', borderColor: 'divider', overflow: 'hidden', bgcolor: 'background.paper' }}>
-                  {/* Image area — 160px, matches card image container */}
-                  <Skeleton variant="rectangular" height={160} sx={{ display: 'block' }} />
-
-                  {/* Card body — px 16, pt 16, pb 12, gap 12 */}
-                  <Box sx={{ px: '16px', pt: '16px', pb: '12px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
-                    {/* Title — single truncated line */}
-                    <Skeleton variant="rectangular" width="72%" height={13} sx={{ borderRadius: '4px' }} />
-
-                    {/* Category row — small icon + pill badge */}
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
-                      <Skeleton variant="circular" width={11} height={11} />
-                      <Skeleton variant="rectangular" width={72} height={20} sx={{ borderRadius: '999px' }} />
-                    </Box>
-
-                    {/* Meta row — date left, file size right */}
-                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                      <Skeleton variant="rectangular" width={88} height={11} sx={{ borderRadius: '4px' }} />
-                      <Skeleton variant="rectangular" width={36} height={11} sx={{ borderRadius: '4px' }} />
-                    </Box>
-
-                    {/* Task link row — icon + short label, pt 6 */}
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: '6px', pt: '6px' }}>
-                      <Skeleton variant="circular" width={12} height={12} />
-                      <Skeleton variant="rectangular" width={80} height={11} sx={{ borderRadius: '4px' }} />
-                    </Box>
+                  {/* Header */}
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, px: '16px', pt: '16px', pb: '12px' }}>
+                    <Skeleton variant="rounded" width={40} height={40} sx={{ borderRadius: '8px' }} />
+                    <Skeleton variant="rectangular" width="60%" height={13} sx={{ borderRadius: '4px' }} />
                   </Box>
-
-                  {/* Divider */}
+                  <Box sx={{ height: '1px', bgcolor: 'divider', mx: '16px' }} />
+                  {/* Meta rows */}
+                  <Box sx={{ px: '16px', py: '12px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+                    {Array.from({ length: 5 }).map((_, j) => (
+                      <Box key={j} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Skeleton variant="circular" width={12} height={12} />
+                        <Skeleton variant="rectangular" width={50} height={11} sx={{ borderRadius: '4px' }} />
+                        <Skeleton variant="rectangular" width={80} height={11} sx={{ borderRadius: '4px' }} />
+                      </Box>
+                    ))}
+                  </Box>
                   <Box sx={{ height: '1px', bgcolor: 'divider' }} />
-
-                  {/* Action row — px 16, py 8 — 3 icons left, 1 right */}
-                  <Box sx={{ px: '16px', py: '8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                      <Skeleton variant="circular" width={14} height={14} />
-                      <Skeleton variant="circular" width={14} height={14} />
-                      <Skeleton variant="circular" width={14} height={14} />
-                    </Box>
-                    <Skeleton variant="circular" width={14} height={14} />
+                  <Box sx={{ px: '16px', py: '10px', display: 'flex', gap: 1 }}>
+                    <Skeleton variant="rounded" width={80} height={24} sx={{ borderRadius: '6px' }} />
+                    <Skeleton variant="rounded" width={60} height={24} sx={{ borderRadius: '6px' }} />
                   </Box>
                 </Box>
               ))}
             </Box>
           ) : (
-            <Box>
-              {Array.from({ length: 6 }).map((_, i) => (
-                <Skeleton key={i} height={48} sx={{ mb: 0.5 }} />
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              {Array.from({ length: 8 }).map((_, i) => (
+                <Box key={i} sx={{ display: 'flex', alignItems: 'center', gap: 1.5, px: '14px', py: '10px', borderRadius: '10px', border: '1px solid', borderColor: 'divider', bgcolor: 'background.paper' }}>
+                  <Skeleton variant="rounded" width={48} height={48} sx={{ borderRadius: '8px', flexShrink: 0 }} />
+                  <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                    <Skeleton variant="rectangular" width="55%" height={13} sx={{ borderRadius: '4px' }} />
+                    <Skeleton variant="rectangular" width="80%" height={11} sx={{ borderRadius: '4px' }} />
+                  </Box>
+                </Box>
               ))}
             </Box>
           );
@@ -395,33 +372,36 @@ export default function DocumentExplorerPage() {
       )}
 
       {/* Results */}
-      {!isLoading && !showFuzzyLoader && rawResults.length > 0 && (
-        viewMode === 'grid' ? (
-          <Box
-            sx={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fill, 280px)',
-              gap: 2,
-              alignItems: 'start',
-              opacity: isBackgroundFetching ? 0.6 : 1,
-              transition: 'opacity 0.2s',
-            }}
-          >
+      {!isLoading && !showFuzzyLoader && rawResults.length > 0 && (() => {
+        const opacitySx = { opacity: isBackgroundFetching ? 0.6 : 1, transition: 'opacity 0.2s' };
+
+        if (viewMode === 'detail') {
+          return (
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, 260px)',
+                gap: 2,
+                alignItems: 'start',
+                ...opacitySx,
+              }}
+            >
+              {rawResults.map((doc) => (
+                <DocumentCardDetail key={doc.id} doc={doc} organizationId={organizationId} />
+              ))}
+            </Box>
+          );
+        }
+
+        // Compact view — stacked rows with thumbnails
+        return (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '6px', ...opacitySx }}>
             {rawResults.map((doc) => (
-              <DocumentCard key={doc.id} doc={doc} organizationId={organizationId} />
+              <DocumentCardCompact key={doc.id} doc={doc} organizationId={organizationId} />
             ))}
           </Box>
-        ) : (
-          <Box
-            sx={{
-              opacity: isBackgroundFetching ? 0.6 : 1,
-              transition: 'opacity 0.2s',
-            }}
-          >
-            <DocumentTable docs={rawResults} />
-          </Box>
-        )
-      )}
+        );
+      })()}
     </Box>
   );
 }

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/layout.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/layout.tsx
@@ -48,6 +48,7 @@ export default async function ProjectLayout({
         slug: projectSlug,
       },
     },
+    select: { id: true, slug: true, name: true, organizationId: true },
   });
 
   // Project not found - redirect to org home

--- a/src/components/documents/DocumentCardCompact.tsx
+++ b/src/components/documents/DocumentCardCompact.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useState } from 'react';
+import { Box, Typography, useTheme, alpha } from '@mui/material';
+import {
+  Download,
+  Trash2,
+  Ellipsis,
+  FileText,
+  FileSpreadsheet,
+  SquareCheck,
+  CircleDashed,
+} from 'lucide-react';
+import { format } from 'date-fns';
+import { formatFileSize } from '@/lib/utils/formatting';
+import { getCategoryLabel } from '@/lib/constants/documentCategories';
+import DeleteDocumentDialog from './DeleteDocumentDialog';
+import type { DocumentResult } from './types';
+
+interface DocumentCardCompactProps {
+  doc: DocumentResult;
+  organizationId: string;
+}
+
+/**
+ * Option C: "Two-Line Compact" — Balanced
+ * Small square thumbnail (48×48) on the left. Row 1: filename + category badge.
+ * Row 2: date · size · uploader · task status. Actions on hover.
+ */
+export default function DocumentCardCompact({ doc, organizationId }: DocumentCardCompactProps) {
+  const theme = useTheme();
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const isImage = doc.mimeType.startsWith('image/');
+  const categoryLabel = getCategoryLabel(doc.folderId);
+
+  return (
+    <Box
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        px: '14px',
+        py: '10px',
+        borderRadius: '10px',
+        border: '1px solid',
+        borderColor: hovered ? alpha(theme.palette.primary.main, 0.3) : 'divider',
+        bgcolor: 'background.paper',
+        transition: 'border-color 0.2s, background-color 0.15s',
+        cursor: 'pointer',
+        '&:hover': {
+          bgcolor: alpha(theme.palette.primary.main, 0.02),
+        },
+      }}
+    >
+      {/* Thumbnail */}
+      <Box
+        sx={{
+          width: 48,
+          height: 48,
+          borderRadius: '8px',
+          bgcolor: 'background.default',
+          border: '1px solid',
+          borderColor: 'divider',
+          overflow: 'hidden',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        {isImage ? (
+          <Box
+            component="img"
+            src={doc.blobUrl}
+            alt={doc.name}
+            sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
+          />
+        ) : (
+          doc.mimeType.includes('spreadsheet') || doc.mimeType.includes('excel') || doc.mimeType === 'text/csv'
+            ? <FileSpreadsheet size={20} style={{ color: theme.palette.text.disabled }} />
+            : <FileText size={20} style={{ color: theme.palette.text.disabled }} />
+        )}
+      </Box>
+
+      {/* Text content */}
+      <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        {/* Row 1: name + badge */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+          <Typography
+            sx={{
+              fontSize: 13,
+              fontWeight: 600,
+              lineHeight: 1,
+              color: 'text.primary',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              flex: 1,
+              minWidth: 0,
+            }}
+          >
+            {doc.name}
+          </Typography>
+          <Box
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              borderRadius: '4px',
+              bgcolor: 'docExplorer.badgeBg',
+              px: '6px',
+              py: '2px',
+              flexShrink: 0,
+            }}
+          >
+            <Typography sx={{ fontSize: 10, fontWeight: 600, lineHeight: 1, color: 'text.secondary' }}>
+              {categoryLabel}
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* Row 2: meta */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+          <Typography sx={{ fontSize: 11, lineHeight: 1, color: 'text.secondary' }}>
+            {format(new Date(doc.createdAt), 'MMM d, yyyy')}
+          </Typography>
+          <Typography sx={{ fontSize: 11, lineHeight: 1, color: 'text.disabled' }}>·</Typography>
+          <Typography sx={{ fontSize: 11, lineHeight: 1, color: 'text.secondary' }}>
+            {formatFileSize(doc.size)}
+          </Typography>
+          {doc.uploadedBy.name && (
+            <>
+              <Typography sx={{ fontSize: 11, lineHeight: 1, color: 'text.disabled' }}>·</Typography>
+              <Typography sx={{ fontSize: 11, lineHeight: 1, color: 'text.secondary' }}>
+                {doc.uploadedBy.name}
+              </Typography>
+            </>
+          )}
+          <Typography sx={{ fontSize: 11, lineHeight: 1, color: 'text.disabled' }}>·</Typography>
+          {doc.taskId ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '3px' }}>
+              <SquareCheck size={10} style={{ color: theme.palette.docExplorer.linkedGreen }} />
+              <Typography sx={{ fontSize: 11, fontWeight: 500, lineHeight: 1, color: 'docExplorer.linkedGreen' }}>
+                Linked
+              </Typography>
+            </Box>
+          ) : (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '3px' }}>
+              <CircleDashed size={10} style={{ color: theme.palette.text.disabled }} />
+              <Typography sx={{ fontSize: 11, lineHeight: 1, color: 'text.disabled' }}>
+                Unlinked
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      </Box>
+
+      {/* Hover actions */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+          opacity: hovered ? 1 : 0,
+          transition: 'opacity 0.15s',
+          flexShrink: 0,
+        }}
+      >
+        <Box
+          component="a"
+          href={doc.blobUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 28,
+            height: 28,
+            borderRadius: '6px',
+            color: 'text.secondary',
+            '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
+          }}
+        >
+          <Download size={14} />
+        </Box>
+        <Box
+          component="button"
+          onClick={(e: React.MouseEvent) => { e.stopPropagation(); setDeleteOpen(true); }}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 28,
+            height: 28,
+            borderRadius: '6px',
+            border: 'none',
+            bgcolor: 'transparent',
+            cursor: 'pointer',
+            color: 'text.secondary',
+            '&:hover': { bgcolor: 'action.hover', color: 'docExplorer.destructiveMain' },
+          }}
+        >
+          <Trash2 size={14} />
+        </Box>
+        <Box
+          component="button"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 28,
+            height: 28,
+            borderRadius: '6px',
+            border: 'none',
+            bgcolor: 'transparent',
+            cursor: 'pointer',
+            color: 'text.secondary',
+            '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
+          }}
+        >
+          <Ellipsis size={14} />
+        </Box>
+      </Box>
+
+      <DeleteDocumentDialog
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        documentId={doc.id}
+        documentName={doc.name}
+        organizationId={organizationId}
+      />
+    </Box>
+  );
+}

--- a/src/components/documents/DocumentCardDetail.tsx
+++ b/src/components/documents/DocumentCardDetail.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useState } from 'react';
+import { Box, Typography, useTheme, alpha } from '@mui/material';
+import {
+  Download,
+  Trash2,
+  FileText,
+  FileSpreadsheet,
+  FileImage,
+  SquareCheck,
+  CircleDashed,
+  Folder,
+  Calendar,
+  HardDrive,
+  User,
+} from 'lucide-react';
+import { format } from 'date-fns';
+import { formatFileSize } from '@/lib/utils/formatting';
+import { getCategoryLabel } from '@/lib/constants/documentCategories';
+import DeleteDocumentDialog from './DeleteDocumentDialog';
+import type { DocumentResult } from './types';
+
+interface DocumentCardDetailProps {
+  doc: DocumentResult;
+  organizationId: string;
+}
+
+function getDetailFileIcon(mimeType: string, color: string) {
+  if (mimeType.startsWith('image/')) return <FileImage size={22} style={{ color }} />;
+  if (mimeType.includes('spreadsheet') || mimeType.includes('excel') || mimeType === 'text/csv')
+    return <FileSpreadsheet size={22} style={{ color }} />;
+  return <FileText size={22} style={{ color }} />;
+}
+
+/**
+ * Option D: "Stacked Metadata" — Detail-Rich
+ * No preview. Pure metadata card with label:value pairs stacked vertically.
+ * Everything visible, no hidden info. Explicit action buttons.
+ */
+export default function DocumentCardDetail({ doc, organizationId }: DocumentCardDetailProps) {
+  const theme = useTheme();
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const isImage = doc.mimeType.startsWith('image/');
+  const categoryLabel = getCategoryLabel(doc.folderId);
+
+  const metaRows = [
+    { icon: <Folder size={12} style={{ color: theme.palette.text.disabled }} />, label: 'Category', value: categoryLabel },
+    { icon: <Calendar size={12} style={{ color: theme.palette.text.disabled }} />, label: 'Uploaded', value: format(new Date(doc.createdAt), 'MMM d, yyyy') },
+    { icon: <HardDrive size={12} style={{ color: theme.palette.text.disabled }} />, label: 'Size', value: formatFileSize(doc.size) },
+    { icon: <User size={12} style={{ color: theme.palette.text.disabled }} />, label: 'By', value: doc.uploadedBy.name ?? doc.uploadedBy.email },
+  ];
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        borderRadius: '12px',
+        border: '1px solid',
+        borderColor: 'divider',
+        bgcolor: 'background.paper',
+        overflow: 'hidden',
+        transition: 'border-color 0.2s',
+        '&:hover': {
+          borderColor: alpha(theme.palette.primary.main, 0.3),
+        },
+      }}
+    >
+      {/* Header — thumbnail + filename */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          px: '16px',
+          pt: '16px',
+          pb: '12px',
+        }}
+      >
+        <Box
+          sx={{
+            width: 48,
+            height: 48,
+            borderRadius: '8px',
+            bgcolor: 'background.default',
+            border: '1px solid',
+            borderColor: 'divider',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+            overflow: 'hidden',
+          }}
+        >
+          {isImage ? (
+            <Box
+              component="img"
+              src={doc.blobUrl}
+              alt={doc.name}
+              sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
+            />
+          ) : (
+            getDetailFileIcon(doc.mimeType, theme.palette.text.secondary)
+          )}
+        </Box>
+        <Typography
+          sx={{
+            fontSize: 13,
+            fontWeight: 600,
+            lineHeight: 1.3,
+            color: 'text.primary',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            flex: 1,
+            minWidth: 0,
+          }}
+        >
+          {doc.name}
+        </Typography>
+      </Box>
+
+      {/* Divider */}
+      <Box sx={{ height: '1px', bgcolor: 'divider', mx: '16px' }} />
+
+      {/* Metadata rows */}
+      <Box sx={{ px: '16px', py: '12px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+        {metaRows.map((row) => (
+          <Box key={row.label} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {row.icon}
+            <Typography sx={{ fontSize: 11, fontWeight: 500, lineHeight: 1, color: 'text.disabled', width: 60, flexShrink: 0 }}>
+              {row.label}
+            </Typography>
+            <Typography sx={{ fontSize: 11, fontWeight: 500, lineHeight: 1, color: 'text.primary' }}>
+              {row.value}
+            </Typography>
+          </Box>
+        ))}
+
+        {/* Task row */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {doc.taskId ? (
+            <SquareCheck size={12} style={{ color: theme.palette.docExplorer.linkedGreen }} />
+          ) : (
+            <CircleDashed size={12} style={{ color: theme.palette.text.disabled }} />
+          )}
+          <Typography sx={{ fontSize: 11, fontWeight: 500, lineHeight: 1, color: 'text.disabled', width: 60, flexShrink: 0 }}>
+            Task
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: 11,
+              fontWeight: 500,
+              lineHeight: 1,
+              color: doc.taskId ? 'docExplorer.linkedGreen' : 'text.disabled',
+            }}
+          >
+            {doc.taskId ? 'Linked' : 'Not linked'}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Divider */}
+      <Box sx={{ height: '1px', bgcolor: 'divider' }} />
+
+      {/* Action buttons */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: '16px', py: '10px' }}>
+        <Box
+          component="a"
+          href={doc.blobUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            px: '10px',
+            py: '5px',
+            borderRadius: '6px',
+            border: '1px solid',
+            borderColor: 'divider',
+            bgcolor: 'transparent',
+            textDecoration: 'none',
+            cursor: 'pointer',
+            transition: 'background-color 0.12s',
+            '&:hover': { bgcolor: 'action.hover' },
+          }}
+        >
+          <Download size={12} style={{ color: theme.palette.text.secondary }} />
+          <Typography sx={{ fontSize: 11, fontWeight: 500, lineHeight: 1, color: 'text.secondary' }}>
+            Download
+          </Typography>
+        </Box>
+        <Box
+          component="button"
+          onClick={(e: React.MouseEvent) => { e.stopPropagation(); setDeleteOpen(true); }}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            px: '10px',
+            py: '5px',
+            borderRadius: '6px',
+            border: '1px solid',
+            borderColor: 'divider',
+            bgcolor: 'transparent',
+            cursor: 'pointer',
+            transition: 'background-color 0.12s, color 0.12s',
+            '&:hover': { bgcolor: 'docExplorer.destructiveLight', borderColor: 'docExplorer.destructiveMain' },
+          }}
+        >
+          <Trash2 size={12} style={{ color: theme.palette.text.secondary }} />
+          <Typography sx={{ fontSize: 11, fontWeight: 500, lineHeight: 1, color: 'text.secondary' }}>
+            Delete
+          </Typography>
+        </Box>
+      </Box>
+
+      <DeleteDocumentDialog
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        documentId={doc.id}
+        documentName={doc.name}
+        organizationId={organizationId}
+      />
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds missing Prisma migration for `Project.location` column (fixes Sentry CINNABAR-CLOCK-6 & 7 — `PrismaClientKnownRequestError` on preview/production)
- Adds explicit `select` clause to project layout query to only fetch needed fields
- Redesigns document explorer with new compact (row) and detail (card) view modes, replacing the old grid/list toggle

## Test plan
- [ ] Verify Vercel preview build applies the migration successfully
- [ ] Confirm project pages load without Prisma errors on preview
- [ ] Test compact and detail view toggles in document explorer
- [ ] Verify document actions (download, delete) work in both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)