### PR TITLE
Disable Bryntum built-in loading mask in Gantt chart

### DIFF
--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -40,6 +40,8 @@ export function createGanttConfig(
   return {
     // Performance optimizations
     autoHeight: false,
+    loadMask: null,
+    syncMask: null,
     rowHeight: 45, // Consistent row height for better performance
     animateTreeNodeToggle: false, // Disable animations for faster rendering
     detectCSSCompatibilityIssues: false,

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -143,6 +143,7 @@ export type GanttConfig = {
   bufferCoef?: number;
   detectCSSCompatibilityIssues: boolean;
   loadMask?: string | null | Record<string, unknown>;
+  syncMask?: string | null | Record<string, unknown>;
   rowHeight?: number;
   animateTreeNodeToggle?: boolean;
   project: {


### PR DESCRIPTION
## Summary
- Disables Bryntum's built-in `loadMask` and `syncMask` overlays so only the custom `GanttLoadingSpinner` (3D cube) is shown during data loading and syncing.

## Test plan
- [ ] Open Gantt chart and verify only the custom 3D cube loader appears during initial load
- [ ] Make a task change and verify no "Saving changes..." mask appears during sync
- [ ] Verify chart renders normally after load completes