### PR TITLE
Refactor task popover, add requirements tracking, and always-visible ellipsis

### DIFF
--- a/claudedocs/components-guide.md
+++ b/claudedocs/components-guide.md
@@ -212,6 +212,16 @@ bryntum/
     BryntumPanelHeader.tsx
     CsiCodeSelector.tsx
     GanttLoadingSpinner.tsx
+    task-popover/             ← extracted sub-components for TaskDetailsPopover
+      types.ts
+      TaskHeader.tsx
+      CoverImageBanner.tsx
+      FolderRow.tsx
+      BaseFolderContent.tsx
+      PhotosFolderContent.tsx
+      TrackableFolderContent.tsx
+      RequirementCounter.tsx
+      FilePreviewPanel.tsx
   hooks/
     useTaskPopover.ts
     useBryntumThemeAssets.ts

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -272,9 +272,11 @@ model GanttTask {
     note               String?
     csiCode            String?
     baselines          Json?
-    coverImageUrl      String?
-    version            Int       @default(1)
-    updatedAt          DateTime  @updatedAt
+    coverImageUrl          String?
+    requiredSubmittals     Int?
+    requiredInspections    Int?
+    version                Int       @default(1)
+    updatedAt              DateTime  @updatedAt
 
     project      Project        @relation(fields: [projectId], references: [id], onDelete: Cascade)
     parent       GanttTask?     @relation("TaskHierarchy", fields: [parentId], references: [id], onDelete: Cascade)

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -567,11 +567,10 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
           text-overflow: ellipsis;
           white-space: nowrap;
         }
