### PR TITLE
Redesign error pages with branding

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -2,6 +2,8 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { useEffect } from "react";
+import { Box, Typography, Button } from "@mui/material";
+import { LogoIcon } from "@/components/ui/Logo";
 
 export default function Error({
   error,
@@ -15,22 +17,52 @@ export default function Error({
   }, [error]);
 
   return (
-    <div style={{ padding: 40, fontFamily: "system-ui, sans-serif", textAlign: "center" }}>
-      <h2>Something went wrong</h2>
-      <p style={{ color: "#666" }}>An unexpected error occurred.</p>
-      <button
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "100vh",
+        bgcolor: "background.default",
+        textAlign: "center",
+        px: 2,
+      }}
+    >
+      <LogoIcon size={40} sx={{ mb: 3, color: "text.primary" }} />
+
+      <Typography
+        variant="h4"
+        sx={{ fontWeight: 600, mb: 1, color: "text.primary" }}
+      >
+        Something went wrong
+      </Typography>
+
+      <Typography
+        sx={{ color: "text.secondary", fontSize: "0.95rem", mb: 3 }}
+      >
+        An unexpected error occurred.
+      </Typography>
+
+      <Button
         onClick={reset}
-        style={{
-          marginTop: 16,
-          padding: "8px 16px",
-          borderRadius: 6,
-          border: "1px solid #ccc",
-          cursor: "pointer",
-          background: "#fff",
+        variant="contained"
+        sx={{
+          bgcolor: "text.primary",
+          color: "background.default",
+          textTransform: "none",
+          fontWeight: 500,
+          px: 3,
+          py: 1,
+          borderRadius: "8px",
+          "&:hover": {
+            bgcolor: "text.primary",
+            opacity: 0.9,
+          },
         }}
       >
         Try again
-      </button>
-    </div>
+      </Button>
+    </Box>
   );
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -17,18 +17,67 @@ export default function GlobalError({
   return (
     <html>
       <body>
-        <div style={{ padding: 40, fontFamily: "system-ui, sans-serif", textAlign: "center" }}>
-          <h2>Something went wrong</h2>
-          <p style={{ color: "#666" }}>An unexpected error occurred.</p>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: "100vh",
+            backgroundColor: "#fafafa",
+            textAlign: "center",
+            padding: "0 16px",
+            fontFamily:
+              'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+          }}
+        >
+          <svg
+            width="40"
+            height="40"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{ marginBottom: 24 }}
+          >
+            <rect x="3" y="3" width="3" height="18" rx="0.5" fill="#1a1a1a" />
+            <rect x="3" y="3" width="18" height="3" rx="0.5" fill="#1a1a1a" />
+            <rect x="18" y="3" width="3" height="10" rx="0.5" fill="#1a1a1a" />
+            <rect x="10" y="9" width="2.5" height="12" rx="0.5" fill="#1a1a1a" />
+          </svg>
+
+          <h2
+            style={{
+              fontSize: "2.125rem",
+              fontWeight: 600,
+              margin: "0 0 8px",
+              color: "#1a1a1a",
+            }}
+          >
+            Something went wrong
+          </h2>
+
+          <p
+            style={{
+              fontSize: "0.95rem",
+              color: "#666",
+              margin: "0 0 24px",
+            }}
+          >
+            An unexpected error occurred.
+          </p>
+
           <button
             onClick={reset}
             style={{
-              marginTop: 16,
-              padding: "8px 16px",
-              borderRadius: 6,
-              border: "1px solid #ccc",
+              backgroundColor: "#1a1a1a",
+              color: "#fafafa",
+              border: "none",
+              padding: "8px 24px",
+              borderRadius: 8,
+              fontSize: "0.875rem",
+              fontWeight: 500,
               cursor: "pointer",
-              background: "#fff",
+              fontFamily: "inherit",
             }}
           >
             Try again


### PR DESCRIPTION
## Summary
- Redesigned `error.tsx` to use MUI components (Box, Typography, Button) with the LogoIcon and theme tokens, matching the existing `not-found.tsx` style
- Redesigned `global-error.tsx` with inline styles and an inline SVG logo to visually match, since it renders outside the MUI theme provider

## Test plan
- [ ] Trigger a runtime error in a route to verify `error.tsx` renders with branding
- [ ] Verify the "Try again" button calls `reset` and recovers from the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)