### PR TITLE
Make project location field required

### DIFF
--- a/src/lib/validations/project.ts
+++ b/src/lib/validations/project.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const createProjectSchema = z.object({
   name: z.string().min(1, "Project name is required").max(100).trim(),
-  location: z.string().max(200).trim(),
+  location: z.string().min(1, "Location is required").max(200).trim(),
   template: z.enum(["BLANK"]).default("BLANK").optional(),
 });
 


### PR DESCRIPTION
Makes the location field required when creating a new project. Adds a `min(1)` Zod validation with an error message so users must provide a location before submitting.