### PR TITLE
Add version control for Gantt chart schedules

### DIFF
--- a/prisma/migrations/20260401000000_add_schedule_version/migration.sql
+++ b/prisma/migrations/20260401000000_add_schedule_version/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "ScheduleVersion" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "snapshot" JSONB NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ScheduleVersion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ScheduleVersion_projectId_createdAt_idx" ON "ScheduleVersion"("projectId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ScheduleVersion" ADD CONSTRAINT "ScheduleVersion_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ScheduleVersion" ADD CONSTRAINT "ScheduleVersion_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
     notifications      Notification[]
     activeOrganization Organization?    @relation("ActiveOrganization", fields: [activeOrganizationId], references: [id], onDelete: SetNull)
     activeProject      Project?         @relation("ActiveProject", fields: [activeProjectId], references: [id], onDelete: SetNull)
+    scheduleVersions   ScheduleVersion[]
 }
 
 model Session {
@@ -144,6 +145,7 @@ model Project {
     ganttAssignments GanttAssignment[]
     ganttTimeRanges GanttTimeRange[]
     activeUsers     User[]           @relation("ActiveProject")
+    scheduleVersions ScheduleVersion[]
 
     @@unique([organizationId, slug])
     @@index([organizationId])
@@ -347,4 +349,18 @@ model GanttTimeRange {
     project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
     @@index([projectId])
+}
+
+model ScheduleVersion {
+    id          String   @id @default(cuid())
+    projectId   String
+    name        String
+    snapshot    Json
+    createdById String
+    createdAt   DateTime @default(now())
+
+    project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+    createdBy User    @relation(fields: [createdById], references: [id], onDelete: Cascade)
+
+    @@index([projectId, createdAt])
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { LoadingProvider } from "@/components/providers/LoadingProvider";
 import ThemeRegistry from "@/components/providers/ThemeRegistry";
 import { SnackbarProvider } from "@/hooks/useSnackbar";
 
+
 export const metadata: Metadata = {
   title: "BuildTrack Pro",
   description: "Construction project management",

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback, type CSSProperties } from 'react';
 import { BryntumGantt } from '@bryntum/gantt-react';
+import { Menu } from '@bryntum/gantt';
 import '@bryntum/gantt/gantt.css';
 import { Box } from '@mui/material';
 import { api } from '@/trpc/react';
@@ -105,8 +106,6 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     // Returning false prevents Bryntum from applying the empty conflict response.
     const onBeforeResponseApply = ({ requestType, response }: { requestType: string; response: Record<string, unknown> }) => {
       if (requestType !== 'sync') return;
-      console.log('[Gantt:beforeResponseApply] response keys:', Object.keys(response), 'conflict:', response.conflict);
-
       if (response.conflict) {
         // Manually clear Bryntum's "Saving changes, please wait..." mask
         // since returning false prevents the sync cycle from finalizing.
@@ -122,6 +121,7 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     const onSync = () => {
       skipVersionRef.current = false;
       void utils.gantt.tasks.invalidate();
+      // Sync complete — store events already tracked the changes
     };
 
     const onSyncFail = () => {
@@ -134,39 +134,76 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     // recalculations) are intentionally NOT injected — they skip the version check.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const onBeforeSync = ({ pack }: { pack: any }) => {
-      console.log('[Gantt:beforeSync] FIRED — skipVersion:', skipVersionRef.current, 'pack keys:', Object.keys(pack as object));
-
       // When user clicks "Proceed" after a conflict, skip version injection
       // so the server does a last-write-wins save (no version check).
       if (skipVersionRef.current) {
-        console.log('[Gantt:beforeSync] Skipping version injection (force save)');
         return;
       }
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const taskChanges = pack?.tasks as { updated?: Array<Record<string, unknown>> } | undefined;
-      console.log('[Gantt:beforeSync] taskChanges:', taskChanges ? `updated: ${taskChanges.updated?.length ?? 0}` : 'none');
       if (taskChanges?.updated) {
         for (const task of taskChanges.updated) {
-          console.log('[Gantt:beforeSync] Task in pack:', task.id, 'typeof id:', typeof task.id, 'existing version in pack:', task.version);
           if (task.id && typeof task.id === 'string') {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             const record = gantt.project.taskStore.getById(task.id) as { get?: (field: string) => unknown; data?: Record<string, unknown> } | null;
-            console.log('[Gantt:beforeSync] Record found:', !!record, 'has get:', !!record?.get);
             if (record?.get) {
               const version = record.get('version');
-              console.log('[Gantt:beforeSync] Task', task.id, '→ store version:', version, 'typeof:', typeof version);
               if (typeof version === 'number') {
                 task.version = version;
-                console.log('[Gantt:beforeSync] Task', task.id, '→ INJECTED version:', version);
-              } else {
-                console.warn('[Gantt:beforeSync] Task', task.id, '→ version NOT a number, skipping injection. record.data:', JSON.stringify(record.data));
               }
             }
           }
         }
       }
     };
+
+    // Track changes via direct store events (add/remove/update).
+    // These fire synchronously BEFORE auto-sync, so they're reliable.
+    // We dispatch individual change events; the ganttChangesStore accumulates them.
+    const taskStore = gantt.project.taskStore;
+
+    const onTaskAdd = ({ records }: { records: Array<{ id?: string; name?: string; isRoot?: boolean }> }) => {
+      const tasks = records
+        .filter((r) => !r.isRoot && r.id)
+        .map((r) => ({ id: String(r.id), name: r.name ?? 'New Task' }));
+      if (tasks.length > 0) {
+        window.dispatchEvent(new CustomEvent('gantt-task-change', {
+          detail: { type: 'add', tasks },
+        }));
+      }
+    };
+
+    const onTaskRemove = ({ records }: { records: Array<{ id?: string; name?: string; isRoot?: boolean }> }) => {
+      const tasks = records
+        .filter((r) => !r.isRoot && r.id)
+        .map((r) => ({ id: String(r.id), name: r.name ?? 'Task' }));
+      if (tasks.length > 0) {
+        window.dispatchEvent(new CustomEvent('gantt-task-change', {
+          detail: { type: 'remove', tasks },
+        }));
+      }
+    };
+
+    // Track updates only for user-initiated field changes (name, note, csiCode),
+    // NOT scheduling engine recalculations (dates, duration, percentDone, etc.)
+    const userEditableFields = new Set(['name', 'note', 'csiCode', 'manuallyScheduled']);
+    const onTaskUpdate = ({ record, changes }: { record: { id?: string; name?: string; isRoot?: boolean }; changes: Record<string, unknown> }) => {
+      if (record.isRoot || !record.id) return;
+      const userChanges = Object.keys(changes).filter((k) => userEditableFields.has(k));
+      if (userChanges.length > 0) {
+        window.dispatchEvent(new CustomEvent('gantt-task-change', {
+          detail: { type: 'update', tasks: [{ id: String(record.id), name: record.name ?? 'Task' }] },
+        }));
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    taskStore.on('add', onTaskAdd);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    taskStore.on('remove', onTaskRemove);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    taskStore.on('update', onTaskUpdate);
 
     gantt.project.on('beforeResponseApply', onBeforeResponseApply);
     gantt.project.on('sync', onSync);
@@ -177,6 +214,12 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
       gantt.project?.un('sync', onSync);
       gantt.project?.un('syncFail', onSyncFail);
       gantt.project?.un('beforeSync', onBeforeSync);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      gantt.project?.taskStore?.un('add', onTaskAdd);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      gantt.project?.taskStore?.un('remove', onTaskRemove);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      gantt.project?.taskStore?.un('update', onTaskUpdate);
     };
   }, [isLoading, getGanttInstance, utils]);
 
@@ -305,6 +348,69 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     }
   }, [getGanttInstance]);
 
+  // Listen for force-sync requests (e.g. before saving a version).
+  // Per Bryntum docs: commitAsync() ensures the scheduling engine finishes calculating,
+  // then sync() persists all pending CRUD changes. sync() queues if one is already in-flight.
+  // We loop until crudStoreHasChanges() returns false (max 3 attempts) to handle the case
+  // where new changes appear during an in-flight sync.
+  useEffect(() => {
+    const handleForceSync = () => {
+      const gantt = getGanttInstance();
+      if (!gantt?.project) {
+        window.dispatchEvent(new Event('gantt-sync-done'));
+        return;
+      }
+
+      const syncUntilClean = async (attempt = 1): Promise<void> => {
+        const MAX_ATTEMPTS = 3;
+
+        // 1. Commit pending scheduling engine calculations
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        await gantt.project.commitAsync();
+
+        // 2. Check if there are CRUD changes to persist
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        const dirty = gantt.project.crudStoreHasChanges() as boolean;
+
+        if (!dirty) {
+          return;
+        }
+
+        // 3. Sync — this queues behind any in-flight sync per Bryntum docs
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        await gantt.project.sync();
+
+        // 4. Check again — new changes may have appeared during in-flight sync
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        const stillDirty = gantt.project.crudStoreHasChanges() as boolean;
+        if (stillDirty && attempt < MAX_ATTEMPTS) {
+          return syncUntilClean(attempt + 1);
+        }
+      };
+
+      void syncUntilClean().then(() => {
+        window.dispatchEvent(new Event('gantt-sync-done'));
+      }).catch(() => {
+        window.dispatchEvent(new Event('gantt-sync-done'));
+      });
+    };
+    window.addEventListener('gantt-force-sync', handleForceSync);
+    return () => window.removeEventListener('gantt-force-sync', handleForceSync);
+  }, [getGanttInstance]);
+
+  // Listen for external reload requests (e.g. after restoring a version)
+  useEffect(() => {
+    const handleReload = () => {
+      const gantt = getGanttInstance();
+      if (gantt?.project) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        void gantt.project.load();
+      }
+    };
+    window.addEventListener('gantt-reload', handleReload);
+    return () => window.removeEventListener('gantt-reload', handleReload);
+  }, [getGanttInstance]);
+
   // Attach the taskClick listener on the Bryntum instance (not in the static config)
   // so we can use the latest handleTaskClick reference from useTaskPopover.
   useEffect(() => {
@@ -329,62 +435,99 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     return () => { detach?.(); };
   }, [isLoading, getGanttInstance, closeTaskPopover]);
 
