### PR TITLE
Add project cover image upload and refactor project forms

### DIFF
--- a/claudedocs/components-guide.md
+++ b/claudedocs/components-guide.md
@@ -8,11 +8,11 @@ Conventions for adding, naming, and structuring components in `src/components/`.
 
 | Directory | Purpose |
 |-----------|---------|
-| `ui/` | Shared design-system primitives (Button, Label, dropdowns, image helpers, spinner) |
+| `ui/` | Shared design-system primitives (Button, Label, dropdowns, image helpers, spinner, ProjectAvatar) |
 | `layout/` | App shell: Header, Sidebar, MobileDrawer, OrgSwitcher, ProjectSwitcher, UserMenu, PageHeader |
 | `providers/` | React context providers: ThemeRegistry, OrgProvider, ProjectProvider, LoadingProvider |
 | `dashboard/` | Dashboard feature components (StatsCards, ProjectsList, TeamActivity) |
-| `projects/` | Project CRUD dialogs and trees (AddProjectDialog, ProjectsTree, ProjectDetailPanel) |
+| `projects/` | Project CRUD dialogs and trees (AddProjectDialog, ProjectFormBody, ProjectsTree, ProjectDetailPanel) |
 | `documents/` | Document feature components (DocumentList, UploadDialog, FileDropzone) |
 | `team/` | Team/invite management (MembersList, InviteDialog, RoleSelect, PendingInvitesList) |
 | `onboarding/` | Onboarding wizard and step components |
@@ -178,6 +178,7 @@ const { control, handleSubmit, reset, formState: { errors } } = useForm<InputTyp
 | `ImageWithFallback` / `OptimizedImage` | `next/image` | Always use over bare `<img>` |
 | `FileDropzone` | `react-dropzone` | Standalone or embedded dropzone; accepts `getRootProps`/`getInputProps` for standalone mode |
 | `UploadOverlay` | `CircularProgress` | Upload progress overlay with spinner; variants: `dark` (image overlay), `light` (form area) |
+| `ProjectAvatar` | `next/image` + `Box` | Renders project cover image (with `onError` fallback) or project icon; used in ProjectSwitcher and ProjectFormBody |
 
 For any MUI component without a `ui/` wrapper, use MUI directly — do not create wrappers unless the abstraction is used in 3+ places.
 

--- a/claudedocs/environment-setup.md
+++ b/claudedocs/environment-setup.md
@@ -34,7 +34,7 @@ Validation is defined in `src/env.js` using `@t3-oss/env-nextjs` and Zod. The bu
 **Prerequisites**
 - Node.js 24 (see `.nvmrc`; use `nvm use`)
 - npm 11.3+ (declared in `packageManager` field)
-- PostgreSQL 14+ running locally with `pg_trgm` and `vector` extensions
+- PostgreSQL 17 (`brew install postgresql@17`) running locally with `pg_trgm` and `vector` extensions
 - Vercel CLI (`npm i -g vercel`) — non-DB secrets are managed in Vercel
 
 **Setup**
@@ -46,6 +46,9 @@ nvm use
 npm install          # runs prisma generate via postinstall
 
 # 2. Create local database (if not already done)
+# Ensure PostgreSQL 17 binaries are on PATH:
+export PATH="/opt/homebrew/opt/postgresql@17/bin:$PATH"
+brew services start postgresql@17
 createdb construction
 psql -d construction -c "CREATE EXTENSION IF NOT EXISTS pg_trgm; CREATE EXTENSION IF NOT EXISTS vector;"
 

--- a/prisma/migrations/20260402100000_add_project_image_url/migration.sql
+++ b/prisma/migrations/20260402100000_add_project_image_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN "imageUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -123,6 +123,7 @@ model Project {
     location       String          @default("")
     slug           String
     icon           String          @default("building")
+    imageUrl       String?
     status         String          @default("active")
     organizationId String
     template       ProjectTemplate @default(BLANK)

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/manage/page.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/manage/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { UserPlus, Trash, Warning } from '@phosphor-icons/react';
+import { Trash, Warning, PlusCircle } from '@phosphor-icons/react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Box, Typography, Tabs, Tab, Paper } from '@mui/material';
 import { useTheme, alpha } from '@mui/material/styles';
@@ -79,18 +79,6 @@ export default function ManagePage() {
             {projectName}
           </Typography>
         </Box>
-        {canManage && (
-          <Button
-            variant="contained"
-            onClick={() => setInviteDialogOpen(true)}
-            startIcon={<UserPlus size={16} />}
-            sx={{
-              visibility: activeTab === 'settings' ? 'hidden' : 'visible',
-            }}
-          >
-            Invite
-          </Button>
-        )}
       </Box>
 
       {/* Tabs */}
@@ -138,6 +126,39 @@ export default function ManagePage() {
               transition={{ duration: 0.15 }}
               sx={{ p: 2 }}
             >
+              {canManage && (
+                <Box
+                  onClick={() => setInviteDialogOpen(true)}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.5,
+                    p: 1.75,
+                    mb: 1.5,
+                    borderRadius: '12px',
+                    cursor: 'pointer',
+                    transition: 'background-color 0.2s',
+                    '&:hover': { bgcolor: 'action.hover' },
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 38,
+                      height: 38,
+                      borderRadius: '50%',
+                      bgcolor: alpha(theme.palette.primary.main, 0.08),
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <PlusCircle size={20} weight="light" color={theme.palette.primary.main} />
+                  </Box>
+                  <Typography sx={{ fontWeight: 600, fontSize: '0.875rem', color: 'text.primary' }}>
+                    Invite Member
+                  </Typography>
+                </Box>
+              )}
               <MembersList members={members} isLoading={membersLoading} />
             </Box>
           )}

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { Mail, Lock, Eye, EyeOff, ArrowRight, User, KeyRound, ChevronLeft } from 'lucide-react';
-import { authClient, signUp } from '@/lib/auth-client';
+import { Envelope, Lock, Eye, EyeSlash, ArrowRight, User, Key, CaretLeft } from '@phosphor-icons/react';
+import { authClient, signUp, signOut } from '@/lib/auth-client';
 import { api } from '@/trpc/react';
 import { TRPCClientError } from '@trpc/client';
 import { LogoIcon } from '@/components/ui/Logo';