-        /* Row actions ⋮ button — right side of name cell, hover-visible */
+        /* Row actions ⋮ button — right side of name cell, always visible */
         .gantt-row-actions-btn {
           flex-shrink: 0;
-          opacity: 0;
-          transition: opacity 0.15s;
+          opacity: 1;
           background: none;
           border: none;
           box-shadow: none;
@@ -584,11 +583,6 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
           font-weight: bold;
           letter-spacing: 1px;
           line-height: 1;
-        }
-        .b-grid-row:hover .gantt-row-actions-btn,
-        .gantt-row-actions-btn:focus,
-        .gantt-row-actions-btn.gantt-menu-open {
-          opacity: 1;
         }
         .gantt-row-actions-btn:hover {
           background: rgba(0, 0, 0, 0.04);

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -2,75 +2,21 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { useDrag } from '@use-gesture/react';
-import { useDropzone } from 'react-dropzone';
-import {
-  X,
-  FolderSimple,
-  FolderOpen,
-  Question,
-  PaperPlaneTilt,
-  PencilSimpleLine,
-  Camera,
-  ClipboardText,
-  type Icon as PhosphorIcon,
-  FileText,
-  Plus,
-  Image,
-  Trash,
-  CaretDown,
-  CaretRight,
-  CalendarBlank,
-  Timer,
-  SquaresFour,
-  List,
-  ImageSquare,
-  DownloadSimple,
-  ArrowsOut,
-} from '@phosphor-icons/react';
-import { Box, Popover, IconButton, Typography, CircularProgress, Divider, Skeleton } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
-import type { Theme } from '@mui/material/styles';
-import UploadOverlay from '@/components/ui/UploadOverlay';
+import { Box, Popover, Typography, Divider } from '@mui/material';
 
 import { POPOVER_WIDTH, POPOVER_EXPANDED_WIDTH } from '../constants';
-import { formatFileSize } from '@/lib/utils/formatting';
-import type { PopoverPlacement } from '../types';
-import { folderData } from '@/lib/folders';
+import { folderData, expandFolderIds } from '@/lib/folders';
 import { useProjectContext } from '@/components/providers/ProjectProvider';
+import { useOrgContext } from '@/components/providers/OrgProvider';
 import UploadDialog from '@/components/documents/UploadDialog';
 import { api } from '@/trpc/react';
-import { useSnackbar } from '@/hooks/useSnackbar';
-import CsiCodeSelector from '@/components/bryntum/components/CsiCodeSelector';
+import type { PopoverPlacement } from '../types';
+import type { PreviewDoc, DocumentItem } from './task-popover/types';
 
-const folderIconMap: Record<string, PhosphorIcon> = {
-  rfi: Question,
-  submittals: PaperPlaneTilt,
-  'change-orders': PencilSimpleLine,
-  photos: Camera,
-  inspections: ClipboardText,
-};
-
-function getStatusInfo(percentDone: number, palette: Theme['palette']) {
-  if (percentDone >= 100) {
-    return { label: 'Complete', dotColor: palette.status.active, chipBg: palette.status.activeBg, chipColor: palette.status.activeText };
-  }
-  if (percentDone > 0) {
-    return { label: 'In Progress', dotColor: palette.status.inProgress, chipBg: palette.status.inProgressBg, chipColor: palette.status.inProgressText };
-  }
-  return { label: 'Not Started', dotColor: palette.text.disabled, chipBg: palette.action.hover, chipColor: palette.text.secondary };
-}
-
-function formatDate(date: Date | string | null | undefined): string {
-  if (!date) return '';
-  return new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-}
-
-function formatDuration(duration: number | null | undefined, unit: string): string {
-  if (!duration) return '';
-  const rounded = Math.round(duration);
-  const u = unit === 'day' ? 'day' : unit;
-  return `${rounded} ${u}${rounded !== 1 ? 's' : ''}`;
-}
+import TaskHeader from './task-popover/TaskHeader';
+import CoverImageBanner from './task-popover/CoverImageBanner';
+import FolderRow from './task-popover/FolderRow';
+import FilePreviewPanel from './task-popover/FilePreviewPanel';
 
 type TaskDetailsPopoverProps = {
   open: boolean;
@@ -88,24 +34,12 @@ export function TaskDetailsPopover({
   onClose,
 }: TaskDetailsPopoverProps) {
   const { projectId, organizationId } = useProjectContext();
-  const theme = useTheme();
-  const { showSnackbar } = useSnackbar();
+  const { memberRole } = useOrgContext();
+  const canManageRequirements = memberRole === 'owner' || memberRole === 'admin';
+
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
   const [uploadFolder, setUploadFolder] = useState<{ id: string; name: string } | null>(null);
-  const [coverUploading, setCoverUploading] = useState(false);
-  const [coverDeleting, setCoverDeleting] = useState(false);
-  const [coverImageLoaded, setCoverImageLoaded] = useState(false);
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const [photosViewMode, setPhotosViewMode] = useState<'grid' | 'list'>('grid');
-  const [previewDoc, setPreviewDoc] = useState<{
-    id: string;
-    name: string;
-    blobUrl: string;
-    mimeType: string;
-    size: number;
-    createdAt: string | Date;
-    uploadedBy: { name: string | null } | null;
-  } | null>(null);
+  const [previewDoc, setPreviewDoc] = useState<PreviewDoc | null>(null);
 
   // ── Drag state ──
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
@@ -127,6 +61,7 @@ export function TaskDetailsPopover({
     },
   );
 
+  // ── Data queries ──
   const utils = api.useUtils();
 
   const { data: taskDetail, isLoading: taskDetailLoading } = api.gantt.taskDetail.useQuery(
@@ -144,68 +79,28 @@ export function TaskDetailsPopover({
     { enabled: !!organizationId && !!projectId && !!taskId }
   );
 
-  const coverImageUrl = taskDetail?.coverImageUrl ?? null;
-  const percentDone = taskDetail?.percentDone ?? 0;
-
-  // Reset image loaded state when cover URL changes (different task opened)
-  useEffect(() => {
-    setCoverImageLoaded(false);
-  }, [coverImageUrl]);
-  const statusInfo = getStatusInfo(percentDone, theme.palette);
-
-  const uploadCoverImage = useCallback(
-    async (file: File) => {
-      if (!taskId) return;
-      const preview = URL.createObjectURL(file);
-      setPreviewUrl(preview);
-      setCoverUploading(true);
-      try {
-        const formData = new FormData();
-        formData.append('file', file);
-        formData.append('projectId', projectId);
-        formData.append('taskId', taskId);
-        const res = await fetch('/api/gantt/cover-image', { method: 'POST', body: formData });
-        if (res.ok) {
-          void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId });
-        } else {
-          const body = await res.json().catch(() => ({ error: 'Upload failed' }));
-          showSnackbar((body as { error?: string }).error ?? 'Upload failed', 'error');
-        }
-      } finally {
-        setCoverUploading(false);
-        URL.revokeObjectURL(preview);
-        setPreviewUrl(null);
-      }
+  // ── Requirement mutation ──
+  const updateRequirementMutation = api.gantt.updateRequirement.useMutation({
+    onSuccess: () => {
+      void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId: taskId! });
     },
-    [taskId, projectId, organizationId, utils, showSnackbar]
+  });
+
+  const handleSaveRequirement = useCallback(
+    (field: 'requiredSubmittals' | 'requiredInspections', count: number | null) => {
+      if (!taskId) return;
+      updateRequirementMutation.mutate({
+        organizationId,
+        projectId,
+        taskId,
+        field,
+        count,
+      });
+    },
+    [taskId, organizationId, projectId, updateRequirementMutation]
   );
 
-  // Cleanup preview URL on unmount
-  useEffect(() => {
-    return () => {
-      if (previewUrl) URL.revokeObjectURL(previewUrl);
-    };
-  }, [previewUrl]);
-
-  const handleCoverRemove = useCallback(async () => {
-    if (!taskId) return;
-    setCoverUploading(true);
-    setCoverDeleting(true);
-    try {
-      const res = await fetch('/api/gantt/cover-image', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ projectId, taskId }),
-      });
-      if (res.ok) {
-        void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId });
-      }
-    } finally {
-      setCoverUploading(false);
-      setCoverDeleting(false);
-    }
-  }, [taskId, projectId, organizationId, utils]);
-
+  // ── Callbacks ──
   const toggleFolder = useCallback((folderId: string) => {
     setExpandedFolders((prev) => {
       const next = new Set(prev);
@@ -218,7 +113,7 @@ export function TaskDetailsPopover({
   const handleUploadComplete = useCallback(() => {
     void utils.document.countByTask.invalidate({ organizationId, projectId, taskId: taskId! });
     void utils.document.listByTask.invalidate({ organizationId, projectId, taskId: taskId! });
-    void utils.document.listByFolder.invalidate();
+    void utils.document.listByFolder.invalidate({ organizationId, projectId, taskId: taskId! });
     setUploadFolder(null);
   }, [organizationId, projectId, taskId, utils]);
 
@@ -228,44 +123,7 @@ export function TaskDetailsPopover({
     onClose();
   };
 
-  const { getRootProps, getInputProps, isDragActive, open: openFilePicker } = useDropzone({
-    onDrop: (files) => {
-      if (files[0]) void uploadCoverImage(files[0]);
-    },
-    onDropRejected: (rejections) => {
-      const code = rejections[0]?.errors[0]?.code;
-      if (code === 'file-too-large') {
-        showSnackbar('Image must be under 10MB', 'error');
-      } else if (code === 'file-invalid-type') {
-        showSnackbar('Only JPG, PNG, GIF, and WebP images are supported', 'error');
-      } else {
-        showSnackbar('File not accepted', 'error');
-      }
-    },
-    accept: {
-      'image/jpeg': ['.jpg', '.jpeg'],
-      'image/png': ['.png'],
-      'image/gif': ['.gif'],
-      'image/webp': ['.webp'],
-    },
-    maxFiles: 1,
-    maxSize: 10 * 1024 * 1024,
-    noClick: !!coverImageUrl,
-    noKeyboard: !!coverImageUrl,
-    disabled: coverUploading,
-  });
-
-  const metaDateRange = [
-    taskDetail?.startDate ? formatDate(taskDetail.startDate) : null,
-    taskDetail?.endDate ? formatDate(taskDetail.endDate) : null,
-  ]
-    .filter(Boolean)
-    .join(' — ');
-
-  const durationLabel = formatDuration(
-    taskDetail?.duration,
-    taskDetail?.durationUnit ?? 'day'
-  );
+  const coverImageUrl = taskDetail?.coverImageUrl ?? null;
 
   return (
     <>
@@ -296,131 +154,57 @@ export function TaskDetailsPopover({
         }}
       >
         <Box sx={{ display: 'flex' }}>
-        {/* ── LEFT PANEL ── */}
-        <Box sx={{ width: POPOVER_WIDTH, flexShrink: 0, bgcolor: 'background.paper', display: 'flex', flexDirection: 'column', maxHeight: '85vh', overflowY: 'auto' }}>
+          {/* ── LEFT PANEL ── */}
+          <Box sx={{ width: POPOVER_WIDTH, flexShrink: 0, bgcolor: 'background.paper', display: 'flex', flexDirection: 'column', maxHeight: '85vh', overflowY: 'auto' }}>
 
-          {/* ── DRAG HANDLE BAR ── */}
-          <Box
-            {...bindDrag()}
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              py: '5px',
-              cursor: isDragging ? 'grabbing' : 'grab',
-              touchAction: 'none',
-              userSelect: 'none',
-              '&:hover .drag-pill': { opacity: 0.5 },
-            }}
-          >
+            {/* Drag handle */}
             <Box
-              className="drag-pill"
+              {...bindDrag()}
               sx={{
-                width: 32,
-                height: 3.5,
-                borderRadius: '999px',
-                bgcolor: 'text.primary',
-                opacity: 0.15,
-                transition: 'opacity 0.15s',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                py: '5px',
+                cursor: isDragging ? 'grabbing' : 'grab',
+                touchAction: 'none',
+                userSelect: 'none',
+                '&:hover .drag-pill': { opacity: 0.5 },
               }}
-            />
-          </Box>
-
-          {/* ── HEADER ── */}
-          <Box
-            sx={{
-              p: '8px 14px 12px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 1.25,
-            }}
-          >
-            {/* Title row: title + close */}
-            <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-            {/* Title + metadata */}
-            <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                <Typography
-                  sx={{
-                    fontWeight: 600,
-                    fontSize: '0.9375rem',
-                    lineHeight: 1.2,
-                    letterSpacing: '-0.01em',
-                    color: 'text.primary',
-                    wordBreak: 'break-word',
-                  }}
-                >
-                  {taskName}
-                </Typography>
-                {taskDetailLoading ? (
-                  <>
-                    <Skeleton variant="text" width={140} height={14} sx={{ borderRadius: '4px' }} />
-                    <Skeleton variant="rounded" width={110} height={20} sx={{ borderRadius: '6px' }} />
-                  </>
-                ) : (
-                  <>
-                    {(metaDateRange || durationLabel) && (
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
-                        {metaDateRange && (
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                            <CalendarBlank size={12} color="var(--mui-palette-text-secondary)" style={{ flexShrink: 0 }} />
-                            <Typography sx={{ fontSize: '0.6875rem', fontWeight: 500, color: 'text.secondary', lineHeight: 1 }}>
-                              {metaDateRange}
-                            </Typography>
-                          </Box>
-                        )}
-                        {metaDateRange && durationLabel && (
-                          <Box sx={{ width: 3, height: 3, borderRadius: '50%', bgcolor: 'text.disabled', flexShrink: 0 }} />
-                        )}
-                        {durationLabel && (
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                            <Timer size={12} color="var(--mui-palette-text-secondary)" style={{ flexShrink: 0 }} />
-                            <Typography sx={{ fontSize: '0.6875rem', fontWeight: 500, color: 'text.secondary', lineHeight: 1 }}>
-                              {durationLabel}
-                            </Typography>
-                          </Box>
-                        )}
-                      </Box>
-                    )}
-                    {taskId && (
-                      <CsiCodeSelector
-                        csiCode={taskDetail?.csiCode}
-                        organizationId={organizationId}
-                        projectId={projectId}
-                        taskId={taskId}
-                      />
-                    )}
-                  </>
-                )}
-              </Box>
-
-              {/* Close button */}
+            >
               <Box
-                component="button"
-                onClick={handleClose}
+                className="drag-pill"
                 sx={{
-                  width: 26,
-                  height: 26,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  borderRadius: '6px',
-                  border: 'none',
-                  bgcolor: 'transparent',
-                  cursor: 'pointer',
-                  color: 'text.secondary',
-                  flexShrink: 0,
-                  mt: '1px',
-                  '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
-                  transition: 'background-color 0.15s, color 0.15s',
+                  width: 32,
+                  height: 3.5,
+                  borderRadius: '999px',
+                  bgcolor: 'text.primary',
+                  opacity: 0.15,
+                  transition: 'opacity 0.15s',
                 }}
-                aria-label="Close"
-              >
-                <X size={13} />
-              </Box>
+              />
             </Box>
 
-            {/* Progress bar */}
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            <TaskHeader
+              taskName={taskName}
+              taskId={taskId}
+              organizationId={organizationId}
+              projectId={projectId}
+              taskDetail={taskDetail}
+              taskDetailLoading={taskDetailLoading}
+              onClose={handleClose}
+            />
+
+            <CoverImageBanner
+              taskId={taskId}
+              projectId={projectId}
+              organizationId={organizationId}
+              coverImageUrl={coverImageUrl}
+            />
+
+            <Divider sx={{ mx: 2 }} />
+
+            {/* ── DOCUMENTS SECTION ── */}
+            <Box sx={{ p: '12px 16px 14px 16px', display: 'flex', flexDirection: 'column', gap: 1 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <Typography
                   sx={{
@@ -428,888 +212,66 @@ export function TaskDetailsPopover({
                     fontWeight: 600,
                     color: 'text.secondary',
                     textTransform: 'uppercase',
-                    letterSpacing: '0.08em',
+                    letterSpacing: '0.1em',
+                    userSelect: 'none',
                     lineHeight: 1,
                   }}
                 >
-                  Progress
-                </Typography>
-                {taskDetailLoading ? (
-                  <Skeleton variant="text" width={24} height={12} sx={{ borderRadius: '3px' }} />
-                ) : (
-                  <Typography
-                    sx={{
-                      fontSize: '0.625rem',
-                      fontWeight: 700,
-                      color: 'text.primary',
-                      lineHeight: 1,
-                      fontVariantNumeric: 'tabular-nums',
-                    }}
-                  >
-                    {Math.round(percentDone)}%
-                  </Typography>
-                )}
-              </Box>
-              {taskDetailLoading ? (
-                <Skeleton variant="rounded" width="100%" height={4} sx={{ borderRadius: '999px' }} />
-              ) : (
-              <Box
-                sx={{
-                  width: '100%',
-                  height: 4,
-                  borderRadius: '999px',
-                  bgcolor: 'rgba(0,0,0,0.05)',
-                  overflow: 'hidden',
-                }}
-              >
-                <Box
-                  sx={{
-                    height: '100%',
-                    borderRadius: '999px',
-                    bgcolor: statusInfo.dotColor,
-                    width: `${Math.min(percentDone, 100)}%`,
-                    transition: 'width 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
-                  }}
-                />
-              </Box>
-              )}
-            </Box>
-          </Box>
-
-          {/* ── COVER IMAGE BANNER ── */}
-          <Box
-            {...getRootProps()}
-            sx={{
-              mx: '14px',
-              mb: '4px',
-              height: 200,
-              overflow: 'hidden',
-              outline: 'none',
-              position: 'relative',
-              borderRadius: '10px',
-              bgcolor: isDragActive
-                ? 'action.selected'
-                : coverImageUrl
-                  ? 'transparent'
-                  : 'background.default',
-              border: coverImageUrl ? 'none' : '1px solid',
-              borderColor: 'divider',
-              transition: 'background-color 0.2s',
-              '&:hover .cover-actions': { opacity: 1 },
-              '&:hover .empty-cover': { borderColor: 'text.secondary', color: 'text.secondary' },
-              cursor: coverImageUrl ? 'default' : 'pointer',
-            }}
-          >
-            <input {...getInputProps()} />
-
-            {coverUploading ? (
-              <UploadOverlay
-                previewUrl={previewUrl}
-                variant={coverDeleting ? 'dark' : previewUrl ? 'dark' : 'light'}
-                text={coverDeleting ? 'Removing…' : 'Uploading…'}
-              />
-            ) : coverImageUrl ? (
-              <>
-                {!coverImageLoaded && (
-                  <Box
-                    sx={{
-                      position: 'absolute',
-                      inset: 0,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      '@keyframes shimmer': {
-                        '0%': { backgroundPosition: '-200% 0' },
-                        '100%': { backgroundPosition: '200% 0' },
-                      },
-                      background: 'linear-gradient(90deg, var(--mui-palette-background-default) 25%, var(--mui-palette-divider) 50%, var(--mui-palette-background-default) 75%)',
-                      backgroundSize: '200% 100%',
-                      animation: 'shimmer 1.8s ease-in-out infinite',
-                    }}
-                  >
-                    <ImageSquare size={18} color="var(--mui-palette-text-disabled)" />
-                  </Box>
-                )}
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={coverImageUrl}
-                  alt="Task cover"
-                  onLoad={() => setCoverImageLoaded(true)}
-                  style={{
-                    width: '100%',
-                    height: '100%',
-                    objectFit: 'cover',
-                    display: 'block',
-                  }}
-                />
-                {/* Bottom gradient fade into paper */}
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    bottom: 0,
-                    left: 0,
-                    right: 0,
-                    height: 40,
-                    background: 'linear-gradient(to top, var(--mui-palette-background-paper), transparent)',
-                    pointerEvents: 'none',
-                  }}
-                />
-                {/* Hover action buttons */}
-                <Box
-                  className="cover-actions"
-                  sx={{
-                    position: 'absolute',
-                    bottom: 8,
-                    right: 8,
-                    display: 'flex',
-                    gap: 0.5,
-                    opacity: 0,
-                    transition: 'opacity 0.2s',
-                  }}
-                >
-                  <Box
-                    component="button"
-                    onClick={(e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      openFilePicker();
-                    }}
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 0.5,
-                      color: 'white',
-                      height: 26,
-                      px: 1,
-                      bgcolor: 'rgba(0,0,0,0.5)',
-                      backdropFilter: 'blur(8px)',
-                      borderRadius: '6px',
-                      border: 'none',
-                      cursor: 'pointer',
-                      fontSize: '0.625rem',
-                      fontWeight: 500,
-                      fontFamily: 'inherit',
-                      letterSpacing: '0.01em',
-                      lineHeight: 1,
-                      '&:hover': { bgcolor: 'rgba(0,0,0,0.65)' },
-                      transition: 'background-color 0.15s',
-                    }}
-                    aria-label="Change cover image"
-                  >
-                    <Image size={12} />
-                    Change
-                  </Box>
-                  <Box
-                    component="button"
-                    onClick={(e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      void handleCoverRemove();
-                    }}
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 0.5,
-                      color: 'white',
-                      height: 26,
-                      px: 1,
-                      bgcolor: 'rgba(0,0,0,0.5)',
-                      backdropFilter: 'blur(8px)',
-                      borderRadius: '6px',
-                      border: 'none',
-                      cursor: 'pointer',
-                      fontSize: '0.625rem',
-                      fontWeight: 500,
-                      fontFamily: 'inherit',
-                      letterSpacing: '0.01em',
-                      lineHeight: 1,
-                      '&:hover': { bgcolor: 'rgba(185,28,28,0.7)' },
-                      transition: 'background-color 0.15s',
-                    }}
-                    aria-label="Remove cover image"
-                  >
-                    <Trash size={12} />
-                    Remove
-                  </Box>
-                </Box>
-              </>
-            ) : (
-              <Box
-                className="empty-cover"
-                sx={{
-                  width: '100%',
-                  height: '100%',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: 0.75,
-                  borderRadius: 'inherit',
-                  border: '1.5px dashed',
-                  borderColor: isDragActive ? 'text.secondary' : 'divider',
-                  color: isDragActive ? 'text.secondary' : 'text.disabled',
-                  transition: 'border-color 0.15s, color 0.15s',
-                }}
-              >
-                <Image size={15} />
-                <Typography sx={{ fontSize: '0.6875rem', fontWeight: 500, color: 'inherit', lineHeight: 1 }}>
-                  {isDragActive ? 'Drop image here' : 'Add cover image'}
+                  Files
                 </Typography>
               </Box>
-            )}
-          </Box>
 
-          {/* ── DIVIDER ── */}
-          <Divider sx={{ mx: 2 }} />
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+                {folderData.map((folder) => {
+                  const count = counts?.[folder.id] ?? 0;
+                  const folderDocs = ((allDocs ?? []) as DocumentItem[]).filter(
+                    (d) => d.folderId === folder.id
+                  );
 
-          {/* ── DOCUMENTS SECTION ── */}
-          <Box
-            sx={{
-              p: '12px 16px 14px 16px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 1,
-            }}
-          >
-            {/* Section header */}
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-              }}
-            >
-              <Typography
-                sx={{
-                  fontSize: '0.5625rem',
-                  fontWeight: 600,
-                  color: 'text.secondary',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.1em',
-                  userSelect: 'none',
-                  lineHeight: 1,
-                }}
-              >
-                Files
-              </Typography>
-            </Box>
+                  // For trackable folders, sum counts across parent + child IDs
+                  let trackingCurrent: number | undefined;
+                  let trackingRequired: number | null | undefined;
+                  if (folder.trackable && folder.requirementField) {
+                    const allIds = expandFolderIds(folder.id);
+                    trackingCurrent = allIds.reduce((sum, id) => sum + (counts?.[id] ?? 0), 0);
+                    trackingRequired = taskDetail?.[folder.requirementField] ?? null;
+                  }
 
-            {/* Folder tree */}
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
-              {folderData.map((folder) => {
-                const count = counts?.[folder.id] ?? 0;
-                const isOpen = expandedFolders.has(folder.id);
-                const folderDocs = (allDocs ?? []).filter((d) => d.folderId === folder.id);
-
-                return (
-                  <Box key={folder.id}>
-                    {/* Folder row */}
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 0.75,
-                        px: 0.75,
-                        py: 0.625,
-                        borderRadius: '8px',
-                        cursor: 'pointer',
-                        userSelect: 'none',
-                        '&:hover': {
-                          bgcolor: 'action.hover',
-                        },
-                        transition: 'background-color 0.15s',
-                      }}
-                      onClick={() => toggleFolder(folder.id)}
-                    >
-                      {isOpen ? (
-                        <CaretDown
-                          size={14}
-                          color="var(--mui-palette-text-disabled)"
-                          style={{ flexShrink: 0 }}
-                        />
-                      ) : (
-                        <CaretRight
-                          size={14}
-                          color="var(--mui-palette-text-disabled)"
-                          style={{ flexShrink: 0 }}
-                        />
-                      )}
-                      {(() => {
-                        const FolderIcon = folderIconMap[folder.id] ?? (isOpen ? FolderOpen : FolderSimple);
-                        return <FolderIcon size={14} color={folder.color} style={{ flexShrink: 0 }} />;
-                      })()}
-                      <Typography
-                        sx={{
-                          fontSize: '0.8125rem',
-                          fontWeight: isOpen ? 600 : 450,
-                          flex: 1,
-                          color: 'text.primary',
-                          lineHeight: 1,
-                        }}
-                      >
-                        {folder.name}
-                      </Typography>
-                      {count > 0 && (
-                        <Box
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            minWidth: 18,
-                            height: 18,
-                            borderRadius: '999px',
-                            bgcolor: 'rgba(0,0,0,0.05)',
-                            px: 0.75,
-                          }}
-                        >
-                          <Typography
-                            sx={{
-                              fontSize: '0.625rem',
-                              fontWeight: 600,
-                              color: 'text.secondary',
-                              lineHeight: 1,
-                              fontVariantNumeric: 'tabular-nums',
-                            }}
-                          >
-                            {count}
-                          </Typography>
-                        </Box>
-                      )}
-                      <IconButton
-                        size="small"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setUploadFolder({ id: folder.id, name: folder.name });
-                        }}
-                        sx={{
-                          p: 0.5,
-                          width: 22,
-                          height: 22,
-                          color: 'text.disabled',
-                          '&:hover': { color: 'primary.main', bgcolor: 'action.hover' },
-                          transition: 'color 0.15s',
-                        }}
-                        aria-label={`Upload to ${folder.name}`}
-                      >
-                        <Plus size={13} />
-                      </IconButton>
-                    </Box>
-
-                    {/* Expanded file rows — Photos folder gets grid/list; others get standard list */}
-                    {isOpen && folderDocs.length > 0 && folder.id === 'photos' && (
-                      <Box sx={{ pt: 1, pl: '20px' }}>
-                        {/* Grid Toolbar */}
-                        <Box
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'space-between',
-                            pb: 0.5,
-                          }}
-                        >
-                          {/* View Toggle Pill */}
-                          <Box
-                            sx={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: '2px',
-                              bgcolor: 'action.selected',
-                              borderRadius: '12px',
-                              p: '2px',
-                            }}
-                          >
-                            <Box
-                              component="button"
-                              onClick={() => setPhotosViewMode('grid')}
-                              sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                px: 1,
-                                py: 0.5,
-                                borderRadius: '6px',
-                                border: 'none',
-                                cursor: 'pointer',
-                                bgcolor: photosViewMode === 'grid' ? 'background.paper' : 'transparent',
-                                color: photosViewMode === 'grid' ? 'text.primary' : 'text.secondary',
-                                transition: 'all 0.15s',
-                                boxShadow: photosViewMode === 'grid' ? '0 1px 2px rgba(0,0,0,0.08)' : 'none',
-                              }}
-                              aria-label="Grid view"
-                            >
-                              <SquaresFour size={13} />
-                            </Box>
-                            <Box
-                              component="button"
-                              onClick={() => setPhotosViewMode('list')}
-                              sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                px: 1,
-                                py: 0.5,
-                                borderRadius: '6px',
-                                border: 'none',
-                                cursor: 'pointer',
-                                bgcolor: photosViewMode === 'list' ? 'background.paper' : 'transparent',
-                                color: photosViewMode === 'list' ? 'text.primary' : 'text.secondary',
-                                transition: 'all 0.15s',
-                                boxShadow: photosViewMode === 'list' ? '0 1px 2px rgba(0,0,0,0.08)' : 'none',
-                              }}
-                              aria-label="List view"
-                            >
-                              <List size={13} />
-                            </Box>
-                          </Box>
-                          {/* Date label */}
-                          {folderDocs[0]?.createdAt && (
-                            <Typography
-                              sx={{
-                                fontSize: 11,
-                                fontWeight: 500,
-                                color: 'text.secondary',
-                                                              }}
-                            >
-                              {new Date(folderDocs[0].createdAt as string | Date).toLocaleDateString(
-                                'en-US',
-                                { month: 'short', year: 'numeric' }
-                              )}
-                            </Typography>
-                          )}
-                        </Box>
-
-                        {/* Grid or List */}
-                        {photosViewMode === 'grid' ? (
-                          <Box
-                            sx={{
-                              display: 'grid',
-                              gridTemplateColumns: 'repeat(3, 1fr)',
-                              gap: '6px',
-                              pt: 0.5,
-                            }}
-                          >
-                            {folderDocs.map((doc) => (
-                              <Box
-                                key={doc.id}
-                                onClick={() =>
-                                  setPreviewDoc({
-                                    id: doc.id,
-                                    name: doc.name,
-                                    blobUrl: doc.blobUrl,
-                                    mimeType: doc.mimeType,
-                                    size: doc.size,
-                                    createdAt: doc.createdAt as string | Date,
-                                    uploadedBy: doc.uploadedBy ?? null,
-                                  })
-                                }
-                                sx={{
-                                  height: 70,
-                                  borderRadius: '8px',
-                                  overflow: 'hidden',
-                                  cursor: 'pointer',
-                                  bgcolor: 'action.hover',
-                                  border: '2px solid',
-                                  borderColor: previewDoc?.id === doc.id ? 'primary.main' : 'transparent',
-                                  transition: 'border-color 0.15s, transform 0.15s',
-                                  '&:hover': {
-                                    transform: 'scale(1.02)',
-                                    borderColor: previewDoc?.id === doc.id ? 'primary.main' : 'divider',
-                                  },
-                                }}
-                              >
-                                {doc.mimeType.startsWith('image/') ? (
-                                  /* eslint-disable-next-line @next/next/no-img-element */
-                                  <img
-                                    src={doc.blobUrl}
-                                    alt={doc.name}
-                                    style={{
-                                      width: '100%',
-                                      height: '100%',
-                                      objectFit: 'cover',
-                                      display: 'block',
-                                    }}
-                                  />
-                                ) : (
-                                  <Box
-                                    sx={{
-                                      width: '100%',
-                                      height: '100%',
-                                      display: 'flex',
-                                      alignItems: 'center',
-                                      justifyContent: 'center',
-                                    }}
-                                  >
-                                    <FileText size={20} color="var(--mui-palette-text-disabled)" />
-                                  </Box>
-                                )}
-                              </Box>
-                            ))}
-                          </Box>
-                        ) : (
-                          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.125, pt: 0.5 }}>
-                            {folderDocs.map((doc) => (
-                              <Box
-                                key={doc.id}
-                                onClick={() =>
-                                  setPreviewDoc({
-                                    id: doc.id,
-                                    name: doc.name,
-                                    blobUrl: doc.blobUrl,
-                                    mimeType: doc.mimeType,
-                                    size: doc.size,
-                                    createdAt: doc.createdAt as string | Date,
-                                    uploadedBy: doc.uploadedBy ?? null,
-                                  })
-                                }
-                                sx={{
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  gap: 1,
-                                  py: '5px',
-                                  pr: 1,
-                                  pl: '18px',
-                                  borderRadius: '12px',
-                                  cursor: 'pointer',
-                                  bgcolor: previewDoc?.id === doc.id ? 'action.selected' : 'transparent',
-                                  '&:hover': { bgcolor: 'action.hover' },
-                                }}
-                              >
-                                <FileText
-                                  size={14}
-                                  color="var(--mui-palette-text-secondary)"
-                                  style={{ flexShrink: 0 }}
-                                />
-                                <Typography
-                                  sx={{
-                                    fontSize: 12,
-                                    flex: 1,
-                                    color: 'text.primary',
-                                    overflow: 'hidden',
-                                    textOverflow: 'ellipsis',
-                                    whiteSpace: 'nowrap',
-                                                                      }}
-                                >
-                                  {doc.name}
-                                </Typography>
-                                {'createdAt' in doc && doc.createdAt && (
-                                  <Typography
-                                    sx={{
-                                      fontSize: 11,
-                                      color: 'text.secondary',
-                                                                            flexShrink: 0,
-                                      opacity: 0.7,
-                                    }}
-                                  >
-                                    {new Date(doc.createdAt as string | Date).toLocaleDateString(
-                                      'en-US',
-                                      { month: 'short', day: 'numeric' }
-                                    )}
-                                  </Typography>
-                                )}
-                              </Box>
-                            ))}
-                          </Box>
-                        )}
-                      </Box>
-                    )}
-                    {isOpen && folderDocs.length > 0 && folder.id !== 'photos' && (
-                      <Box
-                        sx={{
-                          pl: '20px',
-                          display: 'flex',
-                          flexDirection: 'column',
-                          gap: 0.125,
-                        }}
-                      >
-                        {folderDocs.map((doc) => (
-                          <Box
-                            key={doc.id}
-                            onClick={() =>
-                              setPreviewDoc({
-                                id: doc.id,
-                                name: doc.name,
-                                blobUrl: doc.blobUrl,
-                                mimeType: doc.mimeType,
-                                size: doc.size,
-                                createdAt: doc.createdAt as string | Date,
-                                uploadedBy: doc.uploadedBy ?? null,
-                              })
-                            }
-                            sx={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: 1,
-                              pt: '5px',
-                              pb: '5px',
-                              pr: 1,
-                              pl: '18px',
-                              borderRadius: '12px',
-                              cursor: 'pointer',
-                              bgcolor: previewDoc?.id === doc.id ? 'action.selected' : 'transparent',
-                              '&:hover': { bgcolor: previewDoc?.id === doc.id ? 'action.selected' : 'action.hover' },
-                            }}
-                          >
-                            <FileText
-                              size={14}
-                              color={previewDoc?.id === doc.id
-                                ? 'var(--mui-palette-primary-main)'
-                                : 'var(--mui-palette-text-secondary)'}
-                              style={{ flexShrink: 0 }}
-                            />
-                            <Typography
-                              sx={{
-                                fontSize: 12,
-                                fontWeight: previewDoc?.id === doc.id ? 500 : 400,
-                                flex: 1,
-                                color: 'text.primary',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                                                              }}
-                            >
-                              {doc.name}
-                            </Typography>
-                            {'createdAt' in doc && doc.createdAt && (
-                              <Typography
-                                sx={{
-                                  fontSize: 11,
-                                  color: 'text.secondary',
-                                                                    flexShrink: 0,
-                                  opacity: 0.7,
-                                }}
-                              >
-                                {new Date(doc.createdAt as string | Date).toLocaleDateString(
-                                  'en-US',
-                                  { month: 'short', day: 'numeric' }
-                                )}
-                              </Typography>
-                            )}
-                          </Box>
-                        ))}
-                      </Box>
-                    )}
-                    {isOpen && folderDocs.length === 0 && (
-                      <Box
-                        onClick={() => setUploadFolder({ id: folder.id, name: folder.name })}
-                        sx={{
-                          ml: '36px',
-                          mr: 0.75,
-                          my: 0.75,
-                          py: 1.5,
-                          display: 'flex',
-                          flexDirection: 'column',
-                          alignItems: 'center',
-                          gap: 0.5,
-                          border: '1.5px dashed',
-                          borderColor: 'divider',
-                          borderRadius: '8px',
-                          cursor: 'pointer',
-                          transition: 'border-color 0.15s, background-color 0.15s',
-                          '&:hover': {
-                            borderColor: 'primary.main',
-                            bgcolor: 'rgba(0,0,0,0.02)',
-                          },
-                        }}
-                      >
-                        <Plus size={16} color="var(--mui-palette-text-disabled)" />
-                        <Typography
-                          sx={{
-                            fontSize: 11,
-                            color: 'text.disabled',
-                          }}
-                        >
-                          Drop files or click to upload
-                        </Typography>
-                      </Box>
-                    )}
-                  </Box>
-                );
-              })}
+                  return (
+                    <FolderRow
+                      key={folder.id}
+                      folder={folder}
+                      isExpanded={expandedFolders.has(folder.id)}
+                      onToggle={() => toggleFolder(folder.id)}
+                      count={count}
+                      docs={folderDocs}
+                      onUpload={setUploadFolder}
+                      onSelectDoc={setPreviewDoc}
+                      selectedDocId={previewDoc?.id ?? null}
+                      // Tracking props
+                      required={trackingRequired}
+                      current={trackingCurrent}
+                      canManage={canManageRequirements}
+                      onSaveRequirement={
+                        folder.requirementField
+                          ? (count) => handleSaveRequirement(folder.requirementField!, count)
+                          : undefined
+                      }
+                      isRequirementPending={updateRequirementMutation.isPending}
+                    />
+                  );
+                })}
+              </Box>
             </Box>
           </Box>
 