-  // Attach the row action menu handler on the Gantt instance.
-  // The WidgetColumn menu items use `onItem: 'up.onRowActionClick'` which
-  // resolves to this method on the Gantt widget.
+  // Row action menu — detect clicks on the ⋮ button injected by the name column
+  // renderer, then show a programmatic Bryntum Menu at the button position.
+  const activeMenuRef = useRef<{ destroy: () => void } | null>(null);
   useEffect(() => {
     if (isLoading) return;
     const gantt = getGanttInstance();
     if (!gantt) return;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    (gantt as any).onRowActionClick = ({ source }: { source: { ref: string; up: (type: string) => { cellInfo: { record: unknown } } | null } }) => {
-      // Walk up to the button widget to get the cellInfo injected by WidgetColumn
-      const button = source.up('button');
-      if (!button) return;
-      const record = button.cellInfo?.record as BryntumTaskRecord | undefined;
-      if (!record) return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onCellClick = ({ record, column, event }: { record: any; column: { type: string }; event: MouseEvent }) => {
+      const target = event.target as HTMLElement;
+      const btn = target.closest('.gantt-row-actions-btn') as HTMLElement | null;
+      if (!btn || column.type !== 'name') return;
+
+      event.stopPropagation();
+
+      // Destroy any previously open menu
+      if (activeMenuRef.current) {
+        activeMenuRef.current.destroy();
+        activeMenuRef.current = null;
+      }
+
+      const taskRecord = record as BryntumTaskRecord;
       const g = gantt as unknown as BryntumGanttInstance;
 
-      switch (source.ref) {
-        case 'taskDetails':
-          closeTaskPopover();
-          setTaskInfoRecord(record);
-          break;
-        case 'addSubtask':
-          record.appendChild({ name: 'New Subtask', duration: 1, startDate: new Date() });
-          // Expand the parent so the new subtask is visible
-          if (!record.isExpanded) {
-            g.expand(record);
-          }
-          break;
-        case 'indent':
-          g.indent([record]);
-          break;
-        case 'outdent':
-          g.outdent([record]);
-          break;
-        case 'unlinkTask': {
-          // Remove all dependencies (both incoming and outgoing) for this task
-          const deps = [
-            ...(record.predecessors ?? []),
-            ...(record.successors ?? []),
-          ];
-          if (deps.length > 0) g.dependencyStore.remove(deps);
-          break;
-        }
-        case 'deleteTask':
-          record.remove();
-          break;
-      }
+      btn.classList.add('gantt-menu-open');
+
+      activeMenuRef.current = new Menu({
+        forElement: btn,
+        align: 't-b',
+        items: [
+          {
+            ref: 'taskDetails',
+            text: 'Task Details',
+            icon: 'b-icon b-icon-edit',
+            onItem: () => { closeTaskPopover(); setTaskInfoRecord(taskRecord); },
+          },
+          {
+            ref: 'addSubtask',
+            text: 'Add Subtask',
+            icon: 'b-icon b-icon-add',
+            onItem: () => {
+              taskRecord.appendChild({ name: 'New Subtask', duration: 1, startDate: new Date() });
+              if (!taskRecord.isExpanded) g.expand(taskRecord);
+            },
+          },
+          {
+            ref: 'indent',
+            text: 'Indent',
+            icon: 'b-icon b-icon-indent',
+            onItem: () => { g.indent([taskRecord]); },
+          },
+          {
+            ref: 'outdent',
+            text: 'Outdent',
+            icon: 'b-icon b-icon-outdent',
+            onItem: () => { g.outdent([taskRecord]); },
+          },
+          {
+            ref: 'unlinkTask',
+            text: 'Unlink',
+            icon: 'b-icon b-icon-unlink',
+            onItem: () => {
+              const deps = [...(taskRecord.predecessors ?? []), ...(taskRecord.successors ?? [])];
+              if (deps.length > 0) g.dependencyStore.remove(deps);
+            },
+          },
+          {
+            ref: 'deleteTask',
+            text: 'Delete',
+            icon: 'b-icon b-icon-trash',
+            cls: 'gantt-action-danger',
+            onItem: () => { taskRecord.remove(); },
+          },
+        ],
+        onDestroy: () => {
+          btn.classList.remove('gantt-menu-open');
+          activeMenuRef.current = null;
+        },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    const detach = gantt.on('cellClick', onCellClick) as (() => void) | undefined;
     return () => {
-      const g = getGanttInstance();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-      if (g) delete (g as any).onRowActionClick;
+      detach?.();
+      if (activeMenuRef.current) {
+        activeMenuRef.current.destroy();
+        activeMenuRef.current = null;
+      }
     };
-  }, [isLoading, getGanttInstance]);
+  }, [isLoading, getGanttInstance, closeTaskPopover]);
 
   return (
     <div style={WRAPPER_STYLE}>
@@ -406,22 +549,47 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
           outline: 2.5px solid rgba(43, 45, 66, 0.85) !important;
           outline-offset: 2px;
         }
-        /* Row actions ⋮ button */
+        /* Name cell inner wrapper — flex row with name + dots button */
+        .gantt-name-cell-inner {
+          display: flex;
+          align-items: center;
+          width: 100%;
+          position: relative;
+        }
+        .gantt-name-text {
+          flex: 1;
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+        /* Row actions ⋮ button — right side of name cell, hover-visible */
         .gantt-row-actions-btn {
-          opacity: 0.4;
+          flex-shrink: 0;
+          opacity: 0;
           transition: opacity 0.15s;
-          background: none !important;
-          border: none !important;
-          box-shadow: none !important;
-          min-width: 0 !important;
+          background: none;
+          border: none;
+          box-shadow: none;
+          min-width: 0;
+          padding: 4px 6px;
+          cursor: pointer;
+          border-radius: 4px;
+          color: var(--text-secondary, #8D99AE);
+          font-size: 16px;
+          font-weight: bold;
+          letter-spacing: 1px;
+          line-height: 1;
         }
         .b-grid-row:hover .gantt-row-actions-btn,
         .gantt-row-actions-btn:focus,
-        .gantt-row-actions-btn[aria-expanded="true"] {
+        .gantt-row-actions-btn.gantt-menu-open {
           opacity: 1;
         }
+        .gantt-row-actions-btn:hover {
+          background: rgba(0, 0, 0, 0.04);
+        }
         /* Row actions dropdown menu — clean card style */
-        .gantt-row-actions-btn + .b-menu,
         .b-menu:has(.gantt-action-danger) {
           border-radius: 10px !important;
           box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25) !important;
@@ -429,7 +597,6 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
           padding: 4px 0 !important;
           overflow: hidden;
         }
-        .gantt-row-actions-btn + .b-menu .b-menuitem,
         .b-menu:has(.gantt-action-danger) .b-menuitem {
           padding: 8px 16px !important;
           font-size: 13px !important;
@@ -437,17 +604,14 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
           border-radius: 0 !important;
           gap: 10px !important;
         }
-        .gantt-row-actions-btn + .b-menu .b-menuitem:hover,
         .b-menu:has(.gantt-action-danger) .b-menuitem:hover {
           background: var(--hover-bg, rgba(0, 0, 0, 0.04)) !important;
         }
-        .gantt-row-actions-btn + .b-menu .b-menuitem .b-icon,
         .b-menu:has(.gantt-action-danger) .b-menuitem .b-icon {
           font-size: 14px !important;
           width: 18px !important;
           text-align: center;
         }
-        .gantt-row-actions-btn + .b-menu .b-menu-separator,
         .b-menu:has(.gantt-action-danger) .b-menu-separator {
           margin: 4px 0 !important;
         }

--- a/src/components/bryntum/components/SaveVersionDialog.tsx
+++ b/src/components/bryntum/components/SaveVersionDialog.tsx
@@ -42,11 +42,26 @@ export default function SaveVersionDialog({ open, onOpenChange, projectId }: Sav
   const handleSave = useCallback((data: SaveVersionInput) => {
     setIsSyncing(true);
 
-    const onSyncDone = () => {
+    const SYNC_TIMEOUT_MS = 5000;
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const cleanup = () => {
       window.removeEventListener('gantt-sync-done', onSyncDone);
+      clearTimeout(timeoutId);
+    };
+
+    const onSyncDone = () => {
+      cleanup();
       setIsSyncing(false);
       saveMutation.mutate({ ...data, projectId });
     };
+
+    timeoutId = setTimeout(() => {
+      cleanup();
+      setIsSyncing(false);
+      // Proceed with save even if sync event was not received
+      saveMutation.mutate({ ...data, projectId });
+    }, SYNC_TIMEOUT_MS);
 
     window.addEventListener('gantt-sync-done', onSyncDone);
     window.dispatchEvent(new Event('gantt-force-sync'));

--- a/src/components/bryntum/components/SaveVersionDialog.tsx
+++ b/src/components/bryntum/components/SaveVersionDialog.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Dialog, DialogTitle, DialogContent, DialogActions, TextField } from '@mui/material';
+import { Button } from '@/components/ui/button';
+import { api } from '@/trpc/react';
+import { useSnackbar } from '@/hooks/useSnackbar';
+import { saveVersionSchema, type SaveVersionInput } from '@/lib/validations/schedule';
+
+interface SaveVersionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+}
+
+export default function SaveVersionDialog({ open, onOpenChange, projectId }: SaveVersionDialogProps) {
+  const utils = api.useUtils();
+  const { showSnackbar } = useSnackbar();
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  const { control, handleSubmit, reset, formState: { errors } } = useForm<SaveVersionInput>({
+    resolver: zodResolver(saveVersionSchema),
+    defaultValues: { name: '' },
+  });
+
+  const saveMutation = api.schedule.saveVersion.useMutation({
+    onSuccess: (data) => {
+      void utils.schedule.listVersions.invalidate({ projectId });
+      // Reset the frontend change tracker
+      window.dispatchEvent(new CustomEvent('gantt-version-saved', { detail: { name: data.name } }));
+      showSnackbar('Version saved', 'success');
+      reset();
+      onOpenChange(false);
+    },
+    onError: (error) => {
+      showSnackbar(error.message || 'Failed to save version', 'error');
+    },
+  });
+
+  const handleSave = useCallback((data: SaveVersionInput) => {
+    setIsSyncing(true);
+
+    const onSyncDone = () => {
+      window.removeEventListener('gantt-sync-done', onSyncDone);
+      setIsSyncing(false);
+      saveMutation.mutate({ ...data, projectId });
+    };
+
+    window.addEventListener('gantt-sync-done', onSyncDone);
+    window.dispatchEvent(new Event('gantt-force-sync'));
+  }, [saveMutation, projectId]);
+
+  const handleClose = () => {
+    reset();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+      <form onSubmit={handleSubmit(handleSave)}>
+        <DialogTitle sx={{ fontSize: 16, fontWeight: 600, pb: 1 }}>Save Version</DialogTitle>
+        <DialogContent>
+          <Controller
+            name="name"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Version name"
+                placeholder="e.g. Baseline v1 — March 31"
+                fullWidth
+                autoFocus
+                size="small"
+                error={!!errors.name}
+                helperText={errors.name?.message}
+                sx={{ mt: 1 }}
+              />
+            )}
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button variant="outlined" size="small" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button variant="contained" size="small" type="submit" loading={isSyncing || saveMutation.isPending}>
+            Save
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/src/components/bryntum/components/VersionControlBar.tsx
+++ b/src/components/bryntum/components/VersionControlBar.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { Box, Typography, Popover } from '@mui/material';
+import { ClockCounterClockwise, FloppyDisk, GitDiff, CheckCircle } from '@phosphor-icons/react';
+import { useGanttChangesStore, useGanttChangesListener } from '@/store/ganttChangesStore';
+import { useProjectContext } from '@/components/providers/ProjectProvider';
+import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
+import type { Role } from '@/lib/permissions';
+import { api } from '@/trpc/react';
+import SaveVersionDialog from './SaveVersionDialog';
+import VersionHistoryDrawer from './VersionHistoryDrawer';
+
+export default function VersionControlBar() {
+  const { projectId } = useProjectContext();
+  const { currentOrg } = useOrgFromUrl();
+  const memberRole = (currentOrg?.role ?? 'viewer') as Role;
+
+  const [saveVersionOpen, setSaveVersionOpen] = useState(false);
+  const [versionHistoryOpen, setVersionHistoryOpen] = useState(false);
+  const [changesAnchorEl, setChangesAnchorEl] = useState<HTMLElement | null>(null);
+  const changesRef = useRef<HTMLDivElement>(null);
+
+  useGanttChangesListener();
+  const { hasChanges, changeCount, added, modified, removed, activeVersionName } = useGanttChangesStore();
+
+  const { data: versions } = api.schedule.listVersions.useQuery(
+    { projectId },
+    { enabled: !!projectId },
+  );
+  // Use context's activeVersionName (set on save/restore) if available, else fall back to latest from query
+  const displayVersionName = activeVersionName ?? versions?.[0]?.name ?? null;
+
+  const handleChangesClick = () => {
+    if (hasChanges && changesRef.current) {
+      setChangesAnchorEl(changesRef.current);
+    }
+  };
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          mb: 1.5,
+          flexShrink: 0,
+        }}
+      >
+        <Box
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 1,
+          }}
+        >
+          {/* ── Changes pill ── */}
+          {/* This is the hero: a standalone pill that shows change state */}
+          {/* When dirty, it's clickable and opens the diff popover directly */}
+          <Box
+            ref={changesRef}
+            onClick={handleChangesClick}
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 0.625,
+              height: 30,
+              px: 1.25,
+              borderRadius: '8px',
+              bgcolor: hasChanges ? 'rgba(217, 119, 6, 0.08)' : 'transparent',
+              border: '1px solid',
+              borderColor: hasChanges ? 'rgba(217, 119, 6, 0.20)' : 'transparent',
+              cursor: hasChanges ? 'pointer' : 'default',
+              transition: 'all 0.2s ease',
+              ...(hasChanges && {
+                '&:hover': {
+                  bgcolor: 'rgba(217, 119, 6, 0.13)',
+                  borderColor: 'rgba(217, 119, 6, 0.30)',
+                },
+              }),
+            }}
+          >
+            {hasChanges ? (
+              <>
+                <GitDiff size={13} weight="bold" color="var(--status-amber)" style={{ flexShrink: 0 }} />
+                <Typography
+                  sx={{
+                    fontSize: '0.6875rem',
+                    fontWeight: 600,
+                    color: 'var(--status-amber)',
+                    lineHeight: 1,
+                    whiteSpace: 'nowrap',
+                    letterSpacing: '-0.01em',
+                  }}
+                >
+                  {changeCount} change{changeCount !== 1 ? 's' : ''}
+                </Typography>
+              </>
+            ) : (
+              <>
+                <CheckCircle size={12} weight="fill" style={{ flexShrink: 0, color: 'var(--status-green)', opacity: 0.5 }} />
+                <Typography
+                  sx={{
+                    fontSize: '0.6875rem',
+                    fontWeight: 500,
+                    color: 'text.disabled',
+                    lineHeight: 1,
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  All saved
+                </Typography>
+              </>
+            )}
+          </Box>
+
+          {/* ── Main control bar ── */}
+          <Box
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              bgcolor: 'var(--bg-card)',
+              borderRadius: '10px',
+              border: '1px solid var(--border-color)',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)',
+              height: 34,
+              overflow: 'hidden',
+            }}
+          >
+            {/* Version name — clickable to open history */}
+            <Box
+              onClick={() => setVersionHistoryOpen(true)}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.625,
+                pl: 1.25,
+                pr: 1,
+                height: '100%',
+                cursor: 'pointer',
+                '&:hover': { bgcolor: 'action.hover' },
+                transition: 'background-color 0.15s',
+              }}
+            >
+              <ClockCounterClockwise size={12} weight="bold" style={{ flexShrink: 0, opacity: 0.35 }} />
+              <Typography
+                sx={{
+                  fontSize: '0.6875rem',
+                  fontWeight: 500,
+                  color: 'text.secondary',
+                  lineHeight: 1,
+                  whiteSpace: 'nowrap',
+                  maxWidth: 150,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  letterSpacing: '-0.01em',
+                }}
+              >
+                {displayVersionName ?? 'No versions'}
+              </Typography>
+            </Box>
+
+            {/* Separator */}
+            <Box sx={{ width: '1px', height: 14, bgcolor: 'divider', flexShrink: 0 }} />
+
+            {/* Save button */}
+            <Box
+              component="button"
+              onClick={() => setSaveVersionOpen(true)}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                px: 1.25,
+                height: '100%',
+                border: 'none',
+                borderRadius: '0 9px 9px 0',
+                bgcolor: hasChanges ? 'var(--accent-primary)' : 'transparent',
+                color: hasChanges ? '#fff' : 'text.secondary',
+                cursor: 'pointer',
+                fontSize: '0.6875rem',
+                fontWeight: 600,
+                fontFamily: 'inherit',
+                letterSpacing: '-0.01em',
+                transition: 'background-color 0.2s, color 0.2s, filter 0.2s',
+                '&:hover': {
+                  bgcolor: hasChanges ? 'var(--accent-primary)' : 'action.hover',
+                  filter: hasChanges ? 'brightness(0.85)' : 'none',
+                },
+              }}
+            >
+              <FloppyDisk size={12} weight={hasChanges ? 'fill' : 'regular'} />
+              Save
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+
+      {/* Changes diff popover — anchored to the changes pill */}
+      <Popover
+        open={!!changesAnchorEl}
+        anchorEl={changesAnchorEl}
+        onClose={() => setChangesAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+        slotProps={{
+          paper: {
+            sx: {
+              mt: 1,
+              borderRadius: '12px',
+              minWidth: 240,
+              maxWidth: 320,
+              maxHeight: 380,
+              overflow: 'hidden',
+              boxShadow: '0 4px 24px rgba(0,0,0,0.10), 0 1px 4px rgba(0,0,0,0.06)',
+              border: '1px solid var(--border-color)',
+            },
+          },
+        }}
+      >
+        {/* Header */}
+        <Box
+          sx={{
+            px: 2,
+            py: 1.5,
+            borderBottom: '1px solid var(--border-color)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.75,
+          }}
+        >
+          <GitDiff size={14} weight="bold" color="var(--status-amber)" />
+          <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, letterSpacing: '-0.01em' }}>
+            {changeCount} Unsaved Change{changeCount !== 1 ? 's' : ''}
+          </Typography>
+        </Box>
+
+        {/* Change list */}
+        <Box sx={{ overflow: 'auto', maxHeight: 300 }}>
+          {added.length > 0 && (
+            <Box sx={{ px: 2, py: 1.25 }}>
+              <Typography
+                sx={{
+                  fontSize: '0.5625rem',
+                  fontWeight: 700,
+                  color: 'var(--status-green)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.1em',
+                  mb: 0.5,
+                }}
+              >
+                Added · {added.length}
+              </Typography>
+              {added.slice(0, 8).map((name, i) => (
+                <Box key={i} sx={{ display: 'flex', alignItems: 'center', gap: 0.75, py: 0.25 }}>
+                  <Box sx={{ width: 3, height: 3, borderRadius: '50%', bgcolor: 'var(--status-green)', flexShrink: 0, opacity: 0.6 }} />
+                  <Typography sx={{ fontSize: '0.6875rem', color: 'text.secondary', lineHeight: 1.4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {name}
+                  </Typography>
+                </Box>
+              ))}
+              {added.length > 8 && (
+                <Typography sx={{ fontSize: '0.625rem', color: 'text.disabled', pl: 1.5, mt: 0.25 }}>
+                  +{added.length - 8} more
+                </Typography>
+              )}
+            </Box>
+          )}
+
+          {modified.length > 0 && (
+            <Box sx={{ px: 2, py: 1.25, ...(added.length > 0 && { borderTop: '1px solid var(--border-light)' }) }}>
+              <Typography
+                sx={{
+                  fontSize: '0.5625rem',
+                  fontWeight: 700,
+                  color: 'var(--status-amber)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.1em',
+                  mb: 0.5,
+                }}
+              >
+                Modified · {modified.length}
+              </Typography>
+              {modified.slice(0, 8).map((name, i) => (
+                <Box key={i} sx={{ display: 'flex', alignItems: 'center', gap: 0.75, py: 0.25 }}>
+                  <Box sx={{ width: 3, height: 3, borderRadius: '50%', bgcolor: 'var(--status-amber)', flexShrink: 0, opacity: 0.6 }} />
+                  <Typography sx={{ fontSize: '0.6875rem', color: 'text.secondary', lineHeight: 1.4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {name}
+                  </Typography>
+                </Box>
+              ))}
+              {modified.length > 8 && (
+                <Typography sx={{ fontSize: '0.625rem', color: 'text.disabled', pl: 1.5, mt: 0.25 }}>
+                  +{modified.length - 8} more
+                </Typography>
+              )}
+            </Box>
+          )}
+
+          {removed.length > 0 && (
+            <Box sx={{ px: 2, py: 1.25, ...((added.length > 0 || modified.length > 0) && { borderTop: '1px solid var(--border-light)' }) }}>
+              <Typography
+                sx={{
+                  fontSize: '0.5625rem',
+                  fontWeight: 700,
+                  color: 'var(--status-red)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.1em',
+                  mb: 0.5,
+                }}
+              >
+                Removed · {removed.length}
+              </Typography>
+              {removed.slice(0, 8).map((name, i) => (
+                <Box key={i} sx={{ display: 'flex', alignItems: 'center', gap: 0.75, py: 0.25 }}>
+                  <Box sx={{ width: 3, height: 3, borderRadius: '50%', bgcolor: 'var(--status-red)', flexShrink: 0, opacity: 0.6 }} />
+                  <Typography sx={{ fontSize: '0.6875rem', color: 'text.secondary', lineHeight: 1.4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {name}
+                  </Typography>
+                </Box>
+              ))}
+              {removed.length > 8 && (
+                <Typography sx={{ fontSize: '0.625rem', color: 'text.disabled', pl: 1.5, mt: 0.25 }}>
+                  +{removed.length - 8} more
+                </Typography>
+              )}
+            </Box>
+          )}
+        </Box>
+      </Popover>
+
+      {/* Dialogs */}
+      <SaveVersionDialog
+        open={saveVersionOpen}
+        onOpenChange={setSaveVersionOpen}
+        projectId={projectId}
+      />
+      <VersionHistoryDrawer
+        open={versionHistoryOpen}
+        onOpenChange={setVersionHistoryOpen}
+        projectId={projectId}
+        memberRole={memberRole}
+      />
+    </>
+  );
+}

--- a/src/components/bryntum/components/VersionHistoryDrawer.tsx
+++ b/src/components/bryntum/components/VersionHistoryDrawer.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Drawer,
+  Box,
+  Typography,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Divider,
+} from '@mui/material';
+import { X, DotsThreeVertical, ClockCounterClockwise, Trash } from '@phosphor-icons/react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { formatDistanceToNow } from 'date-fns';
+import { api } from '@/trpc/react';
+import { useSnackbar } from '@/hooks/useSnackbar';
+import { hasPermission } from '@/lib/permissions';
+import type { Role } from '@/lib/permissions';
+
+interface VersionHistoryDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  memberRole: Role;
+  onRestore?: () => void;
+}
+
+export default function VersionHistoryDrawer({
+  open,
+  onOpenChange,
+  projectId,
+  memberRole,
+  onRestore,
+}: VersionHistoryDrawerProps) {
+  const utils = api.useUtils();
+  const { showSnackbar } = useSnackbar();
+  const canManage = hasPermission(memberRole, 'MANAGE_PROJECTS');
+
+  const [confirmAction, setConfirmAction] = useState<{ type: 'restore' | 'delete'; versionId: string; versionName: string } | null>(null);
+
+  const { data: versions = [], isLoading } = api.schedule.listVersions.useQuery(
+    { projectId },
+    { enabled: open },
+  );
+
+  const deleteMutation = api.schedule.deleteVersion.useMutation({
+    onSuccess: () => {
+      void utils.schedule.listVersions.invalidate({ projectId });
+      showSnackbar('Version deleted', 'success');
+      setConfirmAction(null);
+    },
+    onError: (error) => {
+      showSnackbar(error.message || 'Failed to delete version', 'error');
+    },
+  });
+
+  const restoreMutation = api.schedule.restoreVersion.useMutation({
+    onSuccess: () => {
+      void utils.schedule.listVersions.invalidate({ projectId });
+      showSnackbar('Version restored', 'success');
+      const restoredName = confirmAction?.versionName ?? '';
+      setConfirmAction(null);
+      onOpenChange(false);
+      // Trigger Gantt reload and notify store of restored version name
+      window.dispatchEvent(new CustomEvent('gantt-version-restored', { detail: { name: restoredName } }));
+      window.dispatchEvent(new Event('gantt-reload'));
+      onRestore?.();
+    },
+    onError: (error) => {
+      showSnackbar(error.message || 'Failed to restore version', 'error');
+    },
+  });
+
+  const handleConfirm = () => {
+    if (!confirmAction) return;
+    if (confirmAction.type === 'delete') {
+      deleteMutation.mutate({ projectId, versionId: confirmAction.versionId });
+    } else {
+      restoreMutation.mutate({ projectId, versionId: confirmAction.versionId });
+    }
+  };
+
+  return (
+    <>
+      <Drawer
+        anchor="right"
+        open={open}
+        onClose={() => onOpenChange(false)}
+        PaperProps={{
+          sx: { width: 360, maxWidth: '100vw' },
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 2.5, py: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75 }}>
+            <Typography sx={{ fontSize: 15, fontWeight: 600 }}>Version History</Typography>
+            <Typography sx={{ fontSize: 11, color: 'text.disabled', fontWeight: 500 }}>
+              {versions.length}/50
+            </Typography>
+          </Box>
+          <IconButton size="small" onClick={() => onOpenChange(false)} sx={{ p: 0.5 }}>
+            <X size={16} />
+          </IconButton>
+        </Box>
+        {versions.length >= 45 && (
+          <Box sx={{ mx: 2.5, mb: 1, px: 1.5, py: 1, borderRadius: '8px', bgcolor: versions.length >= 50 ? 'error.main' : 'warning.main', opacity: 0.9 }}>
+            <Typography sx={{ fontSize: 11, fontWeight: 500, color: 'white', lineHeight: 1.3 }}>
+              {versions.length >= 50
+                ? 'Version limit reached. Delete older versions to save new ones.'
+                : `${50 - versions.length} versions remaining. Consider deleting older versions.`}
+            </Typography>
+          </Box>
+        )}
+        <Divider />
+
+        <Box sx={{ flex: 1, overflow: 'auto', px: 2.5, py: 1.5 }}>
+          {isLoading ? (
+            <Typography sx={{ fontSize: 13, color: 'text.secondary', textAlign: 'center', py: 4 }}>
+              Loading...
+            </Typography>
+          ) : versions.length === 0 ? (
+            <Box sx={{ textAlign: 'center', py: 6 }}>
+              <Typography sx={{ fontSize: 13, color: 'text.secondary' }}>
+                No versions saved yet
+              </Typography>
+              <Typography sx={{ fontSize: 11, color: 'text.disabled', mt: 0.5 }}>
+                Save a version to create a snapshot of your schedule
+              </Typography>
+            </Box>
+          ) : (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+              {versions.map((version) => (
+                <Box
+                  key={version.id}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    px: 1.5,
+                    py: 1.25,
+                    borderRadius: '8px',
+                    '&:hover': { bgcolor: 'action.hover' },
+                  }}
+                >
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography
+                      sx={{
+                        fontSize: 13,
+                        fontWeight: 500,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {version.name}
+                    </Typography>
+                    <Typography sx={{ fontSize: 11, color: 'text.secondary', mt: 0.25 }}>
+                      {version.createdBy.name ?? version.createdBy.email} · {formatDistanceToNow(new Date(version.createdAt), { addSuffix: true })}
+                    </Typography>
+                  </Box>
+
+                  {canManage && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <IconButton size="small" sx={{ p: 0.5, flexShrink: 0 }}>
+                          <DotsThreeVertical size={16} weight="bold" />
+                        </IconButton>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onClick={() => setConfirmAction({ type: 'restore', versionId: version.id, versionName: version.name })}
+                        >
+                          <ClockCounterClockwise size={14} style={{ marginRight: 8 }} />
+                          Restore
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => setConfirmAction({ type: 'delete', versionId: version.id, versionName: version.name })}
+                        >
+                          <Trash size={14} style={{ marginRight: 8 }} />
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
+      </Drawer>
+
+      {/* Confirmation dialog */}
+      <Dialog open={!!confirmAction} onClose={() => setConfirmAction(null)} maxWidth="xs" fullWidth>
+        <DialogTitle sx={{ fontSize: 16, fontWeight: 600 }}>
+          {confirmAction?.type === 'restore' ? 'Restore Version' : 'Delete Version'}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ fontSize: 13 }}>
+            {confirmAction?.type === 'restore'
+              ? `This will replace your current schedule with "${confirmAction.versionName}". This cannot be undone.`
+              : `Are you sure you want to delete "${confirmAction?.versionName}"? This cannot be undone.`}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button variant="outlined" size="small" onClick={() => setConfirmAction(null)}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            size="small"
+            color={confirmAction?.type === 'delete' ? 'error' : 'primary'}
+            loading={deleteMutation.isPending || restoreMutation.isPending}
+            onClick={handleConfirm}
+          >
+            {confirmAction?.type === 'restore' ? 'Restore' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -1,5 +1,6 @@
 import { TaskModel } from '@bryntum/gantt';
-import type { GanttConfig } from '../types';
+import type { DomClassList } from '@bryntum/gantt';
+import type { GanttConfig, ColumnRendererData } from '../types';
 
 // Extend TaskModel to include the `version` field used for optimistic locking.
 // Without this, Bryntum silently drops the version from loaded data and
@@ -51,9 +52,6 @@ export function createGanttConfig(
       autoSync: false,
       taskModelClass: VersionedTaskModel,
 
-      // Enable delay calculation for better initial load performance
-      delayCalculation: true,
-
       transport: projectId
         ? {
             load: {
@@ -86,7 +84,6 @@ export function createGanttConfig(
         },
       },
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     columns: [
       {
         type: 'name',
@@ -94,6 +91,24 @@ export function createGanttConfig(
         flex: 1,
         minWidth: 300,
         resizable: true,
+        // Inject a three-dot actions button alongside the task name.
+        // TreeColumn renderer return value replaces the cell content —
+        // return a DomConfig object that includes both the name and the button.
+        renderer({ value, record }: ColumnRendererData) {
+          return {
+            class: 'gantt-name-cell-inner',
+            children: [
+              { tag: 'span', class: 'gantt-name-text', text: String(value ?? '') },
+              {
+                tag: 'button',
+                class: 'gantt-row-actions-btn',
+                type: 'button',
+                dataset: { taskId: String(record.id) },
+                text: '⋮',
+              },
+            ],
+          };
+        },
       },
       // Single-clicking the name cell scrolls the timeline to the task's bar (see cellClick listener).
       // Double-clicking starts inline name editing (Bryntum native behavior).
@@ -110,63 +125,6 @@ export function createGanttConfig(
         width: 100,
         resizable: true,
       },
-      {
-        type: 'widget',
-        width: 40,
-        resizable: false,
-        sortable: false,
-        filterable: false,
-        text: '',
-        widgets: [
-          {
-            type: 'button',
-            menuIcon: false,
-            icon: 'b-icon b-icon-menu-vertical',
-            cls: 'gantt-row-actions-btn',
-            menu: {
-              items: {
-                taskDetails: {
-                  text: 'Task Details',
-                  icon: 'b-icon b-icon-edit',
-                  weight: 50,
-                  onItem: 'up.onRowActionClick',
-                },
-                addSubtask: {
-                  text: 'Add Subtask',
-                  icon: 'b-icon b-icon-add',
-                  weight: 100,
-                  onItem: 'up.onRowActionClick',
-                },
-                indent: {
-                  text: 'Indent',
-                  icon: 'b-icon b-icon-indent',
-                  weight: 200,
-                  onItem: 'up.onRowActionClick',
-                },
-                outdent: {
-                  text: 'Outdent',
-                  icon: 'b-icon b-icon-outdent',
-                  weight: 300,
-                  onItem: 'up.onRowActionClick',
-                },
-                unlinkTask: {
-                  text: 'Unlink',
-                  icon: 'b-icon b-icon-unlink',
-                  weight: 500,
-                  onItem: 'up.onRowActionClick',
-                },
-                deleteTask: {
-                  text: 'Delete',
-                  icon: 'b-icon b-icon-trash',
-                  cls: 'gantt-action-danger',
-                  weight: 600,
-                  onItem: 'up.onRowActionClick',
-                },
-              },
-            },
-          },
-        ],
-      },
     ],
     features: {
       taskEdit: false,
@@ -182,17 +140,31 @@ export function createGanttConfig(
     startDate: new Date(new Date().getFullYear(), new Date().getMonth() - 3, 1),
     endDate: new Date(new Date().getFullYear(), new Date().getMonth() + 24, 1),
     barMargin: 10,
+
+    // Differentiate parent bars from child bars.
+    // Adds 'gantt-parent-bar' class to parent tasks for CSS targeting.
+    // Parent bars show no text (name is in the tree column).
+    taskRenderer({ taskRecord, renderData }: {
+      taskRecord: TaskModel;
+      renderData: { cls: DomClassList | string; style: string | Record<string, string>; wrapperCls: DomClassList | string; iconCls: DomClassList | string };
+    }) {
+      if (taskRecord.isParent) {
+        if (typeof renderData.cls !== 'string') {
+          renderData.cls.add('gantt-parent-bar');
+        }
+        return '';
+      }
+      return taskRecord.name;
+    },
+
     listeners: {
       // Bryntum blocks the duration cell editor for parent tasks before
       // beforeCellEditStart ever fires (checked internally in DurationColumn).
       // cellDblClick fires first, so we can set manuallyScheduled: true here —
       // telling the scheduling engine to stop auto-deriving duration from children
       // — before Bryntum decides whether to open the editor.
-      cellDblClick({ record, column }: {
-        record: { isParent: boolean; manuallyScheduled: boolean; set: (field: string, value: unknown) => void };
-        column: { type: string };
-      }) {
-        if (column.type === 'duration' && record.isParent && !record.manuallyScheduled) {
+      cellDblClick({ record, column }) {
+        if (column.type === 'duration' && record.isParent && !record.get('manuallyScheduled')) {
           record.set('manuallyScheduled', true);
         }
       },

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -1,3 +1,5 @@
+import type { Model, Column, Grid, Row, TaskModel, DomClassList } from '@bryntum/gantt';
+
 export type PopoverPlacement = {
   anchorPosition: { top: number; left: number };
   transformOrigin: {
@@ -27,6 +29,31 @@ export type TaskClickEventPayload = {
 
 export type TaskClickHandler = (payload: TaskClickEventPayload) => void;
 
+/** Bryntum DomConfig — a virtual DOM node descriptor used by column renderers. */
+export interface BryntumDomConfig {
+  tag?: string;
+  class?: string;
+  html?: string;
+  text?: string;
+  style?: string | Record<string, string>;
+  dataset?: Record<string, string>;
+  children?: BryntumDomConfig[];
+  [key: string]: unknown;
+}
+
+/** Column renderer data — mirrors Bryntum's own renderer signature from gantt.d.ts. */
+export interface ColumnRendererData {
+  cellElement: HTMLElement;
+  value: unknown;
+  record: Model;
+  column: Column;
+  grid: Grid;
+  row: Row;
+  size: { height: number; configuredHeight: number };
+  isExport: boolean;
+  isMeasuring: boolean;
+}
+
 type GanttColumnConfig = {
   type: string;
   field?: string;
@@ -37,8 +64,8 @@ type GanttColumnConfig = {
   resizable?: boolean;
   sortable?: boolean;
   filterable?: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   widgets?: Record<string, unknown>[];
+  renderer?: (data: ColumnRendererData) => string | BryntumDomConfig | BryntumDomConfig[] | HTMLElement | void;
 };
 
 type TooltipRendererArgs = {
@@ -149,8 +176,7 @@ export type GanttConfig = {
   project: {
     autoLoad: boolean;
     autoSync?: boolean;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    taskModelClass?: any;
+    taskModelClass?: typeof TaskModel;
     delayCalculation?: boolean;
     transport: {
       load: {
@@ -187,11 +213,32 @@ export type GanttConfig = {
   startDate?: Date;
   endDate?: Date;
   barMargin: number;
+  taskRenderer?: (detail: {
+    taskRecord: TaskModel;
+    renderData: {
+      cls: DomClassList | string;
+      style: string | Record<string, string>;
+      wrapperCls: DomClassList | string;
+      iconCls: DomClassList | string;
+    };
+  }) => string | BryntumDomConfig | BryntumDomConfig[];
   listeners: {
     taskClick?: TaskClickHandler;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    cellDblClick?: (...args: any[]) => void;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    cellClick?: (...args: any[]) => void;
+    cellDblClick?: (event: {
+      grid: Grid;
+      record: Model;
+      column: Column;
+      cellElement: HTMLElement;
+      target: HTMLElement;
+      event: MouseEvent;
+    }) => void;
+    cellClick?: (event: {
+      grid: Grid;
+      record: Model;
+      column: Column;
+      cellElement: HTMLElement;
+      target: HTMLElement;
+      event: MouseEvent;
+    }) => void;
   };
 };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -16,6 +16,7 @@ import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
 import { useNotifications } from '@/hooks/useNotifications';
 import { useNavigationLoading } from '@/hooks/useNavigationLoading';
 import { useProjectSwitcher } from '@/hooks/useProjectSwitcher';
+import { api } from '@/trpc/react';
 import ProjectSwitcher from './ProjectSwitcher';
 import LocationWeather from './LocationWeather';
 

--- a/src/components/layout/ProjectShell.tsx
+++ b/src/components/layout/ProjectShell.tsx
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic';
 import { Box } from '@mui/material';
 import FilesContent from '@/components/files/FilesContent';
 import GanttLoadingSpinner from '@/components/bryntum/components/GanttLoadingSpinner';
+import VersionControlBar from '@/components/bryntum/components/VersionControlBar';
 
 const BryntumGanttWrapper = dynamic(
   () => import('@/components/bryntum/BryntumGanttWrapper'),
@@ -57,6 +58,7 @@ export default function ProjectShell({ children, projectId, projectName }: Proje
             display: isGanttRoute ? 'flex' : 'none',
           }}
         >
+          <VersionControlBar />
           <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', height: '100%' }}>
             <BryntumGanttWrapper
               projectId={projectId}

--- a/src/lib/validations/schedule.ts
+++ b/src/lib/validations/schedule.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const saveVersionSchema = z.object({
+  name: z.string().min(1, "Version name is required").max(100).trim(),
+}).strict();
+
+export type SaveVersionInput = z.infer<typeof saveVersionSchema>;
+
+export const versionIdSchema = z.object({
+  versionId: z.string(),
+}).strict();
+
+export type VersionIdInput = z.infer<typeof versionIdSchema>;

--- a/src/lib/validations/schedule.ts
+++ b/src/lib/validations/schedule.ts
@@ -7,7 +7,7 @@ export const saveVersionSchema = z.object({
 export type SaveVersionInput = z.infer<typeof saveVersionSchema>;
 
 export const versionIdSchema = z.object({
-  versionId: z.string(),
+  versionId: z.string().cuid(),
 }).strict();
 
 export type VersionIdInput = z.infer<typeof versionIdSchema>;

--- a/src/server/api/helpers/ganttSnapshot.ts
+++ b/src/server/api/helpers/ganttSnapshot.ts
@@ -1,0 +1,121 @@
+import "server-only";
+import { TRPCError } from "@trpc/server";
+import { Prisma } from "../../../../generated/prisma";
+
+type DbClient = Omit<Prisma.TransactionClient, never>;
+
+export interface GanttSnapshot {
+  schemaVersion: 1;
+  capturedAt: string;
+  tasks: Array<Record<string, unknown>>;
+  dependencies: Array<Record<string, unknown>>;
+  resources: Array<Record<string, unknown>>;
+  assignments: Array<Record<string, unknown>>;
+  timeRanges: Array<Record<string, unknown>>;
+}
+
+const MAX_SNAPSHOT_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
+
+/**
+ * Capture a full snapshot of all Gantt data for a project.
+ * Returns the raw DB records (not Bryntum-mapped) so restore can use createMany directly.
+ */
+export async function captureGanttSnapshot(
+  db: DbClient,
+  projectId: string,
+): Promise<GanttSnapshot> {
+  const [tasks, dependencies, resources, assignments, timeRanges] = await Promise.all([
+    db.ganttTask.findMany({
+      where: { projectId },
+      orderBy: { orderIndex: "asc" },
+      select: {
+        id: true,
+        parentId: true,
+        name: true,
+        percentDone: true,
+        startDate: true,
+        endDate: true,
+        duration: true,
+        durationUnit: true,
+        effort: true,
+        effortUnit: true,
+        expanded: true,
+        manuallyScheduled: true,
+        constraintType: true,
+        constraintDate: true,
+        rollup: true,
+        cls: true,
+        iconCls: true,
+        note: true,
+        csiCode: true,
+        baselines: true,
+        orderIndex: true,
+        version: true,
+        coverImageUrl: true,
+      },
+    }),
+    db.ganttDependency.findMany({
+      where: { projectId },
+      select: {
+        id: true,
+        fromTaskId: true,
+        toTaskId: true,
+        type: true,
+        lag: true,
+        lagUnit: true,
+        cls: true,
+      },
+    }),
+    db.ganttResource.findMany({
+      where: { projectId },
+      select: {
+        id: true,
+        name: true,
+        city: true,
+        calendar: true,
+        image: true,
+      },
+    }),
+    db.ganttAssignment.findMany({
+      where: { projectId },
+      select: {
+        id: true,
+        taskId: true,
+        resourceId: true,
+        units: true,
+      },
+    }),
+    db.ganttTimeRange.findMany({
+      where: { projectId },
+      select: {
+        id: true,
+        name: true,
+        startDate: true,
+        duration: true,
+        durationUnit: true,
+        cls: true,
+      },
+    }),
+  ]);
+
+  const snapshot: GanttSnapshot = {
+    schemaVersion: 1,
+    capturedAt: new Date().toISOString(),
+    tasks: tasks as unknown as Array<Record<string, unknown>>,
+    dependencies: dependencies as unknown as Array<Record<string, unknown>>,
+    resources: resources as unknown as Array<Record<string, unknown>>,
+    assignments: assignments as unknown as Array<Record<string, unknown>>,
+    timeRanges: timeRanges as unknown as Array<Record<string, unknown>>,
+  };
+
+  // Validate size
+  const jsonSize = Buffer.byteLength(JSON.stringify(snapshot), "utf-8");
+  if (jsonSize > MAX_SNAPSHOT_SIZE_BYTES) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `Snapshot too large (${Math.round(jsonSize / 1024 / 1024)}MB). Maximum is 5MB.`,
+    });
+  }
+
+  return snapshot;
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -11,6 +11,7 @@ import { notificationRouter } from "@/server/api/routers/notification";
 import { ganttRouter } from "@/server/api/routers/gantt";
 import { betaRouter } from "@/server/api/routers/beta";
 import { weatherRouter } from "@/server/api/routers/weather";
+import { scheduleRouter } from "@/server/api/routers/schedule";
 
 /**
  * This is the primary router for your server.
@@ -30,6 +31,7 @@ export const appRouter = createTRPCRouter({
   gantt: ganttRouter,
   beta: betaRouter,
   weather: weatherRouter,
+  schedule: scheduleRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/schedule.ts
+++ b/src/server/api/routers/schedule.ts
@@ -1,0 +1,280 @@
+import { TRPCError } from "@trpc/server";
+import { Prisma } from "../../../../generated/prisma";
+import { createTRPCRouter, projectProcedure } from "@/server/api/trpc";
+import { saveVersionSchema, versionIdSchema } from "@/lib/validations/schedule";
+import { hasPermission } from "@/lib/permissions";
+import { captureGanttSnapshot } from "@/server/api/helpers/ganttSnapshot";
+import type { GanttSnapshot } from "@/server/api/helpers/ganttSnapshot";
+
+const MAX_VERSIONS_PER_PROJECT = 50;
+
+/**
+ * Topological sort for tasks with self-referential parentId.
+ * Ensures parents are always inserted before their children.
+ */
+function topologicalSortTasks(tasks: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  const taskMap = new Map<string, Record<string, unknown>>();
+  const childrenMap = new Map<string, string[]>();
+  const roots: string[] = [];
+
+  for (const task of tasks) {
+    const id = task.id as string;
+    taskMap.set(id, task);
+    if (!task.parentId) {
+      roots.push(id);
+    } else {
+      const parentId = task.parentId as string;
+      const children = childrenMap.get(parentId) ?? [];
+      children.push(id);
+      childrenMap.set(parentId, children);
+    }
+  }
+
+  const sorted: Array<Record<string, unknown>> = [];
+  const queue = [...roots];
+
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    const task = taskMap.get(id);
+    if (task) {
+      sorted.push(task);
+    }
+    const children = childrenMap.get(id);
+    if (children) {
+      queue.push(...children);
+    }
+  }
+
+  return sorted;
+}
+
+export const scheduleRouter = createTRPCRouter({
+  saveVersion: projectProcedure
+    .input(saveVersionSchema)
+    .mutation(async ({ ctx, input }) => {
+      const projectId = ctx.project.id;
+      const { name } = input;
+
+      // Check version cap
+      const versionCount = await ctx.db.scheduleVersion.count({
+        where: { projectId },
+      });
+
+      if (versionCount >= MAX_VERSIONS_PER_PROJECT) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Maximum of ${MAX_VERSIONS_PER_PROJECT} versions per project. Delete older versions to save new ones.`,
+        });
+      }
+
+      const snapshot = await captureGanttSnapshot(ctx.db, projectId);
+
+      const result = await ctx.db.scheduleVersion.create({
+        data: {
+          projectId,
+          name,
+          snapshot: snapshot as unknown as Prisma.InputJsonValue,
+          createdById: ctx.session.user.id,
+        },
+        select: {
+          id: true,
+          name: true,
+          createdAt: true,
+        },
+      });
+      return result;
+    }),
+
+  listVersions: projectProcedure
+    .query(async ({ ctx }) => {
+      const projectId = ctx.project.id;
+
+      const versions = await ctx.db.scheduleVersion.findMany({
+        where: { projectId },
+        orderBy: { createdAt: "desc" },
+        select: {
+          id: true,
+          name: true,
+          createdAt: true,
+          createdBy: {
+            select: { id: true, name: true, email: true },
+          },
+        },
+      });
+      return versions;
+    }),
+
+  getVersion: projectProcedure
+    .input(versionIdSchema)
+    .query(async ({ ctx, input }) => {
+      const projectId = ctx.project.id;
+      const { versionId } = input;
+
+      const version = await ctx.db.scheduleVersion.findFirst({
+        where: { id: versionId, projectId },
+        select: {
+          id: true,
+          name: true,
+          snapshot: true,
+          createdAt: true,
+          createdBy: {
+            select: { id: true, name: true, email: true },
+          },
+        },
+      });
+
+      if (!version) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Version not found" });
+      }
+
+      return version;
+    }),
+
+  deleteVersion: projectProcedure
+    .input(versionIdSchema)
+    .mutation(async ({ ctx, input }) => {
+      const projectId = ctx.project.id;
+      const { versionId } = input;
+
+      if (!hasPermission(ctx.projectMember.role, "MANAGE_PROJECTS")) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "You don't have permission to delete versions" });
+      }
+
+      const version = await ctx.db.scheduleVersion.findFirst({
+        where: { id: versionId, projectId },
+      });
+
+      if (!version) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Version not found" });
+      }
+
+      await ctx.db.scheduleVersion.delete({
+        where: { id: versionId },
+      });
+
+      return { success: true };
+    }),
+
+  restoreVersion: projectProcedure
+    .input(versionIdSchema)
+    .mutation(async ({ ctx, input }) => {
+      const projectId = ctx.project.id;
+      const { versionId } = input;
+
+      if (!hasPermission(ctx.projectMember.role, "MANAGE_PROJECTS")) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "You don't have permission to restore versions" });
+      }
+
+      const version = await ctx.db.scheduleVersion.findFirst({
+        where: { id: versionId, projectId },
+      });
+
+      if (!version) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Version not found" });
+      }
+
+      const snapshot = version.snapshot as unknown as GanttSnapshot;
+
+      await ctx.db.$transaction(async (tx) => {
+        // 1. Delete all current Gantt data (order matters for FK constraints)
+        await tx.ganttAssignment.deleteMany({ where: { projectId } });
+        await tx.ganttDependency.deleteMany({ where: { projectId } });
+        await tx.ganttTask.deleteMany({ where: { projectId } });
+        await tx.ganttResource.deleteMany({ where: { projectId } });
+        await tx.ganttTimeRange.deleteMany({ where: { projectId } });
+
+        // 2. Re-insert from snapshot
+        if (snapshot.tasks.length > 0) {
+          // Topological sort ensures parents are inserted before children
+          const sortedTasks = topologicalSortTasks(snapshot.tasks);
+
+          for (const task of sortedTasks) {
+            await tx.ganttTask.create({
+              data: {
+                id: task.id as string,
+                projectId,
+                parentId: task.parentId as string | null,
+                name: task.name as string,
+                percentDone: task.percentDone as number,
+                startDate: task.startDate ? new Date(task.startDate as string) : null,
+                endDate: task.endDate ? new Date(task.endDate as string) : null,
+                duration: task.duration as number | null,
+                durationUnit: (task.durationUnit as string) ?? "day",
+                effort: task.effort as number | null,
+                effortUnit: task.effortUnit as string | null,
+                expanded: (task.expanded as boolean) ?? false,
+                manuallyScheduled: (task.manuallyScheduled as boolean) ?? false,
+                constraintType: task.constraintType as string | null,
+                constraintDate: task.constraintDate ? new Date(task.constraintDate as string) : null,
+                rollup: (task.rollup as boolean) ?? false,
+                cls: task.cls as string | null,
+                iconCls: task.iconCls as string | null,
+                note: task.note as string | null,
+                csiCode: task.csiCode as string | null,
+                baselines: (task.baselines as Prisma.InputJsonValue) ?? Prisma.JsonNull,
+                orderIndex: (task.orderIndex as number) ?? 0,
+                version: (task.version as number) ?? 1,
+                coverImageUrl: task.coverImageUrl as string | null,
+              },
+            });
+          }
+        }
+
+        if (snapshot.resources.length > 0) {
+          await tx.ganttResource.createMany({
+            data: snapshot.resources.map((r) => ({
+              id: r.id as string,
+              projectId,
+              name: r.name as string,
+              city: r.city as string | null,
+              calendar: r.calendar as string | null,
+              image: r.image as string | null,
+            })),
+          });
+        }
+
+        if (snapshot.dependencies.length > 0) {
+          await tx.ganttDependency.createMany({
+            data: snapshot.dependencies.map((d) => ({
+              id: d.id as string,
+              projectId,
+              fromTaskId: d.fromTaskId as string,
+              toTaskId: d.toTaskId as string,
+              type: (d.type as number) ?? 2,
+              lag: (d.lag as number) ?? 0,
+              lagUnit: d.lagUnit as string | null,
+              cls: d.cls as string | null,
+            })),
+          });
+        }
+
+        if (snapshot.assignments.length > 0) {
+          await tx.ganttAssignment.createMany({
+            data: snapshot.assignments.map((a) => ({
+              id: a.id as string,
+              projectId,
+              taskId: a.taskId as string,
+              resourceId: a.resourceId as string,
+              units: (a.units as number) ?? 100,
+            })),
+          });
+        }
+
+        if (snapshot.timeRanges.length > 0) {
+          await tx.ganttTimeRange.createMany({
+            data: snapshot.timeRanges.map((tr) => ({
+              id: tr.id as string,
+              projectId,
+              name: tr.name as string,
+              startDate: new Date(tr.startDate as string),
+              duration: tr.duration as number | null,
+              durationUnit: tr.durationUnit as string | null,
+              cls: tr.cls as string | null,
+            })),
+          });
+        }
+      });
+
+      return { success: true };
+    }),
+});

--- a/src/server/api/routers/schedule.ts
+++ b/src/server/api/routers/schedule.ts
@@ -45,6 +45,18 @@ function topologicalSortTasks(tasks: Array<Record<string, unknown>>): Array<Reco
     }
   }
 
+  // Append any orphaned tasks (parentId references a non-existent task)
+  // so they are not silently dropped during restore
+  if (sorted.length < tasks.length) {
+    const sortedIds = new Set(sorted.map((t) => t.id as string));
+    for (const task of tasks) {
+      if (!sortedIds.has(task.id as string)) {
+        // Clear the broken parentId so it can be inserted as a root task
+        sorted.push({ ...task, parentId: null });
+      }
+    }
+  }
+
   return sorted;
 }
 
@@ -110,24 +122,26 @@ export const scheduleRouter = createTRPCRouter({
       const projectId = ctx.project.id;
       const { versionId } = input;
 
-      const version = await ctx.db.scheduleVersion.findFirst({
-        where: { id: versionId, projectId },
+      const version = await ctx.db.scheduleVersion.findUnique({
+        where: { id: versionId },
         select: {
           id: true,
           name: true,
           snapshot: true,
           createdAt: true,
+          projectId: true,
           createdBy: {
             select: { id: true, name: true, email: true },
           },
         },
       });
 
-      if (!version) {
+      if (!version || version.projectId !== projectId) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Version not found" });
       }
 
-      return version;
+      const { projectId: _, ...versionData } = version;
+      return versionData;
     }),
 
   deleteVersion: projectProcedure
@@ -140,11 +154,11 @@ export const scheduleRouter = createTRPCRouter({
         throw new TRPCError({ code: "FORBIDDEN", message: "You don't have permission to delete versions" });
       }
 
-      const version = await ctx.db.scheduleVersion.findFirst({
-        where: { id: versionId, projectId },
+      const version = await ctx.db.scheduleVersion.findUnique({
+        where: { id: versionId },
       });
 
-      if (!version) {
+      if (!version || version.projectId !== projectId) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Version not found" });
       }
 
@@ -165,11 +179,11 @@ export const scheduleRouter = createTRPCRouter({
         throw new TRPCError({ code: "FORBIDDEN", message: "You don't have permission to restore versions" });
       }
 
-      const version = await ctx.db.scheduleVersion.findFirst({
-        where: { id: versionId, projectId },
+      const version = await ctx.db.scheduleVersion.findUnique({
+        where: { id: versionId },
       });
 
-      if (!version) {
+      if (!version || version.projectId !== projectId) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Version not found" });
       }
 

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -8,9 +8,9 @@ const createPrismaClient = () =>
   });
 
 const globalForPrisma = globalThis as unknown as {
-  prismaV2: ReturnType<typeof createPrismaClient> | undefined;
+  prisma: ReturnType<typeof createPrismaClient> | undefined;
 };
 
-export const db = globalForPrisma.prismaV2 ?? createPrismaClient();
+export const db = globalForPrisma.prisma ?? createPrismaClient();
 
-if (env.NODE_ENV !== "production") globalForPrisma.prismaV2 = db;
+if (env.NODE_ENV !== "production") globalForPrisma.prisma = db;

--- a/src/store/ganttChangesStore.ts
+++ b/src/store/ganttChangesStore.ts
@@ -1,0 +1,133 @@
+'use client';
+
+import { create } from 'zustand';
+import { useEffect } from 'react';
+
+interface TaskEntry {
+  id: string;
+  name: string;
+}
+
+interface InternalState {
+  added: Map<string, string>;    // id → name
+  modified: Map<string, string>; // id → name
+  removed: Map<string, string>;  // id → name
+}
+
+interface GanttChangesStore {
+  hasChanges: boolean;
+  changeCount: number;
+  added: string[];
+  modified: string[];
+  removed: string[];
+  activeVersionName: string | null;
+  setActiveVersionName: (name: string | null) => void;
+  handleTaskChange: (type: 'add' | 'remove' | 'update', tasks: TaskEntry[]) => void;
+  reset: () => void;
+}
+
+function computePublicState(internal: InternalState) {
+  const added = Array.from(internal.added.values());
+  const modified = Array.from(internal.modified.values());
+  const removed = Array.from(internal.removed.values());
+  const changeCount = added.length + modified.length + removed.length;
+  return { hasChanges: changeCount > 0, changeCount, added, modified, removed };
+}
+
+export const useGanttChangesStore = create<GanttChangesStore>((set) => {
+  let internal: InternalState = {
+    added: new Map(),
+    modified: new Map(),
+    removed: new Map(),
+  };
+
+  return {
+    hasChanges: false,
+    changeCount: 0,
+    added: [],
+    modified: [],
+    removed: [],
+    activeVersionName: null,
+
+    setActiveVersionName: (name) => set({ activeVersionName: name }),
+
+    handleTaskChange: (type, tasks) => {
+      const added = new Map(internal.added);
+      const modified = new Map(internal.modified);
+      const removed = new Map(internal.removed);
+
+      for (const task of tasks) {
+        if (type === 'add') {
+          if (removed.has(task.id)) {
+            removed.delete(task.id);
+          } else {
+            added.set(task.id, task.name);
+          }
+          modified.delete(task.id);
+        } else if (type === 'remove') {
+          if (added.has(task.id)) {
+            added.delete(task.id);
+          } else {
+            removed.set(task.id, task.name);
+          }
+          modified.delete(task.id);
+        } else if (type === 'update') {
+          if (!added.has(task.id)) {
+            modified.set(task.id, task.name);
+          }
+        }
+      }
+
+      internal = { added, modified, removed };
+      set(computePublicState(internal));
+    },
+
+    reset: () => {
+      internal = { added: new Map(), modified: new Map(), removed: new Map() };
+      set(computePublicState(internal));
+    },
+  };
+});
+
+/**
+ * Hook that subscribes to window custom events and feeds them into the Zustand store.
+ * Call this once in a component that mounts early (e.g., the app layout).
+ */
+export function useGanttChangesListener() {
+  const { handleTaskChange, reset, setActiveVersionName } = useGanttChangesStore();
+
+  useEffect(() => {
+    const onTaskChange = (e: Event) => {
+      const { type, tasks } = (e as CustomEvent<{
+        type: 'add' | 'remove' | 'update';
+        tasks: TaskEntry[];
+      }>).detail;
+      handleTaskChange(type, tasks);
+    };
+
+    const onVersionSaved = (e: Event) => {
+      const name = (e as CustomEvent<{ name?: string }>).detail?.name;
+      if (name) setActiveVersionName(name);
+      reset();
+    };
+
+    const onVersionRestored = (e: Event) => {
+      const name = (e as CustomEvent<{ name?: string }>).detail?.name;
+      if (name) setActiveVersionName(name);
+      reset();
+    };
+
+    const onReload = () => reset();
+
+    window.addEventListener('gantt-task-change', onTaskChange);
+    window.addEventListener('gantt-version-saved', onVersionSaved);
+    window.addEventListener('gantt-version-restored', onVersionRestored);
+    window.addEventListener('gantt-reload', onReload);
+    return () => {
+      window.removeEventListener('gantt-task-change', onTaskChange);
+      window.removeEventListener('gantt-version-saved', onVersionSaved);
+      window.removeEventListener('gantt-version-restored', onVersionRestored);
+      window.removeEventListener('gantt-reload', onReload);
+    };
+  }, [handleTaskChange, reset, setActiveVersionName]);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -65,15 +65,15 @@
   --lp-nav-btn: rgba(15, 23, 42, 0.06);
   --lp-nav-btn-hover: rgba(15, 23, 42, 0.10);
 
-  /* Gantt bar colors */
-  --gantt-task-bg: rgba(37, 99, 235, 0.18);
-  --gantt-task-fill: rgba(37, 99, 235, 0.45);
-  --gantt-task-border: rgba(37, 99, 235, 0.30);
-  --gantt-task-font: #1e40af;
-  --gantt-summary-bg: rgba(22, 163, 74, 0.18);
-  --gantt-summary-fill: rgba(22, 163, 74, 0.45);
-  --gantt-summary-border: rgba(22, 163, 74, 0.30);
-  --gantt-summary-font: #166534;
+  /* Gantt bar colors — deep indigo-blue child tasks, forest green parent tasks */
+  --gantt-task-bg: rgba(30, 64, 175, 0.85);
+  --gantt-task-fill: rgba(30, 64, 175, 0.95);
+  --gantt-task-border: rgba(30, 64, 175, 0.5);
+  --gantt-task-font: #FFFFFF;
+  --gantt-summary-bg: rgba(21, 128, 61, 0.80);
+  --gantt-summary-fill: rgba(21, 128, 61, 0.92);
+  --gantt-summary-border: rgba(21, 128, 61, 0.5);
+  --gantt-summary-font: #FFFFFF;
   --gantt-milestone-bg: rgba(217, 119, 6, 0.70);
   --gantt-milestone-border: rgba(217, 119, 6, 0.40);
 
@@ -260,6 +260,8 @@ body {
 
 /* Refined with subtle shadow and rounded corners */
 .bryntum-gantt-container .b-gantt-task {
+  background-color: var(--gantt-task-bg) !important;
+  border-color: var(--gantt-task-border) !important;
   border-radius: var(--gantt-task-radius) !important;
   box-shadow: var(--gantt-task-shadow) !important;
   border-width: 1px !important;
@@ -293,17 +295,39 @@ body {
   font-size: 11px !important;
   font-weight: 500 !important;
   letter-spacing: 0.01em !important;
+  color: var(--gantt-task-font) !important;
 }
 
 /* Progress bar inside task */
 .bryntum-gantt-container .b-gantt-task-percent {
+  background-color: var(--gantt-task-fill) !important;
   border-radius: var(--gantt-task-radius) 0 0 var(--gantt-task-radius) !important;
   opacity: 0.85 !important;
 }
 
-/* Parent/summary tasks — slightly tighter radius */
+/* Parent/summary tasks — light translucent navy to differentiate from solid child tasks.
+   Uses .gantt-parent-bar class added by taskRenderer for reliable targeting. */
+.bryntum-gantt-container .b-gantt-task.gantt-parent-bar,
 .bryntum-gantt-container .b-gantt-task.b-gantt-task-parent {
+  background-color: var(--gantt-summary-bg) !important;
+  border-color: var(--gantt-summary-border) !important;
   border-radius: 4px !important;
+  box-shadow: none !important;
+}
+
+.bryntum-gantt-container .b-gantt-task.gantt-parent-bar::before,
+.bryntum-gantt-container .b-gantt-task.b-gantt-task-parent::before {
+  display: none !important;
+}
+
+.bryntum-gantt-container .b-gantt-task.gantt-parent-bar .b-gantt-task-content,
+.bryntum-gantt-container .b-gantt-task.b-gantt-task-parent .b-gantt-task-content {
+  color: var(--gantt-summary-font) !important;
+}
+
+.bryntum-gantt-container .b-gantt-task.gantt-parent-bar .b-gantt-task-percent,
+.bryntum-gantt-container .b-gantt-task.b-gantt-task-parent .b-gantt-task-percent {
+  background-color: var(--gantt-summary-fill) !important;
 }
 
 /* ── Splitter ────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Adds a `ScheduleVersion` model to snapshot and restore Gantt chart data (tasks, dependencies, resources, assignments, time ranges) with a 50-version-per-project cap and 5MB size limit
- New `schedule` tRPC router with save, list, get, delete, and restore procedures (restore uses topological sort for parent-child task ordering)
- Frontend: `VersionControlBar` with change-tracking Zustand store, diff popover, `SaveVersionDialog` (with force-sync + timeout), and `VersionHistoryDrawer` with restore/delete confirmation
- Refactored `BryntumGanttWrapper` and `ganttConfig` to support sync events and version control integration

## Test plan
- [ ] Save a version, verify it appears in version history drawer
- [ ] Modify tasks, confirm the changes pill updates with correct counts
- [ ] Restore a version and verify all Gantt data reverts correctly
- [ ] Delete a version and confirm it's removed from the list
- [ ] Verify permission gating: members/viewers cannot restore or delete