### PR TITLE
Add project icons, fix Gantt subtask expand/collapse bugs

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,6 +122,7 @@ model Project {
     name           String
     location       String          @default("")
     slug           String
+    icon           String          @default("building")
     status         String          @default("active")
     organizationId String
     template       ProjectTemplate @default(BLANK)

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -163,7 +163,9 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     // We dispatch individual change events; the ganttChangesStore accumulates them.
     const taskStore = gantt.project.taskStore;
 
-    const onTaskAdd = ({ records }: { records: Array<{ id?: string; name?: string; isRoot?: boolean }> }) => {
+    const onTaskAdd = ({ records, isExpand }: { records: Array<{ id?: string; name?: string; isRoot?: boolean }>; isExpand?: boolean }) => {
+      // Skip expand/collapse visibility changes — these are not real additions
+      if (isExpand) return;
       const tasks = records
         .filter((r) => !r.isRoot && r.id)
         .map((r) => ({ id: String(r.id), name: r.name ?? 'New Task' }));
@@ -174,7 +176,9 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
       }
     };
 
-    const onTaskRemove = ({ records }: { records: Array<{ id?: string; name?: string; isRoot?: boolean }> }) => {
+    const onTaskRemove = ({ records, isCollapse }: { records: Array<{ id?: string; name?: string; isRoot?: boolean }>; isCollapse?: boolean }) => {
+      // Skip expand/collapse visibility changes — these are not real removals
+      if (isCollapse) return;
       const tasks = records
         .filter((r) => !r.isRoot && r.id)
         .map((r) => ({ id: String(r.id), name: r.name ?? 'Task' }));

--- a/src/components/bryntum/components/GanttToolbar.tsx
+++ b/src/components/bryntum/components/GanttToolbar.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import {
-  Box,
-  Stack,
-  IconButton,
-  Divider,
-} from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { Button } from '@/components/ui/button';
 import {
@@ -26,39 +21,48 @@ const VIEW_PRESETS = [
   { label: 'Year',  value: 'monthAndYear' },
 ] as const;
 
-const ICON_SIZE = 14;
+// ─── Shared card styles (matches VersionControlBar / TaskProgressCard) ────────
 
-// ─── MUI sx overrides ─────────────────────────────────────────────────────────
+/** Card container — groups related controls into a single rounded pill */
+const cardContainerSx = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  height: 34,
+  bgcolor: 'var(--bg-card)',
+  borderRadius: '10px',
+  border: '1px solid var(--border-color)',
+  boxShadow: '0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)',
+  overflow: 'hidden',
+} as const;
 
-/** Small outlined toolbar button (zoom –/+/Fit, nav) */
-const toolBtnSx = {
-  minWidth: 0,
-  px: '10px',
-  py: '4px',
-  fontSize: '12px',
+/** Borderless button inside a card container */
+const cardItemSx = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100%',
+  px: 1.25,
+  border: 'none',
+  bgcolor: 'transparent',
+  color: 'var(--text-secondary)',
+  cursor: 'pointer',
+  fontSize: '0.6875rem',
   fontWeight: 500,
   fontFamily: 'var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif',
-  textTransform: 'none',
-  color: 'var(--text-secondary)',
-  borderColor: 'var(--border-color)',
-  borderRadius: '6px',
-  lineHeight: 1.5,
+  letterSpacing: '-0.01em',
+  lineHeight: 1,
+  transition: 'background-color 0.15s, color 0.15s',
   '&:hover': {
-    borderColor: 'var(--border-color)',
-    backgroundColor: 'action.hover',
+    bgcolor: 'action.hover',
   },
 } as const;
 
-/** Small icon-only toolbar button (nav arrows, export, more) */
-const iconBtnSx = {
-  width: 32,
-  height: 32,
-  border: '1px solid var(--border-color)',
-  borderRadius: '8px',
-  color: 'var(--text-secondary)',
-  '&:hover': {
-    backgroundColor: 'action.hover',
-  },
+/** Thin vertical separator inside a card */
+const cardDividerSx = {
+  width: '1px',
+  height: 14,
+  bgcolor: 'divider',
+  flexShrink: 0,
 } as const;
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -129,6 +133,8 @@ export default function GanttToolbar({
     },
   });
 
+  const hasRightControls = onExport || onColumnsClick || onMoreClick;
+
   return (
     <Stack
       direction="row"
@@ -172,57 +178,60 @@ export default function GanttToolbar({
         })}
       </Box>
 
-      {/* ── Zoom Controls ──────────────────────────────────────────────── */}
-      <Stack direction="row" spacing={0.25} alignItems="center">
-        <Button variant="outlined" size="small" sx={toolBtnSx} onClick={onZoomOut} title="Zoom out">
+      {/* ── Zoom + Nav Controls ──────────────────────────────────────────── */}
+      <Box sx={cardContainerSx}>
+        <Box component="button" sx={cardItemSx} onClick={onZoomOut} title="Zoom out">
           –
-        </Button>
-        <Button variant="outlined" size="small" sx={toolBtnSx} onClick={onZoomIn} title="Zoom in">
+        </Box>
+        <Box sx={cardDividerSx} />
+        <Box component="button" sx={cardItemSx} onClick={onZoomIn} title="Zoom in">
           +
-        </Button>
-        <Button variant="outlined" size="small" sx={toolBtnSx} onClick={onZoomToFit} title="Fit all tasks">
+        </Box>
+        <Box sx={cardDividerSx} />
+        <Box component="button" sx={cardItemSx} onClick={onZoomToFit} title="Fit all tasks">
           Fit
-        </Button>
-
-        <Divider orientation="vertical" flexItem sx={{ mx: 0.5, my: 'auto', height: 18, alignSelf: 'center' }} />
-
-        <IconButton size="small" sx={iconBtnSx} onClick={onShiftPrevious} title="Previous time span">
-          <CaretDoubleLeft size={ICON_SIZE} />
-        </IconButton>
-        <IconButton size="small" sx={iconBtnSx} onClick={onShiftNext} title="Next time span">
-          <CaretDoubleRight size={ICON_SIZE} />
-        </IconButton>
-
-      </Stack>
+        </Box>
+        <Box sx={cardDividerSx} />
+        <Box component="button" sx={cardItemSx} onClick={onShiftPrevious} title="Previous time span">
+          <CaretDoubleLeft size={12} weight="bold" />
+        </Box>
+        <Box sx={cardDividerSx} />
+        <Box component="button" sx={cardItemSx} onClick={onShiftNext} title="Next time span">
+          <CaretDoubleRight size={12} weight="bold" />
+        </Box>
+      </Box>
 
       {/* ── Spacer ─────────────────────────────────────────────────────── */}
       <Box sx={{ flex: 1 }} />
 
       {/* ── Right Controls ─────────────────────────────────────────────── */}
-      <Stack direction="row" spacing={0.5} alignItems="center">
-        {onExport && (
-          <IconButton size="small" sx={iconBtnSx} onClick={onExport} title="Export">
-            <DownloadSimple size={ICON_SIZE} />
-          </IconButton>
-        )}
-        {onColumnsClick && (
-          <Button
-            variant="outlined"
-            size="small"
-            startIcon={<Columns size={ICON_SIZE} />}
-            onClick={onColumnsClick}
-            title="Configure columns"
-            sx={{ ...toolBtnSx, borderRadius: '8px', gap: '6px' }}
-          >
-            Columns
-          </Button>
-        )}
-        {onMoreClick && (
-          <IconButton size="small" sx={iconBtnSx} onClick={onMoreClick} title="More options">
-            <DotsThreeVertical size={ICON_SIZE} />
-          </IconButton>
-        )}
-      </Stack>
+      {hasRightControls && (
+        <Box sx={cardContainerSx}>
+          {onExport && (
+            <Box component="button" sx={cardItemSx} onClick={onExport} title="Export">
+              <DownloadSimple size={12} weight="bold" />
+            </Box>
+          )}
+          {onExport && (onColumnsClick || onMoreClick) && <Box sx={cardDividerSx} />}
+          {onColumnsClick && (
+            <Box
+              component="button"
+              sx={{ ...cardItemSx, gap: 0.5, px: 1.5 }}
+              onClick={onColumnsClick}
+              title="Configure columns"
+            >
+              <Columns size={12} weight="bold" />
+              Columns
+            </Box>
+          )}
+          {onColumnsClick && onMoreClick && <Box sx={cardDividerSx} />}
+          {onMoreClick && (
+            <Box component="button" sx={cardItemSx} onClick={onMoreClick} title="More options">
+              <DotsThreeVertical size={12} weight="bold" />
+            </Box>
+          )}
+        </Box>
+      )}
 
       {/* ── Add Task ───────────────────────────────────────────────────── */}
       {onAddTask && (

--- a/src/components/layout/ProjectSwitcher.tsx
+++ b/src/components/layout/ProjectSwitcher.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef } from 'react';
 import { useParams } from 'next/navigation';
 import { ChevronsUpDown, Search, Check, Plus } from 'lucide-react';
-import { Buildings } from '@phosphor-icons/react';
+import { getProjectIcon } from '@/lib/constants/projectIconComponents';
 import { Box, Typography, Menu, ButtonBase } from '@mui/material';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
 import { useProjectSwitcher } from '@/hooks/useProjectSwitcher';
@@ -63,7 +63,10 @@ export default function ProjectSwitcher() {
           '&:hover': { bgcolor: 'action.selected' },
         }}
       >
-        <Buildings size={15} style={{ color: 'var(--mui-palette-text-secondary)', flexShrink: 0 }} />
+        {(() => {
+          const CurrentIcon = getProjectIcon(currentProject?.icon);
+          return <CurrentIcon size={15} style={{ color: 'var(--mui-palette-text-secondary)', flexShrink: 0 }} />;
+        })()}
         <Typography sx={{ fontSize: 14, fontWeight: 500, color: 'text.secondary', lineHeight: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 160 }}>
           {projectSlug && currentProject ? currentProject.name : 'Select project'}
         </Typography>
@@ -158,17 +161,14 @@ export default function ProjectSwitcher() {
                   '&:hover': { bgcolor: 'action.hover' },
                 }}
               >
-                <Box
-                  sx={{
-                    width: 7,
-                    height: 7,
-                    borderRadius: '50%',
-                    flexShrink: 0,
-                    bgcolor: getStatusColor(project.status),
-                    mt: 0.25,
-                    alignSelf: 'flex-start',
-                  }}
-                />
+                {(() => {
+                  const ItemIcon = getProjectIcon(project.icon);
+                  return (
+                    <Box sx={{ flexShrink: 0, color: 'text.secondary', display: 'flex', alignItems: 'center' }}>
+                      <ItemIcon size={14} />
+                    </Box>
+                  );
+                })()}
                 <Box sx={{ flex: 1, minWidth: 0 }}>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                     <Typography

--- a/src/components/projects/AddProjectDialog.tsx
+++ b/src/components/projects/AddProjectDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Building2, ArrowRight, MapPin } from 'lucide-react';
+import { ArrowRight, MapPin } from '@phosphor-icons/react';
 import { api } from '@/trpc/react';
 import { useRouter } from 'next/navigation';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
@@ -14,6 +14,7 @@ import {
   DialogContent,
   DialogActions,
   TextField,
+  Tooltip,
   Typography,
   alpha,
   useTheme,
@@ -24,6 +25,10 @@ import {
   createProjectSchema,
   type CreateProjectInput,
 } from '@/lib/validations/project';
+import {
+  PROJECT_ICON_OPTIONS,
+  getProjectIcon,
+} from '@/lib/constants/projectIconComponents';
 import usePlacesAutocomplete, { getGeocode } from 'use-places-autocomplete';
 import { useState, useCallback, useEffect } from 'react';
 import { env } from '@/env';
@@ -232,15 +237,20 @@ export default function AddProjectDialog({
     control,
     handleSubmit,
     reset,
+    watch,
     formState: { errors },
   } = useForm<CreateProjectInput>({
     resolver: zodResolver(createProjectSchema),
     defaultValues: {
       name: '',
       location: '',
+      icon: 'building',
       template: 'BLANK',
     },
   });
+
+  const selectedIcon = watch('icon') ?? 'building';
+  const HeaderIcon = getProjectIcon(selectedIcon);
 
   const createProject = api.project.create.useMutation({
     onSuccess: (newProject) => {
@@ -310,9 +320,10 @@ export default function AddProjectDialog({
                 alignItems: 'center',
                 justifyContent: 'center',
                 flexShrink: 0,
+                transition: 'all 0.15s ease',
               }}
             >
-              <Building2
+              <HeaderIcon
                 size={22}
                 style={{ color: theme.palette.primary.main }}
               />
@@ -345,6 +356,80 @@ export default function AddProjectDialog({
 
         <DialogContent sx={{ px: 3.5, pt: 2.5, pb: 1 }}>
           <form onSubmit={handleSubmit(onSubmit)} id="add-project-form">
+            {/* Icon Picker */}
+            <Typography
+              component="label"
+              sx={{
+                display: 'block',
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                color: 'text.secondary',
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+                mb: 0.75,
+              }}
+            >
+              Icon
+            </Typography>
+            <Controller
+              name="icon"
+              control={control}
+              render={({ field }) => (
+                <Box
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(7, 1fr)',
+                    gap: 0.75,
+                    mb: 2.5,
+                  }}
+                >
+                  {PROJECT_ICON_OPTIONS.map(({ id, label, Icon }) => {
+                    const isSelected = (field.value ?? 'building') === id;
+                    return (
+                      <Tooltip key={id} title={label} arrow placement="top">
+                        <Box
+                          component="button"
+                          type="button"
+                          onClick={() => field.onChange(id)}
+                          sx={{
+                            width: '100%',
+                            aspectRatio: '1',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            borderRadius: '10px',
+                            border: '1.5px solid',
+                            borderColor: isSelected
+                              ? theme.palette.primary.main
+                              : 'transparent',
+                            bgcolor: isSelected
+                              ? alpha(theme.palette.primary.main, 0.08)
+                              : 'transparent',
+                            color: isSelected
+                              ? theme.palette.primary.main
+                              : theme.palette.text.secondary,
+                            cursor: 'pointer',
+                            transition: 'all 0.15s ease',
+                            p: 0,
+                            '&:hover': {
+                              bgcolor: isSelected
+                                ? alpha(theme.palette.primary.main, 0.12)
+                                : alpha(theme.palette.divider, 0.12),
+                              color: isSelected
+                                ? theme.palette.primary.main
+                                : theme.palette.text.primary,
+                            },
+                          }}
+                        >
+                          <Icon size={20} weight={isSelected ? 'fill' : 'regular'} />
+                        </Box>
+                      </Tooltip>
+                    );
+                  })}
+                </Box>
+              )}
+            />
+
             {/* Project Name */}
             <Typography
               component="label"

--- a/src/lib/constants/projectIconComponents.ts
+++ b/src/lib/constants/projectIconComponents.ts
@@ -1,0 +1,54 @@
+import {
+  Building,
+  BuildingApartment,
+  BuildingOffice,
+  Buildings,
+  AirTrafficControl,
+  Barn,
+  Blueprint,
+  City,
+  Factory,
+  Garage,
+  Hospital,
+  House,
+  HouseLine,
+  HouseSimple,
+  Lighthouse,
+  Storefront,
+  Warehouse,
+  Windmill,
+  Bulldozer,
+  type Icon as PhosphorIcon,
+} from '@phosphor-icons/react';
+import type { ProjectIcon } from './projectIcons';
+
+export const PROJECT_ICON_OPTIONS: { id: ProjectIcon; label: string; Icon: PhosphorIcon }[] = [
+  { id: 'building', label: 'Building', Icon: Building },
+  { id: 'buildingApartment', label: 'Apartment', Icon: BuildingApartment },
+  { id: 'buildingOffice', label: 'Office', Icon: BuildingOffice },
+  { id: 'buildings', label: 'Buildings', Icon: Buildings },
+  { id: 'airTrafficControl', label: 'Air Traffic Control', Icon: AirTrafficControl },
+  { id: 'barn', label: 'Barn', Icon: Barn },
+  { id: 'blueprint', label: 'Blueprint', Icon: Blueprint },
+  { id: 'city', label: 'City', Icon: City },
+  { id: 'factory', label: 'Factory', Icon: Factory },
+  { id: 'garage', label: 'Garage', Icon: Garage },
+  { id: 'hospital', label: 'Hospital', Icon: Hospital },
+  { id: 'house', label: 'House', Icon: House },
+  { id: 'houseLine', label: 'House Line', Icon: HouseLine },
+  { id: 'houseSimple', label: 'House Simple', Icon: HouseSimple },
+  { id: 'lighthouse', label: 'Lighthouse', Icon: Lighthouse },
+  { id: 'storefront', label: 'Storefront', Icon: Storefront },
+  { id: 'warehouse', label: 'Warehouse', Icon: Warehouse },
+  { id: 'windmill', label: 'Windmill', Icon: Windmill },
+  { id: 'bulldozer', label: 'Bulldozer', Icon: Bulldozer },
+];
+
+const ICON_MAP: Record<string, PhosphorIcon> = Object.fromEntries(
+  PROJECT_ICON_OPTIONS.map(({ id, Icon }) => [id, Icon])
+);
+
+export function getProjectIcon(iconId?: string | null): PhosphorIcon {
+  if (!iconId) return Building;
+  return ICON_MAP[iconId] ?? Building;
+}

--- a/src/lib/constants/projectIcons.ts
+++ b/src/lib/constants/projectIcons.ts
@@ -1,0 +1,23 @@
+export const VALID_PROJECT_ICONS = [
+  'building',
+  'buildingApartment',
+  'buildingOffice',
+  'buildings',
+  'airTrafficControl',
+  'barn',
+  'blueprint',
+  'city',
+  'factory',
+  'garage',
+  'hospital',
+  'house',
+  'houseLine',
+  'houseSimple',
+  'lighthouse',
+  'storefront',
+  'warehouse',
+  'windmill',
+  'bulldozer',
+] as const;
+
+export type ProjectIcon = (typeof VALID_PROJECT_ICONS)[number];

--- a/src/lib/validations/project.ts
+++ b/src/lib/validations/project.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
+import { VALID_PROJECT_ICONS } from "@/lib/constants/projectIcons";
 
 export const createProjectSchema = z.object({
   name: z.string().min(1, "Project name is required").max(100).trim(),
   location: z.string().min(1, "Location is required").max(200).trim(),
+  icon: z.enum(VALID_PROJECT_ICONS).default("building").optional(),
   template: z.enum(["BLANK"]).default("BLANK").optional(),
 });
 

--- a/src/lib/validations/schedule.ts
+++ b/src/lib/validations/schedule.ts
@@ -2,12 +2,12 @@ import { z } from "zod";
 
 export const saveVersionSchema = z.object({
   name: z.string().min(1, "Version name is required").max(100).trim(),
-}).strict();
+});
 
 export type SaveVersionInput = z.infer<typeof saveVersionSchema>;
 
 export const versionIdSchema = z.object({
   versionId: z.string().cuid(),
-}).strict();
+});
 
 export type VersionIdInput = z.infer<typeof versionIdSchema>;

--- a/src/server/api/routers/project.ts
+++ b/src/server/api/routers/project.ts
@@ -148,6 +148,7 @@ export const projectRouter = createTRPCRouter({
         data: {
           name: input.name,
           location: input.location,
+          icon: input.icon,
           slug,
           status: "active",
           organizationId,


### PR DESCRIPTION
## Summary
- Add project icon picker with 19 construction-themed Phosphor icons to the Add Project dialog, persisted to a new `icon` field on the Project model
- Display selected project icons in the ProjectSwitcher trigger and dropdown list
- Fix phantom task creation/deletion when expanding or collapsing Gantt subtasks by guarding on `isExpand`/`isCollapse` flags
- Redesign Gantt toolbar with grouped pill-style card containers for zoom, navigation, and action controls
- Remove `.strict()` from schedule validation schemas to fix compatibility with `projectProcedure` injected keys