@@ -80,6 +80,7 @@ export default function SignUpPage() {
   const searchParams = useSearchParams();
   const inviteToken = searchParams.get('invite');
 
+  const emailRef = useRef<HTMLInputElement>(null);
   const [step, setStep] = useState<Step>('register');
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -148,6 +149,15 @@ export default function SignUpPage() {
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleChangeEmail = async () => {
+    await signOut();
+    setEmail('');
+    setOtp('');
+    setError('');
+    setStep('register');
+    setTimeout(() => emailRef.current?.focus(), 50);
   };
 
   const handleResendOtp = async () => {
@@ -296,7 +306,7 @@ export default function SignUpPage() {
           component={Link}
           href="/"
           variant="text"
-          startIcon={<ChevronLeft size={16} />}
+          startIcon={<CaretLeft size={16} />}
           sx={{
             position: 'absolute',
             top: 28,
@@ -378,7 +388,7 @@ export default function SignUpPage() {
                     InputProps={{
                       startAdornment: (
                         <InputAdornment position="start">
-                          <User size={18} />
+                          <User size={18} weight="regular" />
                         </InputAdornment>
                       ),
                     }}
@@ -395,6 +405,7 @@ export default function SignUpPage() {
                   <TextField
                     id="email"
                     type="email"
+                    inputRef={emailRef}
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     placeholder="your.email@company.com"
@@ -404,7 +415,7 @@ export default function SignUpPage() {
                     InputProps={{
                       startAdornment: (
                         <InputAdornment position="start">
-                          <Mail size={18} />
+                          <Envelope size={18} weight="regular" />
                         </InputAdornment>
                       ),
                     }}
@@ -430,7 +441,7 @@ export default function SignUpPage() {
                     InputProps={{
                       startAdornment: (
                         <InputAdornment position="start">
-                          <Lock size={18} />
+                          <Lock size={18} weight="regular" />
                         </InputAdornment>
                       ),
                       endAdornment: (
@@ -440,7 +451,7 @@ export default function SignUpPage() {
                             edge="end"
                             size="small"
                           >
-                            {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                            {showPassword ? <EyeSlash size={18} /> : <Eye size={18} />}
                           </IconButton>
                         </InputAdornment>
                       ),
@@ -467,7 +478,7 @@ export default function SignUpPage() {
                     InputProps={{
                       startAdornment: (
                         <InputAdornment position="start">
-                          <KeyRound size={18} />
+                          <Key size={18} weight="regular" />
                         </InputAdornment>
                       ),
                     }}
@@ -535,7 +546,7 @@ export default function SignUpPage() {
                   {loading ? 'Verifying...' : 'Verify email'}
                 </Button>
 
-                <Box sx={{ textAlign: 'center' }}>
+                <Stack spacing={0.5} alignItems="center">
                   <Button
                     onClick={handleResendOtp}
                     disabled={resendCooldown > 0}
@@ -547,7 +558,15 @@ export default function SignUpPage() {
                       ? `Resend code in ${resendCooldown}s`
                       : "Didn't get the code? Resend"}
                   </Button>
-                </Box>
+                  <Button
+                    onClick={handleChangeEmail}
+                    variant="text"
+                    size="small"
+                    sx={{ color: 'text.secondary', textTransform: 'none', fontSize: '0.8125rem' }}
+                  >
+                    Wrong email? Go back
+                  </Button>
+                </Stack>
               </Stack>
             </Box>
           )}

--- a/src/app/(new-project)/new-project/CreateProjectForm.tsx
+++ b/src/app/(new-project)/new-project/CreateProjectForm.tsx
@@ -1,24 +1,12 @@
 'use client';
 
-import { useForm, Controller } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { Building2, ArrowRight } from 'lucide-react';
-import { api } from '@/trpc/react';
-import { useRouter } from 'next/navigation';
 import {
   Box,
-  TextField,
-  Button,
-  CircularProgress,
-  Typography,
   Paper,
   alpha,
   useTheme,
 } from '@mui/material';
-import {
-  createProjectSchema,
-  type CreateProjectInput,
-} from '@/lib/validations/project';
+import ProjectFormBody from '@/components/projects/ProjectFormBody';
 
 interface CreateProjectFormProps {
   orgSlug: string;
@@ -31,33 +19,7 @@ export default function CreateProjectForm({
   orgName,
   organizationId,
 }: CreateProjectFormProps) {
-  const router = useRouter();
   const theme = useTheme();
-
-  const {
-    control,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<CreateProjectInput>({
-    resolver: zodResolver(createProjectSchema),
-    defaultValues: {
-      name: '',
-      template: 'BLANK',
-    },
-  });
-
-  const createProject = api.project.create.useMutation({
-    onSuccess: (newProject) => {
-      router.replace(`/${orgSlug}/projects/${newProject.slug}/gantt`);
-    },
-  });
-
-  const onSubmit = (data: CreateProjectInput) => {
-    createProject.mutate({
-      ...data,
-      organizationId,
-    });
-  };
 
   return (
     <Paper
@@ -66,160 +28,28 @@ export default function CreateProjectForm({
         width: '100%',
         maxWidth: 480,
         mx: 'auto',
-        p: 5,
         borderRadius: '16px',
         border: '1px solid',
         borderColor: 'divider',
+        overflow: 'hidden',
       }}
     >
-      {/* Icon + Title */}
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 3 }}>
-        <Box
-          sx={{
-            width: 48,
-            height: 48,
-            borderRadius: '12px',
-            bgcolor: alpha(theme.palette.primary.main, 0.08),
-            border: `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            flexShrink: 0,
-          }}
-        >
-          <Building2
-            size={24}
-            style={{ color: theme.palette.primary.main }}
-          />
-        </Box>
-        <Box>
-          <Typography
-            sx={{
-              fontSize: '1.25rem',
-              fontWeight: 700,
-              color: 'text.primary',
-              letterSpacing: '-0.01em',
-              lineHeight: 1.3,
-            }}
-          >
-            Create Your First Project
-          </Typography>
-          <Typography
-            sx={{
-              fontSize: '0.875rem',
-              color: 'text.secondary',
-              mt: 0.5,
-              lineHeight: 1.5,
-            }}
-          >
-            Set up a project for {orgName} to start tracking tasks and timelines.
-          </Typography>
-        </Box>
-      </Box>
+      {/* Header accent bar */}
+      <Box
+        sx={{
+          height: 3,
+          background: `linear-gradient(90deg, ${theme.palette.primary.main}, ${alpha(theme.palette.primary.main, 0.3)})`,
+        }}
+      />
 
-      {/* Form */}
-      <Box component="form" onSubmit={handleSubmit(onSubmit)}>
-        <Typography
-          component="label"
-          htmlFor="project-name-input"
-          sx={{
-            display: 'block',
-            fontSize: '0.75rem',
-            fontWeight: 600,
-            color: 'text.secondary',
-            textTransform: 'uppercase',
-            letterSpacing: '0.05em',
-            mb: 0.75,
-          }}
-        >
-          Project Name
-        </Typography>
-        <Controller
-          name="name"
-          control={control}
-          render={({ field }) => (
-            <TextField
-              {...field}
-              id="project-name-input"
-              placeholder="e.g. Downtown Tower Construction"
-              error={!!errors.name}
-              helperText={errors.name?.message}
-              fullWidth
-              autoFocus
-              autoComplete="off"
-              sx={{
-                '& .MuiOutlinedInput-root': {
-                  borderRadius: '8px',
-                  fontSize: '0.9375rem',
-                  bgcolor: alpha(theme.palette.divider, 0.08),
-                  transition: 'all 0.15s ease',
-                  '& fieldset': {
-                    borderColor: 'transparent',
-                  },
-                  '&:hover fieldset': {
-                    borderColor: alpha(theme.palette.primary.main, 0.3),
-                  },
-                  '&.Mui-focused fieldset': {
-                    borderColor: theme.palette.primary.main,
-                    borderWidth: '1.5px',
-                  },
-                  '&.Mui-focused': {
-                    bgcolor: 'background.paper',
-                    boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
-                  },
-                },
-                '& .MuiOutlinedInput-input': {
-                  py: 1.5,
-                  px: 1.75,
-                  '&::placeholder': {
-                    color: alpha(theme.palette.text.secondary, 0.5),
-                    opacity: 1,
-                  },
-                },
-              }}
-            />
-          )}
+      <Box sx={{ p: 3.5 }}>
+        <ProjectFormBody
+          orgSlug={orgSlug}
+          organizationId={organizationId}
+          title="Create Your First Project"
+          subtitle={`Set up a project for ${orgName} to start tracking tasks and timelines.`}
+          replaceOnNavigate
         />
-
-        {createProject.error && (
-          <Typography
-            sx={{
-              fontSize: '0.8125rem',
-              color: 'error.main',
-              mt: 1.5,
-            }}
-          >
-            {createProject.error.message || 'Failed to create project'}
-          </Typography>
-        )}
-
-        <Button
-          type="submit"
-          variant="contained"
-          fullWidth
-          disabled={createProject.isPending}
-          endIcon={
-            createProject.isPending ? (
-              <CircularProgress size={16} sx={{ color: 'inherit' }} />
-            ) : (
-              <ArrowRight size={18} />
-            )
-          }
-          sx={{
-            mt: 3,
-            borderRadius: '8px',
-            fontWeight: 600,
-            fontSize: '0.9375rem',
-            py: 1.5,
-            textTransform: 'none',
-            boxShadow: `0 1px 3px ${alpha(theme.palette.primary.main, 0.3)}`,
-            '&:hover': {
-              boxShadow: `0 4px 12px ${alpha(theme.palette.primary.main, 0.35)}`,
-            },
-          }}
-        >
-          Create Project
-        </Button>
       </Box>
     </Paper>
   );

--- a/src/app/api/organization/logo/route.ts
+++ b/src/app/api/organization/logo/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { put } from "@vercel/blob";
+import { auth } from "@/lib/auth";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+const ALLOWED_IMAGE_TYPES = [
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+];
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await auth.api.getSession({ headers: req.headers });
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const formData = await req.formData();
+    const file = formData.get("file") as File | null;
+
+    if (!file) {
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ error: "File size exceeds 5MB limit" }, { status: 400 });
+    }
+
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+      return NextResponse.json({ error: "Only image files are allowed" }, { status: 400 });
+    }
+
+    const blob = await put(
+      `organizations/logos/${session.user.id}/${file.name}`,
+      file,
+      { access: "public", addRandomSuffix: true }
+    );
+
+    return NextResponse.json({ logoUrl: blob.url });
+  } catch (error) {
+    console.error("Organization logo upload error:", error);
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/project/image/route.ts
+++ b/src/app/api/project/image/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { put, del } from "@vercel/blob";
+import { db } from "@/server/db";
+import { auth } from "@/lib/auth";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+const ALLOWED_IMAGE_TYPES = [
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+];
+
+async function verifyOrgMembership(userId: string, organizationId: string) {
+  return db.membership.findUnique({
+    where: {
+      userId_organizationId: { userId, organizationId },
+    },
+    select: { role: true },
+  });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await auth.api.getSession({ headers: req.headers });
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const formData = await req.formData();
+    const file = formData.get("file") as File | null;
+    const organizationId = formData.get("organizationId") as string | null;
+
+    if (!file || !organizationId) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ error: "File size exceeds 5MB limit" }, { status: 400 });
+    }
+
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+      return NextResponse.json({ error: "Only image files are allowed" }, { status: 400 });
+    }
+
+    const membership = await verifyOrgMembership(session.user.id, organizationId);
+    if (!membership) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    const blob = await put(
+      `projects/covers/${organizationId}/${file.name}`,
+      file,
+      { access: "public", addRandomSuffix: true }
+    );
+
+    return NextResponse.json({ imageUrl: blob.url });
+  } catch (error) {
+    console.error("Project image upload error:", error);
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const session = await auth.api.getSession({ headers: req.headers });
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { imageUrl, organizationId } = (await req.json()) as {
+      imageUrl?: string;
+      organizationId?: string;
+    };
+
+    if (!imageUrl || !organizationId) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
+
+    const membership = await verifyOrgMembership(session.user.id, organizationId);
+    if (!membership) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    // Verify the URL belongs to this organization's blob path
+    const expectedPrefix = `projects/covers/${organizationId}/`;
+    if (!imageUrl.includes(expectedPrefix)) {
+      return NextResponse.json({ error: "Invalid image URL" }, { status: 403 });
+    }
+
+    try {
+      await del(imageUrl);
+    } catch {
+      // Blob may already be gone
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Project image delete error:", error);
+    return NextResponse.json({ error: "Delete failed" }, { status: 500 });
+  }
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -25,6 +25,7 @@ const PAGE_TITLES: Record<string, string> = {
   files: 'File Tree',
   'document-explorer': 'Document Explorer',
   team: 'Team',
+  manage: 'Manage',
 };
 
 interface HeaderProps {
@@ -76,9 +77,9 @@ export default function Header({ onMenuOpen }: HeaderProps) {
               {pageTitle}
             </Typography>
             <Typography sx={{ color: 'text.disabled', fontSize: 16, lineHeight: 1, userSelect: 'none' }}>·</Typography>
-            <ProjectSwitcher />
           </>
         )}
+        <ProjectSwitcher />
 
         {/* Spacer */}
         <Box sx={{ flex: 1 }} />

--- a/src/components/layout/ProjectSwitcher.tsx
+++ b/src/components/layout/ProjectSwitcher.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState, useRef } from 'react';
+import { useState } from 'react';
 import { useParams } from 'next/navigation';
-import { ChevronsUpDown, Search, Check, Plus } from 'lucide-react';
-import { getProjectIcon } from '@/lib/constants/projectIconComponents';
-import { Box, Typography, Menu, ButtonBase } from '@mui/material';
+import { CaretUpDown, MagnifyingGlass, Check, Plus } from '@phosphor-icons/react';
+import { Box, Typography, Menu, ButtonBase, alpha, useTheme } from '@mui/material';
+import ProjectAvatar from '@/components/ui/ProjectAvatar';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
 import { useProjectSwitcher } from '@/hooks/useProjectSwitcher';
 import AddProjectDialog from '@/components/projects/AddProjectDialog';
@@ -27,6 +27,7 @@ export default function ProjectSwitcher() {
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const params = useParams<{ projectSlug?: string }>();
   const { projectSlug } = params;
+  const theme = useTheme();
 
   const { orgSlug, activeOrganizationId } = useOrgFromUrl();
   const { projects, currentProject, switchProject } = useProjectSwitcher(activeOrganizationId, orgSlug);
@@ -63,14 +64,17 @@ export default function ProjectSwitcher() {
           '&:hover': { bgcolor: 'action.selected' },
         }}
       >
-        {(() => {
-          const CurrentIcon = getProjectIcon(currentProject?.icon);
-          return <CurrentIcon size={15} style={{ color: 'var(--mui-palette-text-secondary)', flexShrink: 0 }} />;
-        })()}
+        <ProjectAvatar
+          imageUrl={currentProject?.imageUrl}
+          icon={currentProject?.icon}
+          size={28}
+          borderRadius="6px"
+          color="var(--mui-palette-text-secondary)"
+        />
         <Typography sx={{ fontSize: 14, fontWeight: 500, color: 'text.secondary', lineHeight: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 160 }}>
           {projectSlug && currentProject ? currentProject.name : 'Select project'}
         </Typography>
-        <ChevronsUpDown style={{ width: 12, height: 12, flexShrink: 0, color: 'var(--mui-palette-text-disabled)' }} />
+        <CaretUpDown size={12} style={{ flexShrink: 0, color: 'var(--mui-palette-text-disabled)' }} />
       </ButtonBase>
 
       <Menu
@@ -81,7 +85,7 @@ export default function ProjectSwitcher() {
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         slotProps={{
           paper: {
-            sx: { width: 240, p: 0, overflow: 'hidden', mt: 0.5 },
+            sx: { width: 280, p: 0, overflow: 'hidden', mt: 0.5, borderRadius: '12px' },
           },
         }}
       >
@@ -110,11 +114,11 @@ export default function ProjectSwitcher() {
               px: 1.25,
               py: 1,
               bgcolor: 'secondary.main',
-              borderRadius: '12px',
+              borderRadius: '10px',
               color: 'text.secondary',
             }}
           >
-            <Search style={{ width: 14, height: 14, color: 'inherit', flexShrink: 0 }} />
+            <MagnifyingGlass size={14} style={{ color: 'inherit', flexShrink: 0 }} />
             <input
               value={search}
               onChange={(e) => setSearch(e.target.value)}
@@ -137,9 +141,10 @@ export default function ProjectSwitcher() {
         <Box sx={{ height: '1px', bgcolor: 'divider' }} />
 
         {/* Project List */}
-        <Box sx={{ py: 0.5, px: 0.75, maxHeight: 220, overflowY: 'auto' }}>
+        <Box sx={{ py: 0.5, px: 0.75, maxHeight: 340, overflowY: 'auto' }}>
           {filtered.map((project) => {
             const isActive = project.slug === projectSlug;
+            const hasImage = !!project.imageUrl;
             return (
               <Box
                 key={project.id}
@@ -147,63 +152,117 @@ export default function ProjectSwitcher() {
                 onClick={() => handleSwitch(project.slug)}
                 sx={{
                   display: 'flex',
-                  alignItems: 'center',
-                  gap: 1.25,
+                  alignItems: 'stretch',
+                  gap: 0,
                   width: '100%',
-                  px: 1.25,
-                  py: 1,
-                  borderRadius: '12px',
-                  border: 'none',
+                  borderRadius: '10px',
+                  border: '1.5px solid',
+                  borderColor: isActive
+                    ? alpha(theme.palette.primary.main, 0.25)
+                    : 'transparent',
                   cursor: 'pointer',
-                  bgcolor: isActive ? 'secondary.main' : 'transparent',
+                  bgcolor: isActive
+                    ? alpha(theme.palette.primary.main, 0.04)
+                    : 'transparent',
                   textAlign: 'left',
-                  transition: 'background-color 0.15s',
-                  '&:hover': { bgcolor: 'action.hover' },
+                  overflow: 'hidden',
+                  transition: 'all 0.15s ease',
+                  mb: 0.5,
+                  p: 0,
+                  '&:hover': {
+                    bgcolor: isActive
+                      ? alpha(theme.palette.primary.main, 0.06)
+                      : 'action.hover',
+                    borderColor: isActive
+                      ? alpha(theme.palette.primary.main, 0.35)
+                      : alpha(theme.palette.divider, 0.5),
+                  },
                 }}
               >
-                {(() => {
-                  const ItemIcon = getProjectIcon(project.icon);
-                  return (
-                    <Box sx={{ flexShrink: 0, color: 'text.secondary', display: 'flex', alignItems: 'center' }}>
-                      <ItemIcon size={14} />
-                    </Box>
-                  );
-                })()}
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                {/* Project image/icon thumbnail */}
+                <Box
+                  sx={{
+                    width: 56,
+                    flexShrink: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    bgcolor: hasImage
+                      ? 'transparent'
+                      : alpha(theme.palette.divider, 0.06),
+                    overflow: 'hidden',
+                  }}
+                >
+                  {hasImage ? (
+                    <Box
+                      component="img"
+                      src={project.imageUrl!}
+                      alt=""
+                      sx={{
+                        width: '100%',
+                        height: '100%',
+                        objectFit: 'cover',
+                      }}
+                    />
+                  ) : (
+                    <ProjectAvatar
+                      icon={project.icon}
+                      size={22}
+                      borderRadius={0}
+                      color={theme.palette.text.disabled}
+                    />
+                  )}
+                </Box>
+
+                {/* Project info */}
+                <Box sx={{ flex: 1, minWidth: 0, py: 1, px: 1.25 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                    <Box
+                      sx={{
+                        width: 6,
+                        height: 6,
+                        borderRadius: '50%',
+                        bgcolor: getStatusColor(project.status),
+                        flexShrink: 0,
+                      }}
+                    />
                     <Typography
                       sx={{
                         fontSize: '0.8125rem',
-                        fontWeight: isActive ? 500 : 400,
+                        fontWeight: isActive ? 600 : 500,
                         color: 'text.primary',
                         flex: 1,
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
                         whiteSpace: 'nowrap',
+                        lineHeight: 1.2,
                       }}
                     >
                       {project.name}
                     </Typography>
-                    <Typography sx={{ fontSize: '0.625rem', color: 'text.disabled', flexShrink: 0 }}>
+                    {isActive && (
+                      <Check size={13} weight="bold" style={{ flexShrink: 0, color: theme.palette.primary.main }} />
+                    )}
+                  </Box>
+
+                  {/* Progress bar */}
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 0.75 }}>
+                    <Box sx={{ flex: 1, height: 3, borderRadius: 2, bgcolor: alpha(theme.palette.divider, 0.15), overflow: 'hidden' }}>
+                      <Box
+                        sx={{
+                          height: '100%',
+                          width: `${project.completionPercent}%`,
+                          borderRadius: 2,
+                          bgcolor: isActive ? 'primary.main' : alpha(theme.palette.text.secondary, 0.35),
+                          transition: 'width 0.3s ease',
+                        }}
+                      />
+                    </Box>
+                    <Typography sx={{ fontSize: '0.625rem', fontWeight: 500, color: 'text.disabled', flexShrink: 0, lineHeight: 1 }}>
                       {project.completionPercent}%
                     </Typography>
                   </Box>
-                  {/* Progress bar */}
-                  <Box sx={{ mt: 0.5, height: 3, borderRadius: 2, bgcolor: 'action.hover', overflow: 'hidden' }}>
-                    <Box
-                      sx={{
-                        height: '100%',
-                        width: `${project.completionPercent}%`,
-                        borderRadius: 2,
-                        bgcolor: 'primary.main',
-                        transition: 'width 0.3s ease',
-                      }}
-                    />
-                  </Box>
                 </Box>
-                {isActive && (
-                  <Check style={{ width: 14, height: 14, flexShrink: 0, color: 'inherit', alignSelf: 'flex-start', marginTop: 2 }} />
-                )}
               </Box>
             );
           })}
@@ -235,7 +294,7 @@ export default function ProjectSwitcher() {
             '&:hover': { bgcolor: 'action.hover' },
           }}
         >
-          <Plus style={{ width: 14, height: 14, color: 'inherit' }} />
+          <Plus size={14} style={{ color: 'inherit' }} />
           <Typography sx={{ fontSize: '0.8125rem', fontWeight: 500, color: 'text.secondary' }}>
             Create new project
           </Typography>

--- a/src/components/onboarding/OnboardingField.tsx
+++ b/src/components/onboarding/OnboardingField.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { type LucideIcon } from "lucide-react";
+import type { Icon as PhosphorIcon } from "@phosphor-icons/react";
 import { Box, Typography, FormHelperText } from "@mui/material";
 
 interface OnboardingFieldProps {
   label: string;
-  icon?: LucideIcon;
+  icon?: PhosphorIcon;
   children: React.ReactNode;
   error?: string;
 }

--- a/src/components/onboarding/OnboardingProgress.tsx
+++ b/src/components/onboarding/OnboardingProgress.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Check } from "lucide-react";
+import { Check } from "@phosphor-icons/react";
 import { Box, Typography, LinearProgress } from "@mui/material";
 
 interface OnboardingProgressProps {
@@ -87,7 +87,7 @@ export function OnboardingProgress({
                       lineHeight: 0,
                     }}
                   >
-                    <Check size={18} strokeWidth={3} />
+                    <Check size={18} weight="bold" />
                   </Box>
                 ) : (
                   index + 1

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -2,12 +2,13 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { ArrowRight, Check } from "lucide-react";
+import { ArrowRight, Check } from "@phosphor-icons/react";
 import { useRouter } from "next/navigation";
 import { LogoIcon } from "@/components/ui/Logo";
 import { OnboardingProgress } from "./OnboardingProgress";
 import { StepIdentity } from "./steps/StepIdentity";
 import { StepContact } from "./steps/StepContact";
+import { StepLogo } from "./steps/StepLogo";
 import { StepReview } from "./steps/StepReview";
 import { api } from "@/trpc/react";
 import { Box, Typography, Paper } from "@mui/material";
@@ -17,6 +18,7 @@ import { useSnackbar } from "@/hooks/useSnackbar";
 const steps = [
   { label: "Company", subtitle: "Tell us about your company" },
   { label: "Contact", subtitle: "How can we reach you?" },
+  { label: "Logo", subtitle: "Add your company logo" },
   { label: "Review", subtitle: "Review and finalize" },
 ];
 
@@ -53,6 +55,7 @@ export function OnboardingWizard() {
     state: "",
     zip: "",
     licenseNumber: "",
+    logoUrl: "",
   });
 
   const completeMutation = api.onboarding.createOrganization.useMutation({
@@ -123,6 +126,7 @@ export function OnboardingWizard() {
       state: formData.state || undefined,
       zip: formData.zip || undefined,
       licenseNumber: formData.licenseNumber || undefined,
+      logoUrl: formData.logoUrl || undefined,
     });
   };
 
@@ -263,6 +267,12 @@ export function OnboardingWizard() {
                       />
                     )}
                     {currentStep === 2 && (
+                      <StepLogo
+                        logoUrl={formData.logoUrl}
+                        onLogoChange={(url) => updateField("logoUrl", url)}
+                      />
+                    )}
+                    {currentStep === 3 && (
                       <StepReview
                         formData={formData}
                         updateField={updateField}
@@ -320,7 +330,7 @@ export function OnboardingWizard() {
                   )}
                 </Box>
 
-                {currentStep === 1 && (
+                {(currentStep === 1 || currentStep === 2) && (
                   <Box sx={{ display: 'flex', justifyContent: 'center' }}>
                     <Button
                       variant="text"

--- a/src/components/onboarding/steps/StepContact.tsx
+++ b/src/components/onboarding/steps/StepContact.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Phone, Globe, MapPin } from "lucide-react";
+import { Phone, Globe, MapPin } from "@phosphor-icons/react";
 import { OnboardingField } from "../OnboardingField";
 import { TextField, Box } from "@mui/material";
 

--- a/src/components/onboarding/steps/StepIdentity.tsx
+++ b/src/components/onboarding/steps/StepIdentity.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Building2, Briefcase } from "lucide-react";
+import { Buildings, Briefcase } from "@phosphor-icons/react";
 import { OnboardingField } from "../OnboardingField";
 import { TextField, Select, MenuItem, FormControl, Box } from "@mui/material";
 
@@ -48,7 +48,7 @@ export function StepIdentity({
     >
       <OnboardingField
         label="Company Name"
-        icon={Building2}
+        icon={Buildings}
         error={errors.name}
       >
         <TextField

--- a/src/components/onboarding/steps/StepLogo.tsx
+++ b/src/components/onboarding/steps/StepLogo.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { motion } from "framer-motion";
+import { Camera, X, CloudArrowUp } from "@phosphor-icons/react";
+import { useDropzone } from "react-dropzone";
+import { Box, Typography, IconButton, CircularProgress } from "@mui/material";
+
+interface StepLogoProps {
+  logoUrl: string;
+  onLogoChange: (url: string) => void;
+}
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.06,
+    },
+  },
+};
+
+const fieldVariants = {
+  hidden: { y: 8, opacity: 0 },
+  visible: { y: 0, opacity: 1 },
+};
+
+export function StepLogo({ logoUrl, onLogoChange }: StepLogoProps) {
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleUpload = useCallback(
+    async (file: File) => {
+      setError("");
+      setUploading(true);
+
+      try {
+        const formData = new FormData();
+        formData.append("file", file);
+
+        const res = await fetch("/api/organization/logo", {
+          method: "POST",
+          body: formData,
+        });
+
+        const data = (await res.json()) as { logoUrl?: string; error?: string };
+
+        if (!res.ok) {
+          setError(data.error || "Upload failed");
+          return;
+        }
+
+        if (data.logoUrl) {
+          onLogoChange(data.logoUrl);
+        }
+      } catch {
+        setError("Upload failed. Please try again.");
+      } finally {
+        setUploading(false);
+      }
+    },
+    [onLogoChange]
+  );
+
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      const file = acceptedFiles[0];
+      if (file) {
+        void handleUpload(file);
+      }
+    },
+    [handleUpload]
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: {
+      "image/jpeg": [".jpg", ".jpeg"],
+      "image/png": [".png"],
+      "image/gif": [".gif"],
+      "image/webp": [".webp"],
+    },
+    maxFiles: 1,
+    maxSize: 5 * 1024 * 1024,
+    disabled: uploading,
+  });
+
+  const handleRemove = () => {
+    onLogoChange("");
+  };
+
+  return (
+    <Box
+      component={motion.div}
+      variants={containerVariants}
+      initial="hidden"
+      animate="visible"
+      sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 3 }}
+    >
+      <Box component={motion.div} variants={fieldVariants}>
+        <Typography
+          variant="body2"
+          sx={{ textAlign: "center", color: "text.secondary", mb: 0.5 }}
+        >
+          Add your company logo to personalize your workspace
+        </Typography>
+      </Box>
+
+      <Box
+        component={motion.div}
+        variants={fieldVariants}
+        sx={{ position: "relative" }}
+      >
+        {logoUrl ? (
+          <Box sx={{ position: "relative" }}>
+            <Box
+              sx={{
+                width: 140,
+                height: 140,
+                borderRadius: "20px",
+                overflow: "hidden",
+                border: "3px solid var(--border-light)",
+              }}
+            >
+              <Box
+                component="img"
+                src={logoUrl}
+                alt="Company logo"
+                sx={{
+                  width: "100%",
+                  height: "100%",
+                  objectFit: "cover",
+                }}
+              />
+            </Box>
+            <IconButton
+              onClick={handleRemove}
+              size="small"
+              sx={{
+                position: "absolute",
+                top: -8,
+                right: -8,
+                bgcolor: "background.paper",
+                border: "1px solid var(--border-light)",
+                boxShadow: 1,
+                width: 28,
+                height: 28,
+                "&:hover": { bgcolor: "error.light", color: "white" },
+              }}
+            >
+              <X size={14} weight="bold" />
+            </IconButton>
+          </Box>
+        ) : (
+          <Box
+            {...getRootProps()}
+            sx={{
+              width: 140,
+              height: 140,
+              borderRadius: "20px",
+              border: "2px dashed",
+              borderColor: isDragActive
+                ? "primary.main"
+                : "var(--border-color)",
+              bgcolor: isDragActive
+                ? "action.hover"
+                : "var(--bg-input)",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 1,
+              cursor: uploading ? "default" : "pointer",
+              transition: "all 0.2s",
+              "&:hover": uploading
+                ? {}
+                : {
+                    borderColor: "primary.main",
+                    bgcolor: "action.hover",
+                  },
+            }}
+          >
+            <input {...getInputProps()} />
+            {uploading ? (
+              <CircularProgress size={28} />
+            ) : (
+              <>
+                <Camera
+                  size={32}
+                  weight="light"
+                  style={{ color: "var(--text-muted)" }}
+                />
+                <Typography
+                  variant="caption"
+                  sx={{ color: "text.disabled", fontSize: "0.6875rem" }}
+                >
+                  Upload logo
+                </Typography>
+              </>
+            )}
+          </Box>
+        )}
+      </Box>
+
+      {!logoUrl && !uploading && (
+        <Box
+          {...getRootProps()}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 0.75,
+            cursor: "pointer",
+            color: "text.secondary",
+            "&:hover": { color: "text.primary" },
+          }}
+        >
+          <CloudArrowUp size={16} weight="bold" />
+          <Typography variant="body2" sx={{ fontSize: "0.8125rem" }}>
+            or drag and drop an image here
+          </Typography>
+        </Box>
+      )}
+
+      {error && (
+        <Typography
+          component={motion.p}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          variant="caption"
+          sx={{ color: "error.main" }}
+        >
+          {error}
+        </Typography>
+      )}
+
+      <Typography
+        component={motion.p}
+        variants={fieldVariants}
+        variant="caption"
+        sx={{ color: "text.disabled", textAlign: "center" }}
+      >
+        JPG, PNG, GIF or WebP. Max 5MB.
+      </Typography>
+    </Box>
+  );
+}

--- a/src/components/onboarding/steps/StepReview.tsx
+++ b/src/components/onboarding/steps/StepReview.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { FileText } from "lucide-react";
+import { FileText } from "@phosphor-icons/react";
 import { OnboardingField } from "../OnboardingField";
 import { TextField, Box, Typography, Paper } from "@mui/material";
 
@@ -16,6 +16,7 @@ interface StepReviewProps {
     state: string;
     zip: string;
     licenseNumber: string;
+    logoUrl: string;
   };
   updateField: (field: string, value: string) => void;
 }
@@ -72,6 +73,30 @@ export function StepReview({ formData, updateField }: StepReviewProps) {
           }}
         />
       </OnboardingField>
+
+      {formData.logoUrl && (
+        <Box
+          component={motion.div}
+          variants={fieldVariants}
+          sx={{ display: "flex", alignItems: "center", gap: 2 }}
+        >
+          <Box
+            component="img"
+            src={formData.logoUrl}
+            alt="Company logo"
+            sx={{
+              width: 48,
+              height: 48,
+              borderRadius: "10px",
+              objectFit: "cover",
+              border: "1px solid var(--border-light)",
+            }}
+          />
+          <Typography variant="body2" sx={{ color: "text.secondary" }}>
+            Company logo uploaded
+          </Typography>
+        </Box>
+      )}
 
       {summaryFields.length > 0 && (
         <Box component={motion.div} variants={fieldVariants}>

--- a/src/components/projects/AddProjectDialog.tsx
+++ b/src/components/projects/AddProjectDialog.tsx
@@ -1,587 +1,62 @@
 'use client';
 
-import { useForm, Controller } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowRight, MapPin } from '@phosphor-icons/react';
-import { api } from '@/trpc/react';
-import { useRouter } from 'next/navigation';
-import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
-import Script from 'next/script';
 import {
-  Autocomplete as MuiAutocomplete,
   Box,
   Dialog,
-  DialogContent,
-  DialogActions,
-  TextField,
-  Tooltip,
-  Typography,
   alpha,
   useTheme,
 } from '@mui/material';
-import { Button } from '@/components/ui/button';
-import { useSnackbar } from '@/hooks/useSnackbar';
-import {
-  createProjectSchema,
-  type CreateProjectInput,
-} from '@/lib/validations/project';
-import {
-  PROJECT_ICON_OPTIONS,
-  getProjectIcon,
-} from '@/lib/constants/projectIconComponents';
-import usePlacesAutocomplete, { getGeocode } from 'use-places-autocomplete';
-import { useState, useCallback, useEffect } from 'react';
-import { env } from '@/env';
-
-const GOOGLE_PLACES_API_KEY = env.NEXT_PUBLIC_GOOGLE_PLACES_API_KEY;
+import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
+import ProjectFormBody from '@/components/projects/ProjectFormBody';
 
 interface AddProjectDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-function LocationAutocompleteField({
-  value,
-  onChange,
-  error,
-  helperText,
-}: {
-  value: string;
-  onChange: (value: string) => void;
-  error?: boolean;
-  helperText?: string;
-}) {
-  const theme = useTheme();
-  const {
-    ready,
-    suggestions: { data },
-    setValue: setSearchValue,
-    clearSuggestions,
-  } = usePlacesAutocomplete({
-    requestOptions: {
-      types: ['address'],
-    },
-    debounce: 300,
-  });
-
-  const [options, setOptions] = useState<string[]>([]);
-
-  const handleInputChange = useCallback(
-    (_event: React.SyntheticEvent, newInputValue: string) => {
-      setSearchValue(newInputValue);
-      onChange(newInputValue);
-    },
-    [setSearchValue, onChange]
-  );
-
-  // Update options when suggestions change
-  useEffect(() => {
-    setOptions(data.map((suggestion) => suggestion.description));
-  }, [data]);
-
-  const handleSelect = useCallback(
-    async (_event: React.SyntheticEvent, newValue: string | null) => {
-      if (newValue) {
-        onChange(newValue);
-        clearSuggestions();
-        // Validate the address exists
-        try {
-          await getGeocode({ address: newValue });
-        } catch {
-          // Address selected from autocomplete, keep it even if geocode fails
-        }
-      } else {
-        onChange('');
-      }
-    },
-    [onChange, clearSuggestions]
-  );
-
-  const fieldSx = {
-    '& .MuiOutlinedInput-root': {
-      borderRadius: '8px',
-      fontSize: '0.9375rem',
-      bgcolor: alpha(theme.palette.divider, 0.08),
-      transition: 'all 0.15s ease',
-      '& fieldset': {
-        borderColor: 'transparent',
-      },
-      '&:hover fieldset': {
-        borderColor: alpha(theme.palette.primary.main, 0.3),
-      },
-      '&.Mui-focused fieldset': {
-        borderColor: theme.palette.primary.main,
-        borderWidth: '1.5px',
-      },
-      '&.Mui-focused': {
-        bgcolor: 'background.paper',
-        boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
-      },
-    },
-    '& .MuiOutlinedInput-input': {
-      py: 1.5,
-      px: 1.75,
-      '&::placeholder': {
-        color: alpha(theme.palette.text.secondary, 0.5),
-        opacity: 1,
-      },
-    },
-  };
-
-  return (
-    <MuiAutocomplete
-      freeSolo
-      options={options}
-      inputValue={value}
-      onInputChange={handleInputChange}
-      onChange={handleSelect}
-      disabled={!ready}
-      filterOptions={(x) => x}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          placeholder="e.g. 123 Main St, New York, NY"
-          error={error}
-          helperText={helperText}
-          fullWidth
-          sx={fieldSx}
-        />
-      )}
-      slotProps={{
-        paper: {
-          sx: {
-            borderRadius: '8px',
-            mt: 0.5,
-            boxShadow: `0 8px 24px ${alpha('#000', 0.12)}`,
-            '& .MuiAutocomplete-option': {
-              fontSize: '0.875rem',
-              py: 1,
-              px: 1.75,
-            },
-          },
-        },
-      }}
-    />
-  );
-}
-
-function PlainLocationField({
-  value,
-  onChange,
-  error,
-  helperText,
-}: {
-  value: string;
-  onChange: (value: string) => void;
-  error?: boolean;
-  helperText?: string;
-}) {
-  const theme = useTheme();
-
-  return (
-    <TextField
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      placeholder="e.g. 123 Main St, New York, NY"
-      error={error}
-      helperText={helperText}
-      fullWidth
-      autoComplete="off"
-      sx={{
-        '& .MuiOutlinedInput-root': {
-          borderRadius: '8px',
-          fontSize: '0.9375rem',
-          bgcolor: alpha(theme.palette.divider, 0.08),
-          transition: 'all 0.15s ease',
-          '& fieldset': {
-            borderColor: 'transparent',
-          },
-          '&:hover fieldset': {
-            borderColor: alpha(theme.palette.primary.main, 0.3),
-          },
-          '&.Mui-focused fieldset': {
-            borderColor: theme.palette.primary.main,
-            borderWidth: '1.5px',
-          },
-          '&.Mui-focused': {
-            bgcolor: 'background.paper',
-            boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
-          },
-        },
-        '& .MuiOutlinedInput-input': {
-          py: 1.5,
-          px: 1.75,
-          '&::placeholder': {
-            color: alpha(theme.palette.text.secondary, 0.5),
-            opacity: 1,
-          },
-        },
-      }}
-    />
-  );
-}
-
 export default function AddProjectDialog({
   open,
   onOpenChange,
 }: AddProjectDialogProps) {
-  const utils = api.useUtils();
-  const router = useRouter();
   const theme = useTheme();
-  const { showSnackbar } = useSnackbar();
-  const [scriptLoaded, setScriptLoaded] = useState(false);
-
   const { orgSlug, activeOrganizationId } = useOrgFromUrl();
 
-  const {
-    control,
-    handleSubmit,
-    reset,
-    watch,
-    formState: { errors },
-  } = useForm<CreateProjectInput>({
-    resolver: zodResolver(createProjectSchema),
-    defaultValues: {
-      name: '',
-      location: '',
-      icon: 'building',
-      template: 'BLANK',
-    },
-  });
-
-  const selectedIcon = watch('icon') ?? 'building';
-  const HeaderIcon = getProjectIcon(selectedIcon);
-
-  const createProject = api.project.create.useMutation({
-    onSuccess: (newProject) => {
-      showSnackbar('Project created successfully', 'success');
-      void utils.project.list.invalidate();
-      void utils.project.getActive.invalidate();
-      reset();
-      onOpenChange(false);
-      router.push(`/${orgSlug}/projects/${newProject.slug}/gantt`);
-    },
-    onError: (error) => {
-      showSnackbar(error.message || 'Failed to create project', 'error');
-    },
-  });
-
-  const onSubmit = (data: CreateProjectInput) => {
-    createProject.mutate({
-      ...data,
-      location: data.location,
-      organizationId: activeOrganizationId,
-    });
+  const handleClose = () => {
+    onOpenChange(false);
   };
 
-  const useGooglePlaces = !!GOOGLE_PLACES_API_KEY && scriptLoaded;
-
   return (
-    <>
-      {GOOGLE_PLACES_API_KEY && (
-        <Script
-          src={`https://maps.googleapis.com/maps/api/js?key=${GOOGLE_PLACES_API_KEY}&libraries=places`}
-          strategy="lazyOnload"
-          onReady={() => setScriptLoaded(true)}
-        />
-      )}
-      <Dialog
-        open={open}
-        onClose={() => onOpenChange(false)}
-        maxWidth={false}
-        PaperProps={{
-          sx: {
-            width: 440,
-            borderRadius: '16px',
-            overflow: 'hidden',
-            boxShadow: `0 24px 64px -16px ${alpha('#000', 0.2)}, 0 8px 20px -8px ${alpha('#000', 0.08)}`,
-          },
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth={false}
+      PaperProps={{
+        sx: {
+          width: 440,
+          borderRadius: '16px',
+          overflow: 'hidden',
+          boxShadow: `0 24px 64px -16px ${alpha('#000', 0.2)}, 0 8px 20px -8px ${alpha('#000', 0.08)}`,
+        },
+      }}
+    >
+      {/* Header accent bar */}
+      <Box
+        sx={{
+          height: 3,
+          background: `linear-gradient(90deg, ${theme.palette.primary.main}, ${alpha(theme.palette.primary.main, 0.3)})`,
         }}
-      >
-        {/* Header accent bar */}
-        <Box
-          sx={{
-            height: 3,
-            background: `linear-gradient(90deg, ${theme.palette.primary.main}, ${alpha(theme.palette.primary.main, 0.3)})`,
-          }}
+      />
+
+      <Box sx={{ p: 3.5 }}>
+        <ProjectFormBody
+          orgSlug={orgSlug}
+          organizationId={activeOrganizationId}
+          title="New Project"
+          subtitle="Set up a new construction project"
+          onCancel={handleClose}
+          onSuccess={handleClose}
         />
-
-        <Box sx={{ p: 3.5, pb: 0 }}>
-          {/* Icon + Title block */}
-          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 1.5 }}>
-            <Box
-              sx={{
-                width: 44,
-                height: 44,
-                borderRadius: '12px',
-                bgcolor: alpha(theme.palette.primary.main, 0.08),
-                border: `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                flexShrink: 0,
-                transition: 'all 0.15s ease',
-              }}
-            >
-              <HeaderIcon
-                size={22}
-                style={{ color: theme.palette.primary.main }}
-              />
-            </Box>
-            <Box sx={{ pt: 0.25 }}>
-              <Typography
-                sx={{
-                  fontSize: '1.125rem',
-                  fontWeight: 700,
-                  color: 'text.primary',
-                  letterSpacing: '-0.01em',
-                  lineHeight: 1.3,
-                }}
-              >
-                New Project
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: '0.8125rem',
-                  color: 'text.secondary',
-                  mt: 0.25,
-                  lineHeight: 1.4,
-                }}
-              >
-                Set up a new construction project
-              </Typography>
-            </Box>
-          </Box>
-        </Box>
-
-        <DialogContent sx={{ px: 3.5, pt: 2.5, pb: 1 }}>
-          <form onSubmit={handleSubmit(onSubmit)} id="add-project-form">
-            {/* Icon Picker */}
-            <Typography
-              component="label"
-              sx={{
-                display: 'block',
-                fontSize: '0.75rem',
-                fontWeight: 600,
-                color: 'text.secondary',
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-                mb: 0.75,
-              }}
-            >
-              Icon
-            </Typography>
-            <Controller
-              name="icon"
-              control={control}
-              render={({ field }) => (
-                <Box
-                  sx={{
-                    display: 'grid',
-                    gridTemplateColumns: 'repeat(7, 1fr)',
-                    gap: 0.75,
-                    mb: 2.5,
-                  }}
-                >
-                  {PROJECT_ICON_OPTIONS.map(({ id, label, Icon }) => {
-                    const isSelected = (field.value ?? 'building') === id;
-                    return (
-                      <Tooltip key={id} title={label} arrow placement="top">
-                        <Box
-                          component="button"
-                          type="button"
-                          onClick={() => field.onChange(id)}
-                          sx={{
-                            width: '100%',
-                            aspectRatio: '1',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            borderRadius: '10px',
-                            border: '1.5px solid',
-                            borderColor: isSelected
-                              ? theme.palette.primary.main
-                              : 'transparent',
-                            bgcolor: isSelected
-                              ? alpha(theme.palette.primary.main, 0.08)
-                              : 'transparent',
-                            color: isSelected
-                              ? theme.palette.primary.main
-                              : theme.palette.text.secondary,
-                            cursor: 'pointer',
-                            transition: 'all 0.15s ease',
-                            p: 0,
-                            '&:hover': {
-                              bgcolor: isSelected
-                                ? alpha(theme.palette.primary.main, 0.12)
-                                : alpha(theme.palette.divider, 0.12),
-                              color: isSelected
-                                ? theme.palette.primary.main
-                                : theme.palette.text.primary,
-                            },
-                          }}
-                        >
-                          <Icon size={20} weight={isSelected ? 'fill' : 'regular'} />
-                        </Box>
-                      </Tooltip>
-                    );
-                  })}
-                </Box>
-              )}
-            />
-
-            {/* Project Name */}
-            <Typography
-              component="label"
-              htmlFor="project-name-input"
-              sx={{
-                display: 'block',
-                fontSize: '0.75rem',
-                fontWeight: 600,
-                color: 'text.secondary',
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-                mb: 0.75,
-              }}
-            >
-              Project Name
-            </Typography>
-            <Controller
-              name="name"
-              control={control}
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  id="project-name-input"
-                  placeholder="e.g. Downtown Tower Construction"
-                  error={!!errors.name}
-                  helperText={errors.name?.message}
-                  fullWidth
-                  autoFocus
-                  autoComplete="off"
-                  sx={{
-                    '& .MuiOutlinedInput-root': {
-                      borderRadius: '8px',
-                      fontSize: '0.9375rem',
-                      bgcolor: alpha(theme.palette.divider, 0.08),
-                      transition: 'all 0.15s ease',
-                      '& fieldset': {
-                        borderColor: 'transparent',
-                      },
-                      '&:hover fieldset': {
-                        borderColor: alpha(theme.palette.primary.main, 0.3),
-                      },
-                      '&.Mui-focused fieldset': {
-                        borderColor: theme.palette.primary.main,
-                        borderWidth: '1.5px',
-                      },
-                      '&.Mui-focused': {
-                        bgcolor: 'background.paper',
-                        boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
-                      },
-                    },
-                    '& .MuiOutlinedInput-input': {
-                      py: 1.5,
-                      px: 1.75,
-                      '&::placeholder': {
-                        color: alpha(theme.palette.text.secondary, 0.5),
-                        opacity: 1,
-                      },
-                    },
-                  }}
-                />
-              )}
-            />
-
-            {/* Location */}
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 2.5, mb: 0.75 }}>
-              <MapPin size={13} style={{ color: theme.palette.text.secondary }} />
-              <Typography
-                component="label"
-                sx={{
-                  display: 'block',
-                  fontSize: '0.75rem',
-                  fontWeight: 600,
-                  color: 'text.secondary',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.05em',
-                }}
-              >
-                Location
-              </Typography>
-            </Box>
-            <Controller
-              name="location"
-              control={control}
-              render={({ field }) =>
-                useGooglePlaces ? (
-                  <LocationAutocompleteField
-                    value={field.value ?? ''}
-                    onChange={field.onChange}
-                    error={!!errors.location}
-                    helperText={errors.location?.message}
-                  />
-                ) : (
-                  <PlainLocationField
-                    value={field.value ?? ''}
-                    onChange={field.onChange}
-                    error={!!errors.location}
-                    helperText={errors.location?.message}
-                  />
-                )
-              }
-            />
-          </form>
-        </DialogContent>
-
-        <DialogActions
-          sx={{
-            px: 3.5,
-            py: 2.5,
-            gap: 1,
-          }}
-        >
-          <Button
-            variant="text"
-            onClick={() => onOpenChange(false)}
-            sx={{
-              color: 'text.secondary',
-              fontWeight: 500,
-              fontSize: '0.8125rem',
-              px: 2,
-              borderRadius: '8px',
-              '&:hover': {
-                bgcolor: alpha(theme.palette.divider, 0.12),
-                color: 'text.primary',
-              },
-            }}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="submit"
-            form="add-project-form"
-            variant="contained"
-            loading={createProject.isPending}
-            onClick={handleSubmit(onSubmit)}
-            endIcon={<ArrowRight size={16} />}
-            sx={{
-              borderRadius: '8px',
-              fontWeight: 600,
-              fontSize: '0.8125rem',
-              px: 2.5,
-              py: 1,
-              textTransform: 'none',
-              boxShadow: `0 1px 3px ${alpha(theme.palette.primary.main, 0.3)}`,
-              '&:hover': {
-                boxShadow: `0 4px 12px ${alpha(theme.palette.primary.main, 0.35)}`,
-              },
-            }}
-          >
-            Create Project
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </>
+      </Box>
+    </Dialog>
   );
 }

--- a/src/components/projects/ProjectFormBody.tsx
+++ b/src/components/projects/ProjectFormBody.tsx
@@ -1,0 +1,905 @@
+'use client';
+
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ArrowRight, MapPin, Image as ImageIcon, Swatches, UploadSimple, X } from '@phosphor-icons/react';
+import { api } from '@/trpc/react';
+import { useRouter } from 'next/navigation';
+import Script from 'next/script';
+import {
+  Autocomplete as MuiAutocomplete,
+  Box,
+  CircularProgress,
+  IconButton,
+  TextField,
+  Tooltip,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
+import { Button } from '@/components/ui/button';
+import ProjectAvatar from '@/components/ui/ProjectAvatar';
+import { useSnackbar } from '@/hooks/useSnackbar';
+import { useLoading } from '@/components/providers/LoadingProvider';
+import {
+  createProjectSchema,
+  type CreateProjectInput,
+} from '@/lib/validations/project';
+import {
+  PROJECT_ICON_OPTIONS,
+} from '@/lib/constants/projectIconComponents';
+import usePlacesAutocomplete, { getGeocode } from 'use-places-autocomplete';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useDropzone } from 'react-dropzone';
+import { env } from '@/env';
+
+const GOOGLE_PLACES_API_KEY = env.NEXT_PUBLIC_GOOGLE_PLACES_API_KEY;
+
+interface ProjectFormBodyProps {
+  orgSlug: string;
+  organizationId: string;
+  title: string;
+  subtitle: string;
+  onCancel?: () => void;
+  onSuccess?: () => void;
+  replaceOnNavigate?: boolean;
+}
+
+function LocationAutocompleteField({
+  value,
+  onChange,
+  error,
+  helperText,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  error?: boolean;
+  helperText?: string;
+}) {
+  const theme = useTheme();
+  const {
+    ready,
+    suggestions: { data },
+    setValue: setSearchValue,
+    clearSuggestions,
+  } = usePlacesAutocomplete({
+    requestOptions: {
+      types: ['address'],
+    },
+    debounce: 300,
+  });
+
+  const [options, setOptions] = useState<string[]>([]);
+
+  const handleInputChange = useCallback(
+    (_event: React.SyntheticEvent, newInputValue: string) => {
+      setSearchValue(newInputValue);
+      onChange(newInputValue);
+    },
+    [setSearchValue, onChange]
+  );
+
+  useEffect(() => {
+    setOptions(data.map((suggestion) => suggestion.description));
+  }, [data]);
+
+  const handleSelect = useCallback(
+    async (_event: React.SyntheticEvent, newValue: string | null) => {
+      if (newValue) {
+        onChange(newValue);
+        clearSuggestions();
+        try {
+          await getGeocode({ address: newValue });
+        } catch {
+          // Address selected from autocomplete, keep it even if geocode fails
+        }
+      } else {
+        onChange('');
+      }
+    },
+    [onChange, clearSuggestions]
+  );
+
+  const fieldSx = {
+    '& .MuiOutlinedInput-root': {
+      borderRadius: '8px',
+      fontSize: '0.9375rem',
+      bgcolor: alpha(theme.palette.divider, 0.08),
+      transition: 'all 0.15s ease',
+      '& fieldset': {
+        borderColor: 'transparent',
+      },
+      '&:hover fieldset': {
+        borderColor: alpha(theme.palette.primary.main, 0.3),
+      },
+      '&.Mui-focused fieldset': {
+        borderColor: theme.palette.primary.main,
+        borderWidth: '1.5px',
+      },
+      '&.Mui-focused': {
+        bgcolor: 'background.paper',
+        boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
+      },
+    },
+    '& .MuiOutlinedInput-input': {
+      py: 1.5,
+      px: 1.75,
+      '&::placeholder': {
+        color: alpha(theme.palette.text.secondary, 0.5),
+        opacity: 1,
+      },
+    },
+  };
+
+  return (
+    <MuiAutocomplete
+      freeSolo
+      options={options}
+      inputValue={value}
+      onInputChange={handleInputChange}
+      onChange={handleSelect}
+      disabled={!ready}
+      filterOptions={(x) => x}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          placeholder="e.g. 123 Main St, New York, NY"
+          error={error}
+          helperText={helperText}
+          fullWidth
+          sx={fieldSx}
+        />
+      )}
+      slotProps={{
+        paper: {
+          sx: {
+            borderRadius: '8px',
+            mt: 0.5,
+            boxShadow: `0 8px 24px ${alpha('#000', 0.12)}`,
+            '& .MuiAutocomplete-option': {
+              fontSize: '0.875rem',
+              py: 1,
+              px: 1.75,
+            },
+          },
+        },
+      }}
+    />
+  );
+}
+
+function PlainLocationField({
+  value,
+  onChange,
+  error,
+  helperText,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  error?: boolean;
+  helperText?: string;
+}) {
+  const theme = useTheme();
+
+  return (
+    <TextField
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="e.g. 123 Main St, New York, NY"
+      error={error}
+      helperText={helperText}
+      fullWidth
+      autoComplete="off"
+      sx={{
+        '& .MuiOutlinedInput-root': {
+          borderRadius: '8px',
+          fontSize: '0.9375rem',
+          bgcolor: alpha(theme.palette.divider, 0.08),
+          transition: 'all 0.15s ease',
+          '& fieldset': {
+            borderColor: 'transparent',
+          },
+          '&:hover fieldset': {
+            borderColor: alpha(theme.palette.primary.main, 0.3),
+          },
+          '&.Mui-focused fieldset': {
+            borderColor: theme.palette.primary.main,
+            borderWidth: '1.5px',
+          },
+          '&.Mui-focused': {
+            bgcolor: 'background.paper',
+            boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
+          },
+        },
+        '& .MuiOutlinedInput-input': {
+          py: 1.5,
+          px: 1.75,
+          '&::placeholder': {
+            color: alpha(theme.palette.text.secondary, 0.5),
+            opacity: 1,
+          },
+        },
+      }}
+    />
+  );
+}
+
+export default function ProjectFormBody({
+  orgSlug,
+  organizationId,
+  title,
+  subtitle,
+  onCancel,
+  onSuccess,
+  replaceOnNavigate,
+}: ProjectFormBodyProps) {
+  const utils = api.useUtils();
+  const router = useRouter();
+  const theme = useTheme();
+  const { showSnackbar } = useSnackbar();
+  const { showLoading, hideLoading } = useLoading();
+  const [scriptLoaded, setScriptLoaded] = useState(false);
+  const [pickerMode, setPickerMode] = useState<'icon' | 'photo'>('icon');
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const uploadedUrlRef = useRef<string | null>(null);
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<CreateProjectInput>({
+    resolver: zodResolver(createProjectSchema),
+    defaultValues: {
+      name: '',
+      location: '',
+      icon: 'building',
+      template: 'BLANK',
+    },
+  });
+
+  const selectedIcon = watch('icon') ?? 'building';
+  const imageUrl = watch('imageUrl');
+
+  const cleanupUploadedImage = useCallback((url?: string) => {
+    const urlToDelete = url ?? uploadedUrlRef.current;
+    if (urlToDelete && organizationId) {
+      void fetch('/api/project/image', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ imageUrl: urlToDelete, organizationId }),
+      }).catch(() => { /* silent cleanup */ });
+      uploadedUrlRef.current = null;
+    }
+  }, [organizationId]);
+
+  // Clean up orphaned image on unmount
+  useEffect(() => {
+    return () => {
+      if (uploadedUrlRef.current) {
+        const urlToDelete = uploadedUrlRef.current;
+        if (urlToDelete && organizationId) {
+          void fetch('/api/project/image', {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ imageUrl: urlToDelete, organizationId }),
+          }).catch(() => { /* silent cleanup */ });
+        }
+      }
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleReset = useCallback(() => {
+    reset();
+    setPickerMode('icon');
+    setUploadError(null);
+  }, [reset]);
+
+  const createProject = api.project.create.useMutation({
+    onSuccess: (newProject) => {
+      showSnackbar('Project created successfully', 'success');
+      void utils.project.list.invalidate();
+      void utils.project.getActive.invalidate();
+      uploadedUrlRef.current = null; // Don't clean up — project owns it now
+      handleReset();
+      if (replaceOnNavigate) {
+        router.replace(`/${orgSlug}/projects/${newProject.slug}/gantt`);
+      } else {
+        router.push(`/${orgSlug}/projects/${newProject.slug}/gantt`);
+      }
+      // Don't hide loading — let the navigation transition handle it
+    },
+    onError: (error) => {
+      hideLoading();
+      showSnackbar(error.message || 'Failed to create project', 'error');
+    },
+  });
+
+  const onSubmit = (data: CreateProjectInput) => {
+    // Close dialog immediately and show global loading overlay
+    onCancel?.();
+    showLoading('Creating your project...');
+    createProject.mutate({
+      ...data,
+      location: data.location,
+      organizationId,
+    });
+  };
+
+  const handleCancel = useCallback(() => {
+    if (uploadedUrlRef.current) {
+      cleanupUploadedImage();
+    }
+    handleReset();
+    onCancel?.();
+  }, [cleanupUploadedImage, handleReset, onCancel]);
+
+  const handlePhotoDrop = useCallback(async (acceptedFiles: File[]) => {
+    const file = acceptedFiles[0];
+    if (!file || !organizationId) return;
+
+    setIsUploading(true);
+    setUploadError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('organizationId', organizationId);
+
+      const res = await fetch('/api/project/image', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!res.ok) {
+        const data = await res.json() as { error?: string };
+        throw new Error(data.error ?? 'Upload failed');
+      }
+
+      const data = await res.json() as { imageUrl: string };
+
+      // Clean up previous upload if replacing
+      if (uploadedUrlRef.current) {
+        cleanupUploadedImage(uploadedUrlRef.current);
+      }
+
+      uploadedUrlRef.current = data.imageUrl;
+      setValue('imageUrl', data.imageUrl);
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : 'Upload failed — try again');
+    } finally {
+      setIsUploading(false);
+    }
+  }, [organizationId, setValue, cleanupUploadedImage]);
+
+  const handleRemovePhoto = useCallback(() => {
+    if (uploadedUrlRef.current) {
+      cleanupUploadedImage();
+    }
+    setValue('imageUrl', undefined);
+    setUploadError(null);
+  }, [setValue, cleanupUploadedImage]);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop: handlePhotoDrop,
+    accept: { 'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.webp'] },
+    maxFiles: 1,
+    maxSize: 5 * 1024 * 1024,
+    disabled: isUploading,
+    onDropRejected: (rejections) => {
+      const error = rejections[0]?.errors[0];
+      if (error?.code === 'file-too-large') {
+        setUploadError('File size exceeds 5MB limit');
+      } else if (error?.code === 'file-invalid-type') {
+        setUploadError('Only image files are allowed');
+      } else {
+        setUploadError('File not accepted');
+      }
+    },
+  });
+
+  const handleSwitchToIcon = useCallback(() => {
+    setPickerMode('icon');
+    setUploadError(null);
+    if (uploadedUrlRef.current) {
+      cleanupUploadedImage();
+      setValue('imageUrl', undefined);
+    }
+  }, [setValue, cleanupUploadedImage]);
+
+  const handleSwitchToPhoto = useCallback(() => {
+    setPickerMode('photo');
+    setUploadError(null);
+  }, []);
+
+  const useGooglePlaces = !!GOOGLE_PLACES_API_KEY && scriptLoaded;
+
+  return (
+    <>
+      {GOOGLE_PLACES_API_KEY && (
+        <Script
+          src={`https://maps.googleapis.com/maps/api/js?key=${GOOGLE_PLACES_API_KEY}&libraries=places`}
+          strategy="lazyOnload"
+          onReady={() => setScriptLoaded(true)}
+        />
+      )}
+
+      {/* Header: Icon + Title */}
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 1.5 }}>
+        <Box
+          sx={{
+            width: 44,
+            height: 44,
+            borderRadius: '12px',
+            bgcolor: imageUrl ? 'transparent' : alpha(theme.palette.primary.main, 0.08),
+            border: imageUrl ? 'none' : `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+            transition: 'all 0.15s ease',
+            overflow: 'hidden',
+          }}
+        >
+          <ProjectAvatar
+            imageUrl={imageUrl}
+            icon={selectedIcon}
+            size={imageUrl ? 44 : 22}
+            borderRadius="12px"
+            color={theme.palette.primary.main}
+          />
+        </Box>
+        <Box sx={{ pt: 0.25 }}>
+          <Typography
+            sx={{
+              fontSize: '1.125rem',
+              fontWeight: 700,
+              color: 'text.primary',
+              letterSpacing: '-0.01em',
+              lineHeight: 1.3,
+            }}
+          >
+            {title}
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: '0.8125rem',
+              color: 'text.secondary',
+              mt: 0.25,
+              lineHeight: 1.4,
+            }}
+          >
+            {subtitle}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Form */}
+      <Box sx={{ pt: 1 }}>
+        <form onSubmit={handleSubmit(onSubmit)} id="project-form">
+          {/* Picker Mode Toggle */}
+          <Box
+            role="radiogroup"
+            aria-label="Project image type"
+            sx={{
+              display: 'inline-flex',
+              borderRadius: '8px',
+              bgcolor: alpha(theme.palette.divider, 0.08),
+              p: '3px',
+              mb: 1.5,
+            }}
+          >
+            <Box
+              component="button"
+              type="button"
+              role="radio"
+              aria-checked={pickerMode === 'icon'}
+              onClick={handleSwitchToIcon}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.75,
+                px: 1.5,
+                py: 0.625,
+                borderRadius: '6px',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                fontFamily: 'inherit',
+                letterSpacing: '0.02em',
+                transition: 'all 0.15s ease',
+                bgcolor: pickerMode === 'icon' ? 'background.paper' : 'transparent',
+                color: pickerMode === 'icon' ? theme.palette.primary.main : theme.palette.text.secondary,
+                boxShadow: pickerMode === 'icon' ? `0 1px 3px ${alpha('#000', 0.08)}` : 'none',
+                '&:hover': {
+                  color: pickerMode === 'icon' ? theme.palette.primary.main : theme.palette.text.primary,
+                },
+              }}
+            >
+              <Swatches size={14} weight={pickerMode === 'icon' ? 'fill' : 'regular'} />
+              Icon
+            </Box>
+            <Box
+              component="button"
+              type="button"
+              role="radio"
+              aria-checked={pickerMode === 'photo'}
+              onClick={handleSwitchToPhoto}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.75,
+                px: 1.5,
+                py: 0.625,
+                borderRadius: '6px',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                fontFamily: 'inherit',
+                letterSpacing: '0.02em',
+                transition: 'all 0.15s ease',
+                bgcolor: pickerMode === 'photo' ? 'background.paper' : 'transparent',
+                color: pickerMode === 'photo' ? theme.palette.primary.main : theme.palette.text.secondary,
+                boxShadow: pickerMode === 'photo' ? `0 1px 3px ${alpha('#000', 0.08)}` : 'none',
+                '&:hover': {
+                  color: pickerMode === 'photo' ? theme.palette.primary.main : theme.palette.text.primary,
+                },
+              }}
+            >
+              <ImageIcon size={14} weight={pickerMode === 'photo' ? 'fill' : 'regular'} />
+              Photo
+            </Box>
+          </Box>
+
+          {/* Icon Picker */}
+          {pickerMode === 'icon' && (
+            <Controller
+              name="icon"
+              control={control}
+              render={({ field }) => (
+                <Box
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(7, 1fr)',
+                    gap: 0.75,
+                    mb: 2.5,
+                  }}
+                >
+                  {PROJECT_ICON_OPTIONS.map(({ id, label, Icon }) => {
+                    const isSelected = (field.value ?? 'building') === id;
+                    return (
+                      <Tooltip key={id} title={label} arrow placement="top">
+                        <Box
+                          component="button"
+                          type="button"
+                          onClick={() => field.onChange(id)}
+                          sx={{
+                            width: '100%',
+                            aspectRatio: '1',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            borderRadius: '10px',
+                            border: '1.5px solid',
+                            borderColor: isSelected
+                              ? theme.palette.primary.main
+                              : 'transparent',
+                            bgcolor: isSelected
+                              ? alpha(theme.palette.primary.main, 0.08)
+                              : 'transparent',
+                            color: isSelected
+                              ? theme.palette.primary.main
+                              : theme.palette.text.secondary,
+                            cursor: 'pointer',
+                            transition: 'all 0.15s ease',
+                            p: 0,
+                            '&:hover': {
+                              bgcolor: isSelected
+                                ? alpha(theme.palette.primary.main, 0.12)
+                                : alpha(theme.palette.divider, 0.12),
+                              color: isSelected
+                                ? theme.palette.primary.main
+                                : theme.palette.text.primary,
+                            },
+                          }}
+                        >
+                          <Icon size={20} weight={isSelected ? 'fill' : 'regular'} />
+                        </Box>
+                      </Tooltip>
+                    );
+                  })}
+                </Box>
+              )}
+            />
+          )}
+
+          {/* Photo Picker */}
+          {pickerMode === 'photo' && (
+            <Box sx={{ mb: 2.5 }}>
+              {imageUrl ? (
+                <Box
+                  sx={{
+                    position: 'relative',
+                    '&:hover .remove-photo-btn': { opacity: 1 },
+                  }}
+                >
+                  <Box
+                    component="img"
+                    src={imageUrl}
+                    alt="Project cover"
+                    sx={{
+                      width: '100%',
+                      height: 120,
+                      objectFit: 'cover',
+                      borderRadius: '10px',
+                    }}
+                  />
+                  <IconButton
+                    className="remove-photo-btn"
+                    onClick={handleRemovePhoto}
+                    aria-label="Remove uploaded photo"
+                    sx={{
+                      position: 'absolute',
+                      top: 6,
+                      right: 6,
+                      bgcolor: alpha('#000', 0.5),
+                      '&:hover': { bgcolor: alpha('#000', 0.7) },
+                      opacity: 0,
+                      transition: 'opacity 0.2s',
+                      color: 'white',
+                      p: 0.5,
+                    }}
+                  >
+                    <X size={14} />
+                  </IconButton>
+                </Box>
+              ) : (
+                <Box
+                  {...getRootProps()}
+                  aria-label="Upload project photo"
+                  aria-busy={isUploading}
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 0.75,
+                    py: 2.5,
+                    border: '1.5px dashed',
+                    borderColor: uploadError
+                      ? theme.palette.error.main
+                      : isDragActive
+                        ? theme.palette.primary.main
+                        : alpha(theme.palette.divider, 0.4),
+                    borderRadius: '10px',
+                    cursor: isUploading ? 'not-allowed' : 'pointer',
+                    bgcolor: isDragActive
+                      ? alpha(theme.palette.primary.main, 0.04)
+                      : 'transparent',
+                    opacity: isUploading ? 0.6 : 1,
+                    transition: 'all 0.15s ease',
+                    '&:hover': {
+                      borderColor: isUploading
+                        ? alpha(theme.palette.divider, 0.4)
+                        : alpha(theme.palette.primary.main, 0.4),
+                      bgcolor: isUploading
+                        ? 'transparent'
+                        : alpha(theme.palette.primary.main, 0.02),
+                    },
+                  }}
+                >
+                  <input {...getInputProps()} />
+                  {isUploading ? (
+                    <CircularProgress size={20} />
+                  ) : (
+                    <UploadSimple
+                      size={20}
+                      style={{ color: theme.palette.text.disabled }}
+                    />
+                  )}
+                  <Typography
+                    sx={{
+                      fontSize: '0.8125rem',
+                      color: 'text.secondary',
+                    }}
+                  >
+                    {isUploading
+                      ? 'Uploading...'
+                      : isDragActive
+                        ? 'Drop image here'
+                        : 'Drag & drop or click to upload'}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: '0.6875rem',
+                      color: 'text.disabled',
+                    }}
+                  >
+                    PNG, JPG, WebP up to 5MB
+                  </Typography>
+                </Box>
+              )}
+              {uploadError && (
+                <Typography
+                  sx={{
+                    fontSize: '0.75rem',
+                    color: 'error.main',
+                    mt: 0.75,
+                  }}
+                >
+                  {uploadError}
+                </Typography>
+              )}
+            </Box>
+          )}
+
+          {/* Project Name */}
+          <Typography
+            component="label"
+            htmlFor="project-name-input"
+            sx={{
+              display: 'block',
+              fontSize: '0.75rem',
+              fontWeight: 600,
+              color: 'text.secondary',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              mb: 0.75,
+            }}
+          >
+            Project Name
+          </Typography>
+          <Controller
+            name="name"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                id="project-name-input"
+                placeholder="e.g. Downtown Tower Construction"
+                error={!!errors.name}
+                helperText={errors.name?.message}
+                fullWidth
+                autoFocus
+                autoComplete="off"
+                sx={{
+                  '& .MuiOutlinedInput-root': {
+                    borderRadius: '8px',
+                    fontSize: '0.9375rem',
+                    bgcolor: alpha(theme.palette.divider, 0.08),
+                    transition: 'all 0.15s ease',
+                    '& fieldset': {
+                      borderColor: 'transparent',
+                    },
+                    '&:hover fieldset': {
+                      borderColor: alpha(theme.palette.primary.main, 0.3),
+                    },
+                    '&.Mui-focused fieldset': {
+                      borderColor: theme.palette.primary.main,
+                      borderWidth: '1.5px',
+                    },
+                    '&.Mui-focused': {
+                      bgcolor: 'background.paper',
+                      boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
+                    },
+                  },
+                  '& .MuiOutlinedInput-input': {
+                    py: 1.5,
+                    px: 1.75,
+                    '&::placeholder': {
+                      color: alpha(theme.palette.text.secondary, 0.5),
+                      opacity: 1,
+                    },
+                  },
+                }}
+              />
+            )}
+          />
+
+          {/* Location */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 2.5, mb: 0.75 }}>
+            <MapPin size={13} style={{ color: theme.palette.text.secondary }} />
+            <Typography
+              component="label"
+              sx={{
+                display: 'block',
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                color: 'text.secondary',
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+              }}
+            >
+              Location
+            </Typography>
+          </Box>
+          <Controller
+            name="location"
+            control={control}
+            render={({ field }) =>
+              useGooglePlaces ? (
+                <LocationAutocompleteField
+                  value={field.value ?? ''}
+                  onChange={field.onChange}
+                  error={!!errors.location}
+                  helperText={errors.location?.message}
+                />
+              ) : (
+                <PlainLocationField
+                  value={field.value ?? ''}
+                  onChange={field.onChange}
+                  error={!!errors.location}
+                  helperText={errors.location?.message}
+                />
+              )
+            }
+          />
+        </form>
+      </Box>
+
+      {/* Actions */}
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          gap: 1,
+          pt: 2.5,
+        }}
+      >
+        {onCancel && (
+          <Button
+            variant="text"
+            onClick={handleCancel}
+            sx={{
+              color: 'text.secondary',
+              fontWeight: 500,
+              fontSize: '0.8125rem',
+              px: 2,
+              borderRadius: '8px',
+              '&:hover': {
+                bgcolor: alpha(theme.palette.divider, 0.12),
+                color: 'text.primary',
+              },
+            }}
+          >
+            Cancel
+          </Button>
+        )}
+        <Button
+          type="submit"
+          form="project-form"
+          variant="contained"
+          loading={createProject.isPending}
+          disabled={isUploading}
+          onClick={handleSubmit(onSubmit)}
+          endIcon={<ArrowRight size={16} />}
+          sx={{
+            borderRadius: '8px',
+            fontWeight: 600,
+            fontSize: '0.8125rem',
+            px: 2.5,
+            py: 1,
+            textTransform: 'none',
+            boxShadow: `0 1px 3px ${alpha(theme.palette.primary.main, 0.3)}`,
+            ...(!onCancel && {
+              width: '100%',
+              py: 1.5,
+              fontSize: '0.9375rem',
+            }),
+            '&:hover': {
+              boxShadow: `0 4px 12px ${alpha(theme.palette.primary.main, 0.35)}`,
+            },
+          }}
+        >
+          Create Project
+        </Button>
+      </Box>
+    </>
+  );
+}

--- a/src/components/team/InviteDialog.tsx
+++ b/src/components/team/InviteDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { UserPlus } from 'lucide-react';
+import { UserPlus } from '@phosphor-icons/react';
 import { api } from '@/trpc/react';
 import {
   Box,

--- a/src/components/team/MembersList.tsx
+++ b/src/components/team/MembersList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { Box, Typography, Avatar, Skeleton, Stack } from '@mui/material';
+import { Box, Typography, Avatar, Skeleton } from '@mui/material';
 import { useTheme, alpha } from '@mui/material/styles';
 import { formatRole } from '@/lib/utils/formatting';
 
@@ -23,6 +23,23 @@ interface MembersListProps {
 
 export default function MembersList({ members, isLoading }: MembersListProps) {
   const theme = useTheme();
+
+  const getRoleDescription = (role: string): string => {
+    switch (role) {
+      case 'owner':
+        return 'Full access — manage members, roles, projects, and organization settings';
+      case 'admin':
+        return 'Manage members, roles, and projects — cannot change organization settings';
+      case 'project_manager':
+        return 'Create and manage projects — cannot manage members or roles';
+      case 'member':
+        return 'View projects they are invited to';
+      case 'viewer':
+        return 'View-only access to assigned projects';
+      default:
+        return '';
+    }
+  };
 
   const getRoleBadgeStyle = (role: string) => {
     switch (role) {
@@ -49,8 +66,8 @@ export default function MembersList({ members, isLoading }: MembersListProps) {
 
   if (isLoading) {
     return (
-      <Stack spacing={1.5}>
-        {[1, 2, 3].map((i) => (
+      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+        {[1, 2].map((i) => (
           <Box
             key={i}
             sx={{
@@ -61,15 +78,17 @@ export default function MembersList({ members, isLoading }: MembersListProps) {
               borderRadius: '12px',
             }}
           >
-            <Skeleton variant="rounded" width={38} height={38} sx={{ borderRadius: '10px' }} />
-            <Box sx={{ flex: 1 }}>
-              <Skeleton width="33%" height={16} sx={{ mb: 0.5 }} />
-              <Skeleton width="50%" height={12} />
+            <Skeleton variant="circular" width={38} height={38} sx={{ flexShrink: 0 }} />
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Skeleton variant="rounded" width={120} height={14} sx={{ borderRadius: '4px' }} />
+                <Skeleton variant="rounded" width={50} height={18} sx={{ borderRadius: '999px' }} />
+              </Box>
+              <Skeleton variant="rounded" width={180} height={12} sx={{ borderRadius: '4px', mt: 0.75 }} />
             </Box>
-            <Skeleton width={80} height={24} />
           </Box>
         ))}
-      </Stack>
+      </Box>
     );
   }
 
@@ -97,7 +116,7 @@ export default function MembersList({ members, isLoading }: MembersListProps) {
           },
         },
       }}
-      sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
+      sx={{ display: 'flex', flexDirection: 'column' }}
     >
       {members.map((member) => (
         <Box
@@ -125,7 +144,7 @@ export default function MembersList({ members, isLoading }: MembersListProps) {
             sx={{
               width: 38,
               height: 38,
-              borderRadius: '10px',
+              borderRadius: '50%',
               background: `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.primary.dark} 100%)`,
               color: theme.palette.primary.contrastText,
               fontWeight: 600,
@@ -136,21 +155,39 @@ export default function MembersList({ members, isLoading }: MembersListProps) {
           </Avatar>
 
           <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Typography
+                sx={{
+                  fontWeight: 600,
+                  fontSize: '0.875rem',
+                  color: 'text.primary',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  minWidth: 0,
+                }}
+              >
+                {member.user.name || member.user.email}
+              </Typography>
+              <Box
+                sx={{
+                  px: 1,
+                  py: 0.25,
+                  borderRadius: '999px',
+                  fontSize: '0.6875rem',
+                  fontWeight: 500,
+                  whiteSpace: 'nowrap',
+                  flexShrink: 0,
+                  ...getRoleBadgeStyle(member.role),
+                }}
+              >
+                {formatRole(member.role)}
+              </Box>
+            </Box>
             <Typography
               sx={{
-                fontWeight: 500,
-                color: 'text.primary',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {member.user.name || member.user.email}
-            </Typography>
-            <Typography
-              variant="body2"
-              sx={{
-                color: 'text.disabled',
+                fontSize: '0.8125rem',
+                color: 'text.secondary',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
@@ -158,20 +195,18 @@ export default function MembersList({ members, isLoading }: MembersListProps) {
             >
               {member.user.email}
             </Typography>
-          </Box>
-
-          <Box
-            sx={{
-              px: 1.5,
-              py: 0.5,
-              borderRadius: '999px',
-              fontSize: '0.75rem',
-              fontWeight: 500,
-              whiteSpace: 'nowrap',
-              ...getRoleBadgeStyle(member.role),
-            }}
-          >
-            {formatRole(member.role)}
+            <Typography
+              sx={{
+                fontSize: '0.75rem',
+                color: 'text.disabled',
+                mt: 0.25,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {getRoleDescription(member.role)}
+            </Typography>
           </Box>
         </Box>
       ))}

--- a/src/components/team/RoleSelect.tsx
+++ b/src/components/team/RoleSelect.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check } from 'lucide-react';
+import { Check } from '@phosphor-icons/react';
 import {
   Box,
   Typography,
@@ -99,7 +99,7 @@ export default function RoleSelect({
               </Typography>
             </Box>
             {value === role.value && (
-              <Check size={16} style={{ marginTop: 4, flexShrink: 0 }} />
+              <Check size={16} weight="bold" style={{ marginTop: 4, flexShrink: 0 }} />
             )}
           </MenuItem>
         ))}

--- a/src/components/ui/ProjectAvatar.tsx
+++ b/src/components/ui/ProjectAvatar.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+import { Box } from '@mui/material';
+import { getProjectIcon } from '@/lib/constants/projectIconComponents';
+
+interface ProjectAvatarProps {
+  imageUrl?: string | null;
+  icon?: string;
+  size: number;
+  borderRadius?: number | string;
+  color?: string;
+}
+
+export default function ProjectAvatar({
+  imageUrl,
+  icon,
+  size,
+  borderRadius = 3,
+  color,
+}: ProjectAvatarProps) {
+  const [imgError, setImgError] = useState(false);
+
+  if (imageUrl && !imgError) {
+    return (
+      <Box
+        component="img"
+        src={imageUrl}
+        alt=""
+        onError={() => setImgError(true)}
+        sx={{
+          width: size,
+          height: size,
+          borderRadius,
+          objectFit: 'cover',
+          flexShrink: 0,
+        }}
+      />
+    );
+  }
+
+  const Icon = getProjectIcon(icon);
+  return <Icon size={size} style={{ color, flexShrink: 0 }} />;
+}

--- a/src/lib/validations/onboarding.ts
+++ b/src/lib/validations/onboarding.ts
@@ -37,6 +37,7 @@ export const createOrganizationSchema = z.object({
       "ZIP code must be in format 12345 or 12345-6789"
     ),
   licenseNumber: z.string().optional(),
+  logoUrl: z.string().url().optional(),
 });
 
 export type CreateOrganizationInput = z.infer<typeof createOrganizationSchema>;

--- a/src/lib/validations/project.ts
+++ b/src/lib/validations/project.ts
@@ -5,6 +5,7 @@ export const createProjectSchema = z.object({
   name: z.string().min(1, "Project name is required").max(100).trim(),
   location: z.string().min(1, "Location is required").max(200).trim(),
   icon: z.enum(VALID_PROJECT_ICONS).default("building").optional(),
+  imageUrl: z.string().url().optional(),
   template: z.enum(["BLANK"]).default("BLANK").optional(),
 });
 

--- a/src/server/api/routers/onboarding.ts
+++ b/src/server/api/routers/onboarding.ts
@@ -59,6 +59,7 @@ export const onboardingRouter = createTRPCRouter({
             state: input.state,
             zip: input.zip,
             licenseNumber: input.licenseNumber,
+            logoUrl: input.logoUrl,
           },
         });
 

--- a/src/server/api/routers/project.ts
+++ b/src/server/api/routers/project.ts
@@ -149,6 +149,7 @@ export const projectRouter = createTRPCRouter({
           name: input.name,
           location: input.location,
           icon: input.icon,
+          imageUrl: input.imageUrl ?? null,
           slug,
           status: "active",
           organizationId,
@@ -392,6 +393,7 @@ export const projectRouter = createTRPCRouter({
       const blobUrls = [
         ...documents.map((d) => d.blobUrl),
         ...tasksWithCovers.map((t) => t.coverImageUrl).filter((url): url is string => !!url),
+        ...(ctx.project.imageUrl ? [ctx.project.imageUrl] : []),
       ];
 
       // Best-effort blob cleanup


### PR DESCRIPTION
## Summary
- Adds project cover image upload via a new `imageUrl` field on the Project model, with API routes for uploading project images and organization logos to Vercel Blob storage
- Extracts shared project form logic into a new `ProjectFormBody` component (used by both `AddProjectDialog` and `CreateProjectForm`), and adds a `ProjectAvatar` UI primitive for displaying project cover images or icons
- Adds a `StepLogo` onboarding step for uploading organization logos, and updates the onboarding wizard to include it; refactors onboarding components to use Phosphor icons
- Refactors `ProjectSwitcher` to show project cover images/icons and updates `MembersList` with improved UI and role management

## Test plan
- [ ] Create a new project and upload a cover image; verify it appears in the project switcher and manage page
- [ ] Run through onboarding wizard and upload an org logo in the new StepLogo step
- [ ] Verify existing projects without images still render correctly via the ProjectAvatar fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)