-        </Box>
-        {/* ── END LEFT PANEL ── */}
-
-        {/* ── RIGHT PREVIEW PANEL ── */}
-        {previewDoc && (
-          <>
-            <Divider orientation="vertical" flexItem />
-            <Box
-              sx={{
-                flex: 1,
-                display: 'flex',
-                flexDirection: 'column',
-                bgcolor: 'background.paper',
-                minWidth: 0,
-                animation: 'slideInRight 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
-                '@keyframes slideInRight': {
-                  from: { opacity: 0, transform: 'translateX(12px)' },
-                  to: { opacity: 1, transform: 'translateX(0)' },
-                },
-              }}
-            >
-              {/* Preview Header */}
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  px: '20px',
-                  py: '14px',
-                }}
-              >
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
-                  {previewDoc.mimeType.startsWith('image/') ? (
-                    <ImageSquare
-                      size={16}
-                      color="var(--mui-palette-text-secondary)"
-                      style={{ flexShrink: 0 }}
-                    />
-                  ) : (
-                    <FileText
-                      size={16}
-                      color="var(--mui-palette-text-secondary)"
-                      style={{ flexShrink: 0 }}
-                    />
-                  )}
-                  <Typography
-                    noWrap
-                    sx={{
-                      fontSize: 13,
-                      fontWeight: 600,
-                      color: 'text.primary',
-                                          }}
-                  >
-                    {previewDoc.name}
-                  </Typography>
-                </Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
-                  <Box
-                    component="button"
-                    onClick={() => window.open(previewDoc.blobUrl, '_blank')}
-                    sx={{
-                      width: 28,
-                      height: 28,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      borderRadius: '6px',
-                      border: 'none',
-                      bgcolor: 'transparent',
-                      cursor: 'pointer',
-                      color: 'text.disabled',
-                      '&:hover': { bgcolor: 'action.hover', color: 'text.secondary' },
-                      transition: 'background-color 0.15s, color 0.15s',
-                    }}
-                    aria-label="Download"
-                  >
-                    <DownloadSimple size={14} />
-                  </Box>
-                  <Box
-                    component="button"
-                    onClick={() => window.open(previewDoc.blobUrl, '_blank')}
-                    sx={{
-                      width: 28,
-                      height: 28,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      borderRadius: '6px',
-                      border: 'none',
-                      bgcolor: 'transparent',
-                      cursor: 'pointer',
-                      color: 'text.disabled',
-                      '&:hover': { bgcolor: 'action.hover', color: 'text.secondary' },
-                      transition: 'background-color 0.15s, color 0.15s',
-                    }}
-                    aria-label="Expand"
-                  >
-                    <ArrowsOut size={14} />
-                  </Box>
-                </Box>
-              </Box>
-
-              <Divider />
-
-              {/* Image / File Preview Area */}
-              <Box
-                sx={{
-                  flex: 1,
-                  overflow: 'hidden',
-                  bgcolor: 'background.default',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                {previewDoc.mimeType.startsWith('image/') ? (
-                  /* eslint-disable-next-line @next/next/no-img-element */
-                  <img
-                    src={previewDoc.blobUrl}
-                    alt={previewDoc.name}
-                    style={{
-                      width: '100%',
-                      height: '100%',
-                      objectFit: 'cover',
-                      display: 'block',
-                    }}
-                  />
-                ) : (
-                  <FileText
-                    size={48}
-                    color="var(--mui-palette-text-disabled)"
-                  />
-                )}
-              </Box>
-
-              <Divider />
-
-              {/* File Metadata */}
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 0,
-                  px: '20px',
-                  py: '12px',
-                }}
-              >
-                {previewDoc.uploadedBy?.name && (
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', py: '8px', borderBottom: '1px solid', borderBottomColor: 'divider' }}>
-                    <Typography sx={{ fontSize: '0.625rem', fontWeight: 500, color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.06em', lineHeight: 1 }}>
-                      Uploaded by
-                    </Typography>
-                    <Typography sx={{ fontSize: '0.6875rem', fontWeight: 600, color: 'text.primary', lineHeight: 1 }}>
-                      {previewDoc.uploadedBy.name}
-                    </Typography>
-                  </Box>
-                )}
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', py: '8px', borderBottom: '1px solid', borderBottomColor: 'divider' }}>
-                  <Typography sx={{ fontSize: '0.625rem', fontWeight: 500, color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.06em', lineHeight: 1 }}>
-                    Date
-                  </Typography>
-                  <Typography sx={{ fontSize: '0.6875rem', fontWeight: 600, color: 'text.primary', lineHeight: 1 }}>
-                    {new Date(previewDoc.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-                  </Typography>
-                </Box>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', py: '8px', borderBottom: '1px solid', borderBottomColor: 'divider' }}>
-                  <Typography sx={{ fontSize: '0.625rem', fontWeight: 500, color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.06em', lineHeight: 1 }}>
-                    Size
-                  </Typography>
-                  <Typography sx={{ fontSize: '0.6875rem', fontWeight: 600, color: 'text.primary', lineHeight: 1 }}>
-                    {formatFileSize(previewDoc.size)}
-                  </Typography>
-                </Box>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', py: '8px' }}>
-                  <Typography sx={{ fontSize: '0.625rem', fontWeight: 500, color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.06em', lineHeight: 1 }}>
-                    Type
-                  </Typography>
-                  <Typography sx={{ fontSize: '0.6875rem', fontWeight: 600, color: 'text.primary', lineHeight: 1 }}>
-                    {previewDoc.mimeType.split('/')[1]?.toUpperCase() ?? previewDoc.mimeType}
-                  </Typography>
-                </Box>
-              </Box>
-            </Box>
-          </>
-        )}
+          {/* ── RIGHT PREVIEW PANEL ── */}
+          {previewDoc && (
+            <>
+              <Divider orientation="vertical" flexItem />
+              <FilePreviewPanel previewDoc={previewDoc} />
+            </>
+          )}
         </Box>
       </Popover>
 
@@ -1327,7 +289,6 @@ export function TaskDetailsPopover({
           onUploadComplete={handleUploadComplete}
         />
       )}
-
     </>
   );
 }

--- a/src/components/bryntum/components/TaskProgressCard.tsx
+++ b/src/components/bryntum/components/TaskProgressCard.tsx
@@ -4,28 +4,49 @@ import { useMemo } from 'react';
 import { Box, Typography } from '@mui/material';
 
 interface TaskProgressCardProps {
-  completedTaskCount: number;
-  taskCount: number;
+  uploaded: number;
+  required: number;
 }
 
-const SEGMENT_COUNT = 8;
+export default function TaskProgressCard({ uploaded, required }: TaskProgressCardProps) {
+  const percent = required > 0 ? Math.min(Math.round((uploaded / required) * 100), 100) : 0;
+  const isFulfilled = required > 0 && uploaded >= required;
+  const remaining = Math.max(required - uploaded, 0);
 
-export default function TaskProgressCard({ completedTaskCount, taskCount }: TaskProgressCardProps) {
-  const percent = taskCount > 0 ? Math.round((completedTaskCount / taskCount) * 100) : 0;
-  const filledSegments = Math.round((percent / 100) * SEGMENT_COUNT);
-
-  const fillColor = useMemo(() => {
-    if (percent >= 100) return 'var(--status-green)';
-    if (percent >= 60) return 'var(--status-amber)';
+  const accentColor = useMemo(() => {
+    if (isFulfilled) return 'var(--status-green)';
+    if (percent >= 50) return 'var(--status-amber)';
     return 'var(--accent-primary)';
-  }, [percent]);
+  }, [percent, isFulfilled]);
+
+  if (required === 0) {
+    return (
+      <Box
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          height: 34,
+          px: 1.5,
+          borderRadius: '10px',
+          bgcolor: 'var(--bg-card)',
+          border: '1px solid var(--border-color)',
+          boxShadow: '0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)',
+          flexShrink: 0,
+        }}
+      >
+        <Typography sx={{ fontSize: '0.625rem', fontWeight: 500, color: 'text.disabled', lineHeight: 1, whiteSpace: 'nowrap' }}>
+          No requirements set
+        </Typography>
+      </Box>
+    );
+  }
 
   return (
     <Box
       sx={{
         display: 'inline-flex',
         alignItems: 'center',
-        gap: 1,
+        gap: '10px',
         height: 34,
         pl: 1.25,
         pr: 1.5,
@@ -36,74 +57,59 @@ export default function TaskProgressCard({ completedTaskCount, taskCount }: Task
         flexShrink: 0,
       }}
     >
-      {/* Segment gauge */}
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '2px',
-        }}
-      >
-        {Array.from({ length: SEGMENT_COUNT }, (_, i) => {
-          const isFilled = i < filledSegments;
-          return (
-            <Box
-              key={i}
-              sx={{
-                width: 4,
-                height: 14,
-                borderRadius: '1.5px',
-                bgcolor: isFilled ? fillColor : 'var(--border-color)',
-                opacity: isFilled ? 1 - i * 0.03 : 0.5,
-                transition: 'background-color 0.3s ease, opacity 0.3s ease',
-              }}
-            />
-          );
-        })}
-      </Box>
-
-      {/* Fraction */}
+      {/* Big remaining number — the hero */}
       <Typography
-        component="span"
         sx={{
-          fontSize: '0.75rem',
-          fontWeight: 600,
-          color: 'text.primary',
+          fontSize: '1.0625rem',
+          fontWeight: 700,
+          color: isFulfilled ? 'var(--status-green)' : 'text.primary',
           lineHeight: 1,
           fontVariantNumeric: 'tabular-nums',
-          letterSpacing: '-0.02em',
-          whiteSpace: 'nowrap',
+          letterSpacing: '-0.03em',
         }}
       >
-        {completedTaskCount}
-        <Typography
-          component="span"
-          sx={{
-            fontSize: '0.6875rem',
-            fontWeight: 400,
-            color: 'text.disabled',
-            mx: '1px',
-          }}
-        >
-          /
-        </Typography>
-        {taskCount}
+        {remaining}
       </Typography>
 
-      {/* Label */}
-      <Typography
-        sx={{
-          fontSize: '0.5625rem',
-          fontWeight: 600,
-          color: 'text.disabled',
-          lineHeight: 1,
-          textTransform: 'uppercase',
-          letterSpacing: '0.08em',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        tasks
-      </Typography>
+      {/* Right side: bar + label */}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '4px', minWidth: 52 }}>
+        {/* Progress bar */}
+        <Box
+          sx={{
+            width: '100%',
+            height: 3,
+            borderRadius: '1.5px',
+            bgcolor: 'rgba(0,0,0,0.06)',
+            overflow: 'hidden',
+          }}
+        >
+          <Box
+            sx={{
+              height: '100%',
+              borderRadius: '1.5px',
+              bgcolor: accentColor,
+              width: `${percent}%`,
+              minWidth: uploaded > 0 ? 3 : 0,
+              transition: 'width 0.4s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.3s ease',
+            }}
+          />
+        </Box>
+
+        {/* Label */}
+        <Typography
+          sx={{
+            fontSize: '0.5rem',
+            fontWeight: 600,
+            color: isFulfilled ? 'var(--status-green)' : 'text.disabled',
+            lineHeight: 1,
+            textTransform: 'uppercase',
+            letterSpacing: '0.06em',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {isFulfilled ? 'all complete' : `remaining of ${required}`}
+        </Typography>
+      </Box>
     </Box>
   );
 }

--- a/src/components/bryntum/components/task-popover/BaseFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/BaseFolderContent.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { FileText, Plus } from '@phosphor-icons/react';
+import type { FolderContentProps, PreviewDoc } from './types';
+
+function BaseFolderContentInner({
+  docs,
+  onSelectDoc,
+  selectedDocId,
+  onUpload,
+  folderName,
+}: FolderContentProps) {
+  if (docs.length === 0) {
+    return (
+      <Box
+        onClick={onUpload}
+        sx={{
+          ml: '36px',
+          mr: 0.75,
+          my: 0.75,
+          py: 1.5,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 0.5,
+          border: '1.5px dashed',
+          borderColor: 'divider',
+          borderRadius: '8px',
+          cursor: 'pointer',
+          transition: 'border-color 0.15s, background-color 0.15s',
+          '&:hover': {
+            borderColor: 'primary.main',
+            bgcolor: 'rgba(0,0,0,0.02)',
+          },
+        }}
+      >
+        <Plus size={16} color="var(--mui-palette-text-disabled)" />
+        <Typography sx={{ fontSize: 11, color: 'text.disabled' }}>
+          Drop files or click to upload
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ pl: '20px', display: 'flex', flexDirection: 'column', gap: 0.125 }}>
+      {docs.map((doc) => {
+        const isSelected = selectedDocId === doc.id;
+        const preview: PreviewDoc = {
+          id: doc.id,
+          name: doc.name,
+          blobUrl: doc.blobUrl,
+          mimeType: doc.mimeType,
+          size: doc.size,
+          createdAt: doc.createdAt,
+          uploadedBy: doc.uploadedBy ?? null,
+        };
+
+        return (
+          <Box
+            key={doc.id}
+            onClick={() => onSelectDoc(preview)}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              pt: '5px',
+              pb: '5px',
+              pr: 1,
+              pl: '18px',
+              borderRadius: '12px',
+              cursor: 'pointer',
+              bgcolor: isSelected ? 'action.selected' : 'transparent',
+              '&:hover': { bgcolor: isSelected ? 'action.selected' : 'action.hover' },
+            }}
+          >
+            <FileText
+              size={14}
+              color={isSelected
+                ? 'var(--mui-palette-primary-main)'
+                : 'var(--mui-palette-text-secondary)'}
+              style={{ flexShrink: 0 }}
+            />
+            <Typography
+              sx={{
+                fontSize: 12,
+                fontWeight: isSelected ? 500 : 400,
+                flex: 1,
+                color: 'text.primary',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {doc.name}
+            </Typography>
+            {doc.createdAt != null && (
+              <Typography
+                sx={{
+                  fontSize: 11,
+                  color: 'text.secondary',
+                  flexShrink: 0,
+                  opacity: 0.7,
+                }}
+              >
+                {new Date(doc.createdAt).toLocaleDateString(
+                  'en-US',
+                  { month: 'short', day: 'numeric' }
+                )}
+              </Typography>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+const BaseFolderContent = React.memo(BaseFolderContentInner);
+export default BaseFolderContent;

--- a/src/components/bryntum/components/task-popover/CoverImageBanner.tsx
+++ b/src/components/bryntum/components/task-popover/CoverImageBanner.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { useDropzone } from 'react-dropzone';
+import { Box, Typography } from '@mui/material';
+import { Image, Trash, ImageSquare } from '@phosphor-icons/react';
+import UploadOverlay from '@/components/ui/UploadOverlay';
+import { api } from '@/trpc/react';
+import { useSnackbar } from '@/hooks/useSnackbar';
+
+interface CoverImageBannerProps {
+  taskId?: string;
+  projectId: string;
+  organizationId: string;
+  coverImageUrl: string | null;
+}
+
+export default function CoverImageBanner({
+  taskId,
+  projectId,
+  organizationId,
+  coverImageUrl,
+}: CoverImageBannerProps) {
+  const { showSnackbar } = useSnackbar();
+  const utils = api.useUtils();
+  const [coverUploading, setCoverUploading] = useState(false);
+  const [coverDeleting, setCoverDeleting] = useState(false);
+  const [coverImageLoaded, setCoverImageLoaded] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    setCoverImageLoaded(false);
+  }, [coverImageUrl]);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  const uploadCoverImage = useCallback(
+    async (file: File) => {
+      if (!taskId) return;
+      const preview = URL.createObjectURL(file);
+      setPreviewUrl(preview);
+      setCoverUploading(true);
+      try {
+        const formData = new FormData();
+        formData.append('file', file);
+        formData.append('projectId', projectId);
+        formData.append('taskId', taskId);
+        const res = await fetch('/api/gantt/cover-image', { method: 'POST', body: formData });
+        if (res.ok) {
+          void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId });
+        } else {
+          const body = await res.json().catch(() => ({ error: 'Upload failed' }));
+          showSnackbar((body as { error?: string }).error ?? 'Upload failed', 'error');
+        }
+      } finally {
+        setCoverUploading(false);
+        URL.revokeObjectURL(preview);
+        setPreviewUrl(null);
+      }
+    },
+    [taskId, projectId, organizationId, utils, showSnackbar]
+  );
+
+  const handleCoverRemove = useCallback(async () => {
+    if (!taskId) return;
+    setCoverUploading(true);
+    setCoverDeleting(true);
+    try {
+      const res = await fetch('/api/gantt/cover-image', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ projectId, taskId }),
+      });
+      if (res.ok) {
+        void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId });
+      }
+    } finally {
+      setCoverUploading(false);
+      setCoverDeleting(false);
+    }
+  }, [taskId, projectId, organizationId, utils]);
+
+  const { getRootProps, getInputProps, isDragActive, open: openFilePicker } = useDropzone({
+    onDrop: (files) => {
+      if (files[0]) void uploadCoverImage(files[0]);
+    },
+    onDropRejected: (rejections) => {
+      const code = rejections[0]?.errors[0]?.code;
+      if (code === 'file-too-large') {
+        showSnackbar('Image must be under 10MB', 'error');
+      } else if (code === 'file-invalid-type') {
+        showSnackbar('Only JPG, PNG, GIF, and WebP images are supported', 'error');
+      } else {
+        showSnackbar('File not accepted', 'error');
+      }
+    },
+    accept: {
+      'image/jpeg': ['.jpg', '.jpeg'],
+      'image/png': ['.png'],
+      'image/gif': ['.gif'],
+      'image/webp': ['.webp'],
+    },
+    maxFiles: 1,
+    maxSize: 10 * 1024 * 1024,
+    noClick: !!coverImageUrl,
+    noKeyboard: !!coverImageUrl,
+    disabled: coverUploading,
+  });
+
+  return (
+    <Box
+      {...getRootProps()}
+      sx={{
+        mx: '14px',
+        mb: '4px',
+        height: 200,
+        overflow: 'hidden',
+        outline: 'none',
+        position: 'relative',
+        borderRadius: '10px',
+        bgcolor: isDragActive
+          ? 'action.selected'
+          : coverImageUrl
+            ? 'transparent'
+            : 'background.default',
+        border: coverImageUrl ? 'none' : '1px solid',
+        borderColor: 'divider',
+        transition: 'background-color 0.2s',
+        '&:hover .cover-actions': { opacity: 1 },
+        '&:hover .empty-cover': { borderColor: 'text.secondary', color: 'text.secondary' },
+        cursor: coverImageUrl ? 'default' : 'pointer',
+      }}
+    >
+      <input {...getInputProps()} />
+
+      {coverUploading ? (
+        <UploadOverlay
+          previewUrl={previewUrl}
+          variant={coverDeleting ? 'dark' : previewUrl ? 'dark' : 'light'}
+          text={coverDeleting ? 'Removing…' : 'Uploading…'}
+        />
+      ) : coverImageUrl ? (
+        <>
+          {!coverImageLoaded && (
+            <Box
+              sx={{
+                position: 'absolute',
+                inset: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                '@keyframes shimmer': {
+                  '0%': { backgroundPosition: '-200% 0' },
+                  '100%': { backgroundPosition: '200% 0' },
+                },
+                background: 'linear-gradient(90deg, var(--mui-palette-background-default) 25%, var(--mui-palette-divider) 50%, var(--mui-palette-background-default) 75%)',
+                backgroundSize: '200% 100%',
+                animation: 'shimmer 1.8s ease-in-out infinite',
+              }}
+            >
+              <ImageSquare size={18} color="var(--mui-palette-text-disabled)" />
+            </Box>
+          )}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={coverImageUrl}
+            alt="Task cover"
+            onLoad={() => setCoverImageLoaded(true)}
+            style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+          />
+          <Box
+            sx={{
+              position: 'absolute',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              height: 40,
+              background: 'linear-gradient(to top, var(--mui-palette-background-paper), transparent)',
+              pointerEvents: 'none',
+            }}
+          />
+          <Box
+            className="cover-actions"
+            sx={{
+              position: 'absolute',
+              bottom: 8,
+              right: 8,
+              display: 'flex',
+              gap: 0.5,
+              opacity: 0,
+              transition: 'opacity 0.2s',
+            }}
+          >
+            <Box
+              component="button"
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                openFilePicker();
+              }}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                color: 'white',
+                height: 26,
+                px: 1,
+                bgcolor: 'rgba(0,0,0,0.5)',
+                backdropFilter: 'blur(8px)',
+                borderRadius: '6px',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: '0.625rem',
+                fontWeight: 500,
+                fontFamily: 'inherit',
+                letterSpacing: '0.01em',
+                lineHeight: 1,
+                '&:hover': { bgcolor: 'rgba(0,0,0,0.65)' },
+                transition: 'background-color 0.15s',
+              }}
+              aria-label="Change cover image"
+            >
+              <Image size={12} />
+              Change
+            </Box>
+            <Box
+              component="button"
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                void handleCoverRemove();
+              }}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                color: 'white',
+                height: 26,
+                px: 1,
+                bgcolor: 'rgba(0,0,0,0.5)',
+                backdropFilter: 'blur(8px)',
+                borderRadius: '6px',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: '0.625rem',
+                fontWeight: 500,
+                fontFamily: 'inherit',
+                letterSpacing: '0.01em',
+                lineHeight: 1,
+                '&:hover': { bgcolor: 'rgba(185,28,28,0.7)' },
+                transition: 'background-color 0.15s',
+              }}
+              aria-label="Remove cover image"
+            >
+              <Trash size={12} />
+              Remove
+            </Box>
+          </Box>
+        </>
+      ) : (
+        <Box
+          className="empty-cover"
+          sx={{
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 0.75,
+            borderRadius: 'inherit',
+            border: '1.5px dashed',
+            borderColor: isDragActive ? 'text.secondary' : 'divider',
+            color: isDragActive ? 'text.secondary' : 'text.disabled',
+            transition: 'border-color 0.15s, color 0.15s',
+          }}
+        >
+          <Image size={15} />
+          <Typography sx={{ fontSize: '0.6875rem', fontWeight: 500, color: 'inherit', lineHeight: 1 }}>
+            {isDragActive ? 'Drop image here' : 'Add cover image'}
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/components/bryntum/components/task-popover/FilePreviewPanel.tsx
+++ b/src/components/bryntum/components/task-popover/FilePreviewPanel.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { Box, Typography, Divider } from '@mui/material';
+import { ImageSquare, FileText, DownloadSimple, ArrowsOut } from '@phosphor-icons/react';
+import { formatFileSize } from '@/lib/utils/formatting';
+import type { PreviewDoc } from './types';
+
+interface FilePreviewPanelProps {
+  previewDoc: PreviewDoc;
+}
+
+export default function FilePreviewPanel({ previewDoc }: FilePreviewPanelProps) {
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        bgcolor: 'background.paper',
+        minWidth: 0,
+        animation: 'slideInRight 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+        '@keyframes slideInRight': {
+          from: { opacity: 0, transform: 'translateX(12px)' },
+          to: { opacity: 1, transform: 'translateX(0)' },
+        },
+      }}
+    >
+      {/* Header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: '20px', py: '14px' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+          {previewDoc.mimeType.startsWith('image/') ? (
+            <ImageSquare size={16} color="var(--mui-palette-text-secondary)" style={{ flexShrink: 0 }} />
+          ) : (
+            <FileText size={16} color="var(--mui-palette-text-secondary)" style={{ flexShrink: 0 }} />
+          )}
+          <Typography noWrap sx={{ fontSize: 13, fontWeight: 600, color: 'text.primary' }}>
+            {previewDoc.name}
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
+          {[
+            { icon: DownloadSimple, label: 'Download' },
+            { icon: ArrowsOut, label: 'Expand' },
+          ].map(({ icon: Icon, label }) => (
+            <Box
+              key={label}
+              component="button"
+              onClick={() => window.open(previewDoc.blobUrl, '_blank')}
+              sx={{
+                width: 28,
+                height: 28,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderRadius: '6px',
+                border: 'none',
+                bgcolor: 'transparent',
+                cursor: 'pointer',
+                color: 'text.disabled',
+                '&:hover': { bgcolor: 'action.hover', color: 'text.secondary' },
+                transition: 'background-color 0.15s, color 0.15s',
+              }}
+              aria-label={label}
+            >
+              <Icon size={14} />
+            </Box>
+          ))}
+        </Box>
+      </Box>
+
+      <Divider />
+
+      {/* Preview area */}
+      <Box
+        sx={{
+          flex: 1,
+          overflow: 'hidden',
+          bgcolor: 'background.default',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {previewDoc.mimeType.startsWith('image/') ? (
+          /* eslint-disable-next-line @next/next/no-img-element */
+          <img
+            src={previewDoc.blobUrl}
+            alt={previewDoc.name}
+            style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+          />
+        ) : (
+          <FileText size={48} color="var(--mui-palette-text-disabled)" />
+        )}
+      </Box>
+
+      <Divider />
+
+      {/* Metadata */}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0, px: '20px', py: '12px' }}>
+        {previewDoc.uploadedBy?.name && (
+          <MetaRow label="Uploaded by" value={previewDoc.uploadedBy.name} hasBorder />
+        )}
+        <MetaRow
+          label="Date"
+          value={new Date(previewDoc.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+          hasBorder
+        />
+        <MetaRow label="Size" value={formatFileSize(previewDoc.size)} hasBorder />
+        <MetaRow
+          label="Type"
+          value={previewDoc.mimeType.split('/')[1]?.toUpperCase() ?? previewDoc.mimeType}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+function MetaRow({ label, value, hasBorder }: { label: string; value: string; hasBorder?: boolean }) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        py: '8px',
+        ...(hasBorder && { borderBottom: '1px solid', borderBottomColor: 'divider' }),
+      }}
+    >
+      <Typography sx={{ fontSize: '0.625rem', fontWeight: 500, color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.06em', lineHeight: 1 }}>
+        {label}
+      </Typography>
+      <Typography sx={{ fontSize: '0.6875rem', fontWeight: 600, color: 'text.primary', lineHeight: 1 }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}

--- a/src/components/bryntum/components/task-popover/FolderRow.tsx
+++ b/src/components/bryntum/components/task-popover/FolderRow.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import React from 'react';
+import { Box, Typography, IconButton } from '@mui/material';
+import {
+  FolderSimple,
+  FolderOpen,
+  Question,
+  PaperPlaneTilt,
+  PencilSimpleLine,
+  Camera,
+  ClipboardText,
+  CaretDown,
+  CaretRight,
+  Plus,
+  type Icon as PhosphorIcon,
+} from '@phosphor-icons/react';
+import type { Folder } from '@/lib/folders';
+import type { DocumentItem, PreviewDoc, FolderContentProps } from './types';
+import BaseFolderContent from './BaseFolderContent';
+import PhotosFolderContent from './PhotosFolderContent';
+import RequirementCounter from './RequirementCounter';
+
+const folderIconMap: Record<string, PhosphorIcon> = {
+  rfi: Question,
+  submittals: PaperPlaneTilt,
+  'change-orders': PencilSimpleLine,
+  photos: Camera,
+  inspections: ClipboardText,
+};
+
+const FOLDER_CONTENT_MAP: Record<string, React.ComponentType<FolderContentProps>> = {
+  photos: PhotosFolderContent,
+};
+
+interface FolderRowProps {
+  folder: Folder;
+  isExpanded: boolean;
+  onToggle: () => void;
+  count: number;
+  docs: DocumentItem[];
+  onUpload: (folder: { id: string; name: string }) => void;
+  onSelectDoc: (doc: PreviewDoc) => void;
+  selectedDocId: string | null;
+  // Tracking props (only used for trackable folders)
+  required?: number | null;
+  current?: number;
+  canManage?: boolean;
+  onSaveRequirement?: (count: number | null) => void;
+  isRequirementPending?: boolean;
+}
+
+function FolderRowInner({
+  folder,
+  isExpanded,
+  onToggle,
+  count,
+  docs,
+  onUpload,
+  onSelectDoc,
+  selectedDocId,
+  required,
+  current,
+  canManage,
+  onSaveRequirement,
+  isRequirementPending,
+}: FolderRowProps) {
+  const FolderIcon = folderIconMap[folder.id] ?? (isExpanded ? FolderOpen : FolderSimple);
+  const isTrackable = folder.trackable && !!onSaveRequirement;
+
+  const contentProps: FolderContentProps = {
+    docs,
+    onSelectDoc,
+    selectedDocId,
+    onUpload: () => onUpload({ id: folder.id, name: folder.name }),
+    folderName: folder.name,
+  };
+
+  const renderContent = () => {
+    if (!isExpanded) return null;
+
+    const SpecificContent = FOLDER_CONTENT_MAP[folder.id];
+    if (SpecificContent) {
+      return <SpecificContent {...contentProps} />;
+    }
+
+    return <BaseFolderContent {...contentProps} />;
+  };
+
+  return (
+    <Box>
+      {/* Folder header row */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
+          px: 0.75,
+          py: 0.625,
+          borderRadius: '8px',
+          cursor: 'pointer',
+          userSelect: 'none',
+          '&:hover': { bgcolor: 'action.hover' },
+          transition: 'background-color 0.15s',
+        }}
+        onClick={onToggle}
+      >
+        {isExpanded ? (
+          <CaretDown size={14} color="var(--mui-palette-text-disabled)" style={{ flexShrink: 0 }} />
+        ) : (
+          <CaretRight size={14} color="var(--mui-palette-text-disabled)" style={{ flexShrink: 0 }} />
+        )}
+        <FolderIcon size={14} color={folder.color} style={{ flexShrink: 0 }} />
+        <Typography
+          sx={{
+            fontSize: '0.8125rem',
+            fontWeight: isExpanded ? 600 : 450,
+            color: 'text.primary',
+            lineHeight: 1,
+            flexShrink: 0,
+          }}
+        >
+          {folder.name}
+        </Typography>
+
+        {/* Tracking indicator — inline in the header row */}
+        {isTrackable ? (
+          <RequirementCounter
+            current={current ?? 0}
+            required={required ?? null}
+            canManage={canManage ?? false}
+            onSave={onSaveRequirement}
+            isPending={isRequirementPending}
+            folderColor={folder.color}
+          />
+        ) : (
+          <>
+            {/* Standard count badge for non-trackable folders */}
+            {count > 0 && (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  minWidth: 18,
+                  height: 18,
+                  borderRadius: '999px',
+                  bgcolor: 'rgba(0,0,0,0.05)',
+                  px: 0.75,
+                  ml: 'auto',
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontSize: '0.625rem',
+                    fontWeight: 600,
+                    color: 'text.secondary',
+                    lineHeight: 1,
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {count}
+                </Typography>
+              </Box>
+            )}
+          </>
+        )}
+
+        <IconButton
+          size="small"
+          onClick={(e) => {
+            e.stopPropagation();
+            onUpload({ id: folder.id, name: folder.name });
+          }}
+          sx={{
+            p: 0.5,
+            width: 22,
+            height: 22,
+            color: 'text.disabled',
+            flexShrink: 0,
+            ...(!isTrackable && { ml: count > 0 ? 0 : 'auto' }),
+            '&:hover': { color: 'primary.main', bgcolor: 'action.hover' },
+            transition: 'color 0.15s',
+          }}
+          aria-label={`Upload to ${folder.name}`}
+        >
+          <Plus size={13} />
+        </IconButton>
+      </Box>
+
+      {/* Content area */}
+      {renderContent()}
+    </Box>
+  );
+}
+
+const FolderRow = React.memo(FolderRowInner);
+export default FolderRow;

--- a/src/components/bryntum/components/task-popover/PhotosFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/PhotosFolderContent.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import { SquaresFour, List, FileText, Plus } from '@phosphor-icons/react';
+import type { FolderContentProps, PreviewDoc } from './types';
+
+function PhotosFolderContentInner({
+  docs,
+  onSelectDoc,
+  selectedDocId,
+  onUpload,
+}: FolderContentProps) {
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+
+  if (docs.length === 0) {
+    return (
+      <Box
+        onClick={onUpload}
+        sx={{
+          ml: '36px',
+          mr: 0.75,
+          my: 0.75,
+          py: 1.5,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 0.5,
+          border: '1.5px dashed',
+          borderColor: 'divider',
+          borderRadius: '8px',
+          cursor: 'pointer',
+          transition: 'border-color 0.15s, background-color 0.15s',
+          '&:hover': {
+            borderColor: 'primary.main',
+            bgcolor: 'rgba(0,0,0,0.02)',
+          },
+        }}
+      >
+        <Plus size={16} color="var(--mui-palette-text-disabled)" />
+        <Typography sx={{ fontSize: 11, color: 'text.disabled' }}>
+          Drop files or click to upload
+        </Typography>
+      </Box>
+    );
+  }
+
+  const makePreview = (doc: (typeof docs)[0]): PreviewDoc => ({
+    id: doc.id,
+    name: doc.name,
+    blobUrl: doc.blobUrl,
+    mimeType: doc.mimeType,
+    size: doc.size,
+    createdAt: doc.createdAt,
+    uploadedBy: doc.uploadedBy ?? null,
+  });
+
+  return (
+    <Box sx={{ pt: 1, pl: '20px' }}>
+      {/* View toggle + date */}
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pb: 0.5 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '2px',
+            bgcolor: 'action.selected',
+            borderRadius: '12px',
+            p: '2px',
+          }}
+        >
+          {(['grid', 'list'] as const).map((mode) => (
+            <Box
+              key={mode}
+              component="button"
+              onClick={() => setViewMode(mode)}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                px: 1,
+                py: 0.5,
+                borderRadius: '6px',
+                border: 'none',
+                cursor: 'pointer',
+                bgcolor: viewMode === mode ? 'background.paper' : 'transparent',
+                color: viewMode === mode ? 'text.primary' : 'text.secondary',
+                transition: 'all 0.15s',
+                boxShadow: viewMode === mode ? '0 1px 2px rgba(0,0,0,0.08)' : 'none',
+              }}
+              aria-label={`${mode} view`}
+            >
+              {mode === 'grid' ? <SquaresFour size={13} /> : <List size={13} />}
+            </Box>
+          ))}
+        </Box>
+        {docs[0]?.createdAt != null && (
+          <Typography sx={{ fontSize: 11, fontWeight: 500, color: 'text.secondary' }}>
+            {new Date(docs[0].createdAt).toLocaleDateString(
+              'en-US',
+              { month: 'short', year: 'numeric' }
+            )}
+          </Typography>
+        )}
+      </Box>
+
+      {viewMode === 'grid' ? (
+        <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '6px', pt: 0.5 }}>
+          {docs.map((doc) => (
+            <Box
+              key={doc.id}
+              onClick={() => onSelectDoc(makePreview(doc))}
+              sx={{
+                height: 70,
+                borderRadius: '8px',
+                overflow: 'hidden',
+                cursor: 'pointer',
+                bgcolor: 'action.hover',
+                border: '2px solid',
+                borderColor: selectedDocId === doc.id ? 'primary.main' : 'transparent',
+                transition: 'border-color 0.15s, transform 0.15s',
+                '&:hover': {
+                  transform: 'scale(1.02)',
+                  borderColor: selectedDocId === doc.id ? 'primary.main' : 'divider',
+                },
+              }}
+            >
+              {doc.mimeType.startsWith('image/') ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img
+                  src={doc.blobUrl}
+                  alt={doc.name}
+                  style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+                />
+              ) : (
+                <Box sx={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <FileText size={20} color="var(--mui-palette-text-disabled)" />
+                </Box>
+              )}
+            </Box>
+          ))}
+        </Box>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.125, pt: 0.5 }}>
+          {docs.map((doc) => (
+            <Box
+              key={doc.id}
+              onClick={() => onSelectDoc(makePreview(doc))}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                py: '5px',
+                pr: 1,
+                pl: '18px',
+                borderRadius: '12px',
+                cursor: 'pointer',
+                bgcolor: selectedDocId === doc.id ? 'action.selected' : 'transparent',
+                '&:hover': { bgcolor: 'action.hover' },
+              }}
+            >
+              <FileText size={14} color="var(--mui-palette-text-secondary)" style={{ flexShrink: 0 }} />
+              <Typography
+                sx={{
+                  fontSize: 12,
+                  flex: 1,
+                  color: 'text.primary',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {doc.name}
+              </Typography>
+              {doc.createdAt != null && (
+                <Typography sx={{ fontSize: 11, color: 'text.secondary', flexShrink: 0, opacity: 0.7 }}>
+                  {new Date(doc.createdAt).toLocaleDateString(
+                    'en-US',
+                    { month: 'short', day: 'numeric' }
+                  )}
+                </Typography>
+              )}
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+const PhotosFolderContent = React.memo(PhotosFolderContentInner);
+export default PhotosFolderContent;

--- a/src/components/bryntum/components/task-popover/RequirementCounter.tsx
+++ b/src/components/bryntum/components/task-popover/RequirementCounter.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, IconButton } from '@mui/material';
+import { Minus, Plus, CheckCircle, CircleDashed, FloppyDisk, X } from '@phosphor-icons/react';
+import { DEFAULT_REQUIRED_COUNT } from '@/lib/constants/requirements';
+
+interface RequirementCounterProps {
+  current: number;
+  required: number | null;
+  canManage: boolean;
+  onSave: (count: number | null) => void;
+  isPending?: boolean;
+  folderColor: string;
+}
+
+export default function RequirementCounter({
+  current,
+  required,
+  canManage,
+  onSave,
+  isPending,
+  folderColor,
+}: RequirementCounterProps) {
+  const [draft, setDraft] = useState<number | null>(required);
+
+  // Sync draft when server value changes
+  useEffect(() => {
+    setDraft(required);
+  }, [required]);
+
+  const isDirty = draft !== required;
+
+  // ── Null state: no requirement set ──
+  if (required === null && draft === null) {
+    if (!canManage) return null;
+
+    return (
+      <Box
+        component="button"
+        onClick={(e: React.MouseEvent) => {
+          e.stopPropagation();
+          setDraft(DEFAULT_REQUIRED_COUNT);
+        }}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+          ml: 'auto',
+          py: '3px',
+          px: '8px',
+          borderRadius: '6px',
+          border: '1px dashed',
+          borderColor: 'divider',
+          bgcolor: 'transparent',
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+          transition: 'all 0.15s',
+          '&:hover': {
+            borderColor: folderColor,
+            bgcolor: `${folderColor}08`,
+          },
+        }}
+      >
+        <CircleDashed
+          size={11}
+          color="var(--mui-palette-text-disabled)"
+          style={{ flexShrink: 0 }}
+        />
+        <Typography
+          sx={{
+            fontSize: '0.5625rem',
+            fontWeight: 500,
+            color: 'text.disabled',
+            lineHeight: 1,
+          }}
+        >
+          Set requirement
+        </Typography>
+      </Box>
+    );
+  }
+
+  // Use draft for display (allows unsaved preview)
+  const displayCount = draft ?? required ?? DEFAULT_REQUIRED_COUNT;
+  const isFulfilled = current >= displayCount;
+  const isPartial = current > 0 && !isFulfilled;
+
+  const statusColor = isFulfilled
+    ? 'var(--mui-palette-success-main)'
+    : isPartial
+      ? folderColor
+      : 'var(--mui-palette-text-disabled)';
+
+  return (
+    <Box
+      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '5px',
+        flex: 1,
+        minWidth: 0,
+        ml: 0.5,
+        opacity: isPending ? 0.6 : 1,
+        transition: 'opacity 0.15s',
+      }}
+    >
+      {/* Segmented progress */}
+      <Box sx={{ display: 'flex', gap: '2px', flex: 1, alignItems: 'center', minWidth: 0 }}>
+        {Array.from({ length: Math.min(displayCount, 10) }).map((_, i) => (
+          <Box
+            key={i}
+            sx={{
+              height: 3.5,
+              flex: 1,
+              maxWidth: 16,
+              borderRadius: '1.5px',
+              bgcolor: i < current ? statusColor : 'rgba(0,0,0,0.06)',
+              transition: 'background-color 0.3s ease',
+            }}
+          />
+        ))}
+        {displayCount > 10 && (
+          <Typography sx={{ fontSize: '0.5rem', color: 'text.disabled', lineHeight: 1, flexShrink: 0 }}>
+            +{displayCount - 10}
+          </Typography>
+        )}
+      </Box>
+
+      {/* Count + status icon */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: '3px', flexShrink: 0 }}>
+        {isFulfilled ? (
+          <CheckCircle size={11} weight="fill" color="var(--mui-palette-success-main)" />
+        ) : null}
+        <Typography
+          sx={{
+            fontSize: '0.5625rem',
+            fontWeight: 600,
+            color: isFulfilled ? 'success.main' : 'text.secondary',
+            lineHeight: 1,
+            fontVariantNumeric: 'tabular-nums',
+            letterSpacing: '-0.01em',
+          }}
+        >
+          {current}/{displayCount}
+        </Typography>
+      </Box>
+
+      {/* Admin stepper + save */}
+      {canManage && (
+        <>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              borderRadius: '5px',
+              border: '1px solid',
+              borderColor: 'divider',
+              overflow: 'hidden',
+              flexShrink: 0,
+            }}
+          >
+            <IconButton
+              size="small"
+              disabled={isPending || displayCount <= 1}
+              onClick={() => setDraft(displayCount - 1)}
+              sx={{
+                p: 0,
+                width: 18,
+                height: 18,
+                borderRadius: 0,
+                color: 'text.disabled',
+                '&:hover': { color: 'text.primary', bgcolor: 'action.hover' },
+                '&.Mui-disabled': { color: 'action.disabled' },
+              }}
+              aria-label="Decrease required count"
+            >
+              <Minus size={9} weight="bold" />
+            </IconButton>
+            <Box sx={{ width: '1px', height: 10, bgcolor: 'divider' }} />
+            <IconButton
+              size="small"
+              disabled={isPending || displayCount >= 50}
+              onClick={() => setDraft(displayCount + 1)}
+              sx={{
+                p: 0,
+                width: 18,
+                height: 18,
+                borderRadius: 0,
+                color: 'text.disabled',
+                '&:hover': { color: 'text.primary', bgcolor: 'action.hover' },
+                '&.Mui-disabled': { color: 'action.disabled' },
+              }}
+              aria-label="Increase required count"
+            >
+              <Plus size={9} weight="bold" />
+            </IconButton>
+          </Box>
+
+          {/* Save / Cancel — appear when dirty */}
+          {isDirty && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '3px', flexShrink: 0 }}>
+              <Box
+                component="button"
+                disabled={isPending}
+                onClick={() => onSave(draft)}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '2px',
+                  px: '5px',
+                  height: 18,
+                  borderRadius: '5px',
+                  border: 'none',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  fontSize: '0.5rem',
+                  fontWeight: 600,
+                  lineHeight: 1,
+                  color: 'white',
+                  bgcolor: folderColor,
+                  transition: 'filter 0.15s',
+                  flexShrink: 0,
+                  '&:hover': { filter: 'brightness(1.1)' },
+                  '&:disabled': { opacity: 0.5, cursor: 'default' },
+                }}
+                aria-label="Save requirement"
+              >
+                <FloppyDisk size={9} weight="bold" />
+                Save
+              </Box>
+              <Box
+                component="button"
+                onClick={() => setDraft(required)}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 18,
+                  height: 18,
+                  borderRadius: '5px',
+                  border: 'none',
+                  bgcolor: 'rgba(0,0,0,0.06)',
+                  cursor: 'pointer',
+                  color: 'text.secondary',
+                  flexShrink: 0,
+                  transition: 'all 0.15s',
+                  '&:hover': { bgcolor: 'rgba(0,0,0,0.1)', color: 'text.primary' },
+                }}
+                aria-label="Cancel"
+              >
+                <X size={10} weight="bold" />
+              </Box>
+            </Box>
+          )}
+        </>
+      )}
+    </Box>
+  );
+}

--- a/src/components/bryntum/components/task-popover/TaskHeader.tsx
+++ b/src/components/bryntum/components/task-popover/TaskHeader.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { Box, Typography, Skeleton } from '@mui/material';
+import { X, CalendarBlank, Timer } from '@phosphor-icons/react';
+import type { Theme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
+import CsiCodeSelector from '@/components/bryntum/components/CsiCodeSelector';
+
+function getStatusInfo(percentDone: number, palette: Theme['palette']) {
+  if (percentDone >= 100) {
+    return { dotColor: palette.status.active };
+  }
+  if (percentDone > 0) {
+    return { dotColor: palette.status.inProgress };
+  }
+  return { dotColor: palette.text.disabled };
+}
+
+function formatDate(date: Date | string | null | undefined): string {
+  if (!date) return '';
+  return new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function formatDuration(duration: number | null | undefined, unit: string): string {
+  if (!duration) return '';
+  const rounded = Math.round(duration);
+  const u = unit === 'day' ? 'day' : unit;
+  return `${rounded} ${u}${rounded !== 1 ? 's' : ''}`;
+}
+
+interface TaskHeaderProps {
+  taskName: string;
+  taskId?: string;
+  organizationId: string;
+  projectId: string;
+  taskDetail: {
+    startDate?: Date | string | null;
+    endDate?: Date | string | null;
+    duration?: number | null;
+    durationUnit?: string;
+    csiCode?: string | null;
+    percentDone?: number;
+  } | null | undefined;
+  taskDetailLoading: boolean;
+  onClose: () => void;
+}
+
+export default function TaskHeader({
+  taskName,
+  taskId,
+  organizationId,
+  projectId,
+  taskDetail,
+  taskDetailLoading,
+  onClose,
+}: TaskHeaderProps) {
+  const theme = useTheme();
+  const percentDone = taskDetail?.percentDone ?? 0;
+  const statusInfo = getStatusInfo(percentDone, theme.palette);
+
+  const metaDateRange = [
+    taskDetail?.startDate ? formatDate(taskDetail.startDate) : null,
+    taskDetail?.endDate ? formatDate(taskDetail.endDate) : null,
+  ]
+    .filter(Boolean)
+    .join(' — ');
+
+  const durationLabel = formatDuration(
+    taskDetail?.duration,
+    taskDetail?.durationUnit ?? 'day'
+  );
+
+  return (
+    <Box sx={{ p: '8px 14px 12px', display: 'flex', flexDirection: 'column', gap: 1.25 }}>
+      {/* Title row */}
+      <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+        <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+          <Typography
+            sx={{
+              fontWeight: 600,
+              fontSize: '0.9375rem',
+              lineHeight: 1.2,
+              letterSpacing: '-0.01em',
+              color: 'text.primary',
+              wordBreak: 'break-word',
+            }}
+          >
+            {taskName}
+          </Typography>
+          {taskDetailLoading ? (
+            <>
+              <Skeleton variant="text" width={140} height={14} sx={{ borderRadius: '4px' }} />
+              <Skeleton variant="rounded" width={110} height={20} sx={{ borderRadius: '6px' }} />
+            </>
+          ) : (
+            <>
+              {(metaDateRange || durationLabel) && (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
+                  {metaDateRange && (
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                      <CalendarBlank size={12} color="var(--mui-palette-text-secondary)" style={{ flexShrink: 0 }} />
+                      <Typography sx={{ fontSize: '0.6875rem', fontWeight: 500, color: 'text.secondary', lineHeight: 1 }}>
+                        {metaDateRange}
+                      </Typography>
+                    </Box>
+                  )}
+                  {metaDateRange && durationLabel && (
+                    <Box sx={{ width: 3, height: 3, borderRadius: '50%', bgcolor: 'text.disabled', flexShrink: 0 }} />
+                  )}
+                  {durationLabel && (
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                      <Timer size={12} color="var(--mui-palette-text-secondary)" style={{ flexShrink: 0 }} />
+                      <Typography sx={{ fontSize: '0.6875rem', fontWeight: 500, color: 'text.secondary', lineHeight: 1 }}>
+                        {durationLabel}
+                      </Typography>
+                    </Box>
+                  )}
+                </Box>
+              )}
+              {taskId && (
+                <CsiCodeSelector
+                  csiCode={taskDetail?.csiCode}
+                  organizationId={organizationId}
+                  projectId={projectId}
+                  taskId={taskId}
+                />
+              )}
+            </>
+          )}
+        </Box>
+
+        {/* Close button */}
+        <Box
+          component="button"
+          onClick={onClose}
+          sx={{
+            width: 26,
+            height: 26,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: '6px',
+            border: 'none',
+            bgcolor: 'transparent',
+            cursor: 'pointer',
+            color: 'text.secondary',
+            flexShrink: 0,
+            mt: '1px',
+            '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
+            transition: 'background-color 0.15s, color 0.15s',
+          }}
+          aria-label="Close"
+        >
+          <X size={13} />
+        </Box>
+      </Box>
+
+      {/* Progress bar */}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Typography
+            sx={{
+              fontSize: '0.5625rem',
+              fontWeight: 600,
+              color: 'text.secondary',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              lineHeight: 1,
+            }}
+          >
+            Progress
+          </Typography>
+          {taskDetailLoading ? (
+            <Skeleton variant="text" width={24} height={12} sx={{ borderRadius: '3px' }} />
+          ) : (
+            <Typography
+              sx={{
+                fontSize: '0.625rem',
+                fontWeight: 700,
+                color: 'text.primary',
+                lineHeight: 1,
+                fontVariantNumeric: 'tabular-nums',
+              }}
+            >
+              {Math.round(percentDone)}%
+            </Typography>
+          )}
+        </Box>
+        {taskDetailLoading ? (
+          <Skeleton variant="rounded" width="100%" height={4} sx={{ borderRadius: '999px' }} />
+        ) : (
+          <Box
+            sx={{
+              width: '100%',
+              height: 4,
+              borderRadius: '999px',
+              bgcolor: 'rgba(0,0,0,0.05)',
+              overflow: 'hidden',
+            }}
+          >
+            <Box
+              sx={{
+                height: '100%',
+                borderRadius: '999px',
+                bgcolor: statusInfo.dotColor,
+                width: `${Math.min(percentDone, 100)}%`,
+                transition: 'width 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
+              }}
+            />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Box } from '@mui/material';
+import BaseFolderContent from './BaseFolderContent';
+import RequirementCounter from './RequirementCounter';
+import type { FolderContentProps } from './types';
+
+interface TrackableFolderContentProps extends FolderContentProps {
+  required: number | null;
+  current: number;
+  canManage: boolean;
+  onSave: (count: number | null) => void;
+  isPending: boolean;
+  folderColor: string;
+}
+
+export default function TrackableFolderContent({
+  docs,
+  onSelectDoc,
+  selectedDocId,
+  onUpload,
+  folderName,
+  required,
+  current,
+  canManage,
+  onSave,
+  isPending,
+  folderColor,
+}: TrackableFolderContentProps) {
+  return (
+    <Box>
+      <RequirementCounter
+        current={current}
+        required={required}
+        canManage={canManage}
+        onSave={onSave}
+        isPending={isPending}
+        folderColor={folderColor}
+      />
+      <BaseFolderContent
+        docs={docs}
+        onSelectDoc={onSelectDoc}
+        selectedDocId={selectedDocId}
+        onUpload={onUpload}
+        folderName={folderName}
+      />
+    </Box>
+  );
+}

--- a/src/components/bryntum/components/task-popover/types.ts
+++ b/src/components/bryntum/components/task-popover/types.ts
@@ -1,0 +1,28 @@
+export interface PreviewDoc {
+  id: string;
+  name: string;
+  blobUrl: string;
+  mimeType: string;
+  size: number;
+  createdAt: string | Date;
+  uploadedBy: { name: string | null } | null;
+}
+
+export interface DocumentItem {
+  id: string;
+  name: string;
+  blobUrl: string;
+  mimeType: string;
+  size: number;
+  folderId: string;
+  createdAt: Date;
+  uploadedBy: { name: string | null } | null;
+}
+
+export interface FolderContentProps {
+  docs: DocumentItem[];
+  onSelectDoc: (doc: PreviewDoc) => void;
+  selectedDocId: string | null;
+  onUpload: () => void;
+  folderName: string;
+}

--- a/src/components/layout/ProjectShell.tsx
+++ b/src/components/layout/ProjectShell.tsx
@@ -12,6 +12,7 @@ import VersionControlBar from '@/components/bryntum/components/VersionControlBar
 import TaskProgressCard from '@/components/bryntum/components/TaskProgressCard';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
 import { useProjectSwitcher } from '@/hooks/useProjectSwitcher';
+import { api } from '@/trpc/react';
 
 const BryntumGanttWrapper = dynamic(
   () => import('@/components/bryntum/BryntumGanttWrapper'),
@@ -98,6 +99,11 @@ export default function ProjectShell({ children, projectId, projectName }: Proje
   const [ganttMounted, setGanttMounted] = useState(false);
   const [filesMounted, setFilesMounted] = useState(false);
 
+  const { data: reqStats } = api.gantt.requirementStats.useQuery(
+    { organizationId: activeOrganizationId!, projectId },
+    { enabled: !!activeOrganizationId }
+  );
+
   // Lazy-mount each tab on first visit — avoids loading heavy bundles until needed
   useEffect(() => {
     if (isGanttRoute && !ganttMounted) {
@@ -127,8 +133,8 @@ export default function ProjectShell({ children, projectId, projectName }: Proje
             {currentProject && (
               <>
                 <TaskProgressCard
-                  completedTaskCount={currentProject.completedTaskCount ?? 0}
-                  taskCount={currentProject.taskCount ?? 0}
+                  uploaded={reqStats?.totalUploaded ?? 0}
+                  required={reqStats?.totalRequired ?? 0}
                 />
                 <SchedulePill endDate={currentProject.endDate as string | null} />
               </>

--- a/src/lib/constants/requirements.ts
+++ b/src/lib/constants/requirements.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_REQUIRED_COUNT = 3;

--- a/src/lib/folders.ts
+++ b/src/lib/folders.ts
@@ -13,6 +13,8 @@ export interface Folder {
   isLeaf: boolean;
   color: string;
   children?: FolderChild[];
+  trackable?: boolean;
+  requirementField?: 'requiredSubmittals' | 'requiredInspections';
 }
 
 export const folderData: Folder[] = [
@@ -27,6 +29,8 @@ export const folderData: Folder[] = [
     name: 'Submittals',
     isLeaf: false,
     color: '#2563EB',
+    trackable: true,
+    requirementField: 'requiredSubmittals',
     children: [
       { id: 'submittals-product', name: 'Product Data' },
       { id: 'submittals-shop', name: 'Shop Drawings' },
@@ -50,6 +54,8 @@ export const folderData: Folder[] = [
     name: 'Inspections',
     isLeaf: false,
     color: '#8E44AD',
+    trackable: true,
+    requirementField: 'requiredInspections',
     children: [
       { id: 'inspections-structural', name: 'Structural' },
       { id: 'inspections-mep', name: 'MEP' },

--- a/src/lib/validations/gantt.ts
+++ b/src/lib/validations/gantt.ts
@@ -95,6 +95,15 @@ export const ganttSyncInputSchema = z.object({
   timeRanges: storeChangesSchema(timeRangeRecordSchema).optional(),
 });
 
+// Requirement tracking schema
+export const updateRequirementSchema = z.object({
+  taskId: z.string(),
+  field: z.enum(['requiredSubmittals', 'requiredInspections']),
+  count: z.number().int().min(0).max(50).nullable(),
+});
+
+export type UpdateRequirementInput = z.infer<typeof updateRequirementSchema>;
+
 // Type exports
 export type GanttLoadInput = z.infer<typeof ganttLoadInputSchema>;
 export type GanttSyncInput = z.infer<typeof ganttSyncInputSchema>;

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { Prisma } from "../../../../generated/prisma";
 import { createTRPCRouter, orgProcedure } from "@/server/api/trpc";
-import { ganttLoadInputSchema, ganttSyncInputSchema } from "@/lib/validations/gantt";
+import { ganttLoadInputSchema, ganttSyncInputSchema, updateRequirementSchema } from "@/lib/validations/gantt";
 import { CSI_SUBDIVISION_MAP, CSI_DIVISION_MAP } from "@/lib/constants/csiCodes";
 import { buildTaskTree, mapDependencyToGantt, mapResourceToGantt, mapAssignmentToGantt, mapTimeRangeToGantt } from "@/server/api/helpers/ganttTree";
 import { syncTasks, syncDependencies, syncResources, syncAssignments, syncTimeRanges, VersionConflictError } from "@/server/api/helpers/ganttSync";
@@ -64,6 +64,8 @@ export const ganttRouter = createTRPCRouter({
           durationUnit: true,
           coverImageUrl: true,
           csiCode: true,
+          requiredSubmittals: true,
+          requiredInspections: true,
           parentId: true,
           parent: {
             select: { name: true },
@@ -85,6 +87,8 @@ export const ganttRouter = createTRPCRouter({
         durationUnit: task.durationUnit,
         coverImageUrl: task.coverImageUrl,
         csiCode: task.csiCode,
+        requiredSubmittals: task.requiredSubmittals,
+        requiredInspections: task.requiredInspections,
         group: task.parent?.name ?? null,
       };
     }),
@@ -288,5 +292,123 @@ export const ganttRouter = createTRPCRouter({
         data: { csiCode },
         select: { id: true, csiCode: true },
       });
+    }),
+
+  /**
+   * Update a task's required submittal/inspection count
+   */
+  updateRequirement: orgProcedure
+    .input(z.object({ projectId: z.string() }).merge(updateRequirementSchema))
+    .mutation(async ({ ctx, input }) => {
+      const { projectId, taskId, field, count } = input;
+
+      if (ctx.membership.role !== "owner" && ctx.membership.role !== "admin") {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Only owners and admins can set requirements" });
+      }
+
+      const task = await ctx.db.ganttTask.findFirst({
+        where: { id: taskId, projectId, project: { organizationId: ctx.organization.id } },
+        select: { id: true },
+      });
+
+      if (!task) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Task not found in this project" });
+      }
+
+      return ctx.db.ganttTask.update({
+        where: { id: taskId },
+        data: { [field]: count },
+        select: { id: true, requiredSubmittals: true, requiredInspections: true },
+      });
+    }),
+
+  /**
+   * Project-wide requirement stats for the toolbar progress card.
+   * Returns total required and total uploaded across all tasks.
+   */
+  requirementStats: orgProcedure
+    .input(z.object({ projectId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const { projectId } = input;
+
+      const project = await ctx.db.project.findFirst({
+        where: { id: projectId, organizationId: ctx.organization.id },
+      });
+
+      if (!project) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Project not found or access denied" });
+      }
+
+      // Get all tasks that have requirements set
+      const tasksWithReqs = await ctx.db.ganttTask.findMany({
+        where: {
+          projectId,
+          OR: [
+            { requiredSubmittals: { not: null } },
+            { requiredInspections: { not: null } },
+          ],
+        },
+        select: {
+          id: true,
+          requiredSubmittals: true,
+          requiredInspections: true,
+        },
+      });
+
+      if (tasksWithReqs.length === 0) {
+        return { totalRequired: 0, totalUploaded: 0 };
+      }
+
+      // Sum all required counts
+      let totalRequired = 0;
+      for (const t of tasksWithReqs) {
+        totalRequired += t.requiredSubmittals ?? 0;
+        totalRequired += t.requiredInspections ?? 0;
+      }
+
+      // Count documents in submittal/inspection folders for these tasks
+      const taskIds = tasksWithReqs.map((t) => t.id);
+      const docCounts = await ctx.db.document.groupBy({
+        by: ["taskId", "folderId"],
+        where: {
+          projectId,
+          taskId: { in: taskIds },
+          folderId: {
+            startsWith: "submittals",
+          },
+        },
+        _count: { id: true },
+      });
+
+      const inspectionDocs = await ctx.db.document.groupBy({
+        by: ["taskId", "folderId"],
+        where: {
+          projectId,
+          taskId: { in: taskIds },
+          folderId: {
+            startsWith: "inspections",
+          },
+        },
+        _count: { id: true },
+      });
+
+      // Sum uploaded per task, capped by their requirement
+      let totalUploaded = 0;
+      for (const t of tasksWithReqs) {
+        if (t.requiredSubmittals != null) {
+          const uploaded = docCounts
+            .filter((d) => d.taskId === t.id)
+            .reduce((sum, d) => sum + d._count.id, 0);
+          totalUploaded += Math.min(uploaded, t.requiredSubmittals);
+        }
+        if (t.requiredInspections != null) {
+          const uploaded = inspectionDocs
+            .filter((d) => d.taskId === t.id)
+            .reduce((sum, d) => sum + d._count.id, 0);
+          totalUploaded += Math.min(uploaded, t.requiredInspections);
+        }
+      }
+
+      return { totalRequired, totalUploaded };
     }),
 });


### PR DESCRIPTION
## Summary
- Refactored `TaskDetailsPopover` into sub-components under `task-popover/` for maintainability
- Added `requiredSubmittals` and `requiredInspections` fields to `GanttTask` schema with requirement counter UI
- Always-visible ellipsis menu on Gantt task rows (no hover required)
- Extracted `TaskHeader`, `CoverImageBanner`, `FolderRow`, `FilePreviewPanel`, and content components

## Test plan
- [ ] Open Gantt chart and verify task rows always show ellipsis menu
- [ ] Click a task to open the popover — verify header, cover image, and folder rows render correctly
- [ ] Check submittals/inspections requirement counters appear and update
- [ ] Run `npx prisma db push` to apply schema changes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)