### PR TITLE
Add project settings edit and user profile tab

### DIFF
--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/layout.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/layout.tsx
@@ -47,7 +47,7 @@ export default async function ProjectLayout({
         slug: projectSlug,
       },
     },
-    select: { id: true, slug: true, name: true, organizationId: true },
+    select: { id: true, slug: true, name: true, icon: true, imageUrl: true, location: true, organizationId: true },
   });
 
   // Project not found - redirect to org home
@@ -69,6 +69,9 @@ export default async function ProjectLayout({
         projectId: project.id,
         projectSlug: project.slug,
         projectName: project.name,
+        projectIcon: project.icon,
+        projectImageUrl: project.imageUrl,
+        projectLocation: project.location,
         organizationId: project.organizationId,
       }}
     >

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/manage/page.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/manage/page.tsx
@@ -1,12 +1,28 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { Trash, Warning, PlusCircle } from '@phosphor-icons/react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Trash, Warning, PlusCircle, MapPin, Swatches, CaretDown,
+  Image as ImageIcon, UploadSimple, X, FloppyDisk,
+} from '@phosphor-icons/react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Box, Typography, Tabs, Tab, Paper } from '@mui/material';
-import { useTheme, alpha } from '@mui/material/styles';
+import {
+  Autocomplete as MuiAutocomplete,
+  Box, Typography, Tabs, Tab, Paper, Popover, TextField,
+  CircularProgress, IconButton, Tooltip,
+} from '@mui/material';
+import { useTheme, alpha, type Theme } from '@mui/material/styles';
+import Script from 'next/script';
+import { useRouter, useParams } from 'next/navigation';
+import { useDropzone } from 'react-dropzone';
+import usePlacesAutocomplete, { getGeocode } from 'use-places-autocomplete';
 import { api } from '@/trpc/react';
-import { canInviteMembers, canDeleteProjects } from '@/lib/permissions';
+import { canInviteMembers, canDeleteProjects, canManageProjects } from '@/lib/permissions';
+import { updateProjectSchema, type UpdateProjectInput } from '@/lib/validations/project';
+import { PROJECT_ICON_OPTIONS, getProjectIcon } from '@/lib/constants/projectIconComponents';
+import ProjectAvatar from '@/components/ui/ProjectAvatar';
 import InviteDialog from '@/components/team/InviteDialog';
 import MembersList from '@/components/team/MembersList';
 import PendingInvitesList from '@/components/team/PendingInvitesList';
@@ -14,6 +30,513 @@ import DeleteProjectDialog from '@/components/projects/DeleteProjectDialog';
 import { Button } from '@/components/ui/button';
 import { useProjectContext } from '@/components/providers/ProjectProvider';
 import { useOrgContext } from '@/components/providers/OrgProvider';
+import { useSnackbar } from '@/hooks/useSnackbar';
+import { env } from '@/env';
+
+const GOOGLE_PLACES_API_KEY = env.NEXT_PUBLIC_GOOGLE_PLACES_API_KEY;
+
+// ---------------------------------------------------------------------------
+// Location fields (reused from ProjectFormBody patterns)
+// ---------------------------------------------------------------------------
+
+const fieldSxFactory = (theme: Theme) => ({
+  '& .MuiOutlinedInput-root': {
+    borderRadius: '8px',
+    fontSize: '0.9375rem',
+    bgcolor: alpha(theme.palette.divider, 0.08),
+    transition: 'all 0.15s ease',
+    '& fieldset': { borderColor: 'transparent' },
+    '&:hover fieldset': { borderColor: alpha(theme.palette.primary.main, 0.3) },
+    '&.Mui-focused fieldset': { borderColor: theme.palette.primary.main, borderWidth: '1.5px' },
+    '&.Mui-focused': {
+      bgcolor: 'background.paper',
+      boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
+    },
+  },
+  '& .MuiOutlinedInput-input': {
+    py: 1.5,
+    px: 1.75,
+    '&::placeholder': { color: alpha(theme.palette.text.secondary, 0.5), opacity: 1 },
+  },
+});
+
+function LocationAutocompleteField({
+  value, onChange, error, helperText,
+}: { value: string; onChange: (v: string) => void; error?: boolean; helperText?: string }) {
+  const theme = useTheme();
+  const {
+    ready,
+    suggestions: { data },
+    setValue: setSearchValue,
+    clearSuggestions,
+  } = usePlacesAutocomplete({ requestOptions: { types: ['address'] }, debounce: 300 });
+
+  const [options, setOptions] = useState<string[]>([]);
+
+  const handleInputChange = useCallback(
+    (_e: React.SyntheticEvent, v: string) => { setSearchValue(v); onChange(v); },
+    [setSearchValue, onChange],
+  );
+
+  useEffect(() => { setOptions(data.map((s) => s.description)); }, [data]);
+
+  const handleSelect = useCallback(
+    async (_e: React.SyntheticEvent, v: string | null) => {
+      if (v) { onChange(v); clearSuggestions(); try { await getGeocode({ address: v }); } catch { /* ok */ } }
+      else { onChange(''); }
+    },
+    [onChange, clearSuggestions],
+  );
+
+  return (
+    <MuiAutocomplete
+      freeSolo options={options} inputValue={value}
+      onInputChange={handleInputChange} onChange={handleSelect}
+      disabled={!ready} filterOptions={(x) => x}
+      renderInput={(params) => (
+        <TextField {...params} placeholder="e.g. 123 Main St, New York, NY"
+          error={error} helperText={helperText} fullWidth sx={fieldSxFactory(theme)} />
+      )}
+      slotProps={{
+        paper: {
+          sx: {
+            borderRadius: '8px', mt: 0.5,
+            boxShadow: `0 8px 24px ${alpha('#000', 0.12)}`,
+            '& .MuiAutocomplete-option': { fontSize: '0.875rem', py: 1, px: 1.75 },
+          },
+        },
+      }}
+    />
+  );
+}
+
+function PlainLocationField({
+  value, onChange, error, helperText,
+}: { value: string; onChange: (v: string) => void; error?: boolean; helperText?: string }) {
+  const theme = useTheme();
+  return (
+    <TextField value={value} onChange={(e) => onChange(e.target.value)}
+      placeholder="e.g. 123 Main St, New York, NY" error={error} helperText={helperText}
+      fullWidth autoComplete="off" sx={fieldSxFactory(theme)} />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Settings Form (extracted for clarity)
+// ---------------------------------------------------------------------------
+
+function ProjectSettingsForm({
+  projectId, organizationId,
+}: { projectId: string; organizationId: string }) {
+  const theme = useTheme();
+  const router = useRouter();
+  const params = useParams<{ orgSlug: string; projectSlug: string }>();
+  const utils = api.useUtils();
+  const { showSnackbar } = useSnackbar();
+  const { projectName, projectIcon, projectImageUrl, projectLocation } = useProjectContext();
+
+  const [scriptLoaded, setScriptLoaded] = useState(false);
+  const [pickerMode, setPickerMode] = useState<'icon' | 'photo'>(projectImageUrl ? 'photo' : 'icon');
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [iconAnchorEl, setIconAnchorEl] = useState<HTMLElement | null>(null);
+  const uploadedUrlRef = useRef<string | null>(null);
+
+  const { control, handleSubmit, watch, setValue, formState: { errors, isDirty } } =
+    useForm<UpdateProjectInput>({
+      resolver: zodResolver(updateProjectSchema),
+      defaultValues: {
+        name: projectName,
+        location: projectLocation,
+        icon: (projectIcon ?? 'building') as UpdateProjectInput['icon'],
+        imageUrl: projectImageUrl ?? undefined,
+      },
+    });
+
+  const selectedIcon = watch('icon') ?? 'building';
+  const imageUrl = watch('imageUrl');
+  const SelectedIconComponent = getProjectIcon(selectedIcon);
+  const selectedIconLabel = PROJECT_ICON_OPTIONS.find(o => o.id === selectedIcon)?.label ?? 'Building';
+
+  // Track whether image changed relative to original
+  const imageChanged = imageUrl !== (projectImageUrl ?? undefined);
+
+  const cleanupUploadedImage = useCallback((url?: string) => {
+    const urlToDelete = url ?? uploadedUrlRef.current;
+    if (urlToDelete && organizationId) {
+      void fetch('/api/project/image', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ imageUrl: urlToDelete, organizationId }),
+      }).catch(() => {});
+      uploadedUrlRef.current = null;
+    }
+  }, [organizationId]);
+
+  // Cleanup orphaned upload on unmount
+  useEffect(() => {
+    return () => {
+      if (uploadedUrlRef.current) {
+        const urlToDelete = uploadedUrlRef.current;
+        if (urlToDelete && organizationId) {
+          void fetch('/api/project/image', {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ imageUrl: urlToDelete, organizationId }),
+          }).catch(() => {});
+        }
+      }
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const updateMutation = api.project.update.useMutation({
+    onSuccess: (updated) => {
+      showSnackbar('Project updated', 'success');
+      uploadedUrlRef.current = null;
+      void utils.project.list.invalidate();
+      void utils.project.getActive.invalidate();
+      void utils.project.getBySlug.invalidate();
+      // If slug changed, navigate to the new URL
+      if (updated.slug !== params.projectSlug) {
+        router.replace(`/${params.orgSlug}/projects/${updated.slug}/manage`);
+      }
+    },
+    onError: (err) => {
+      showSnackbar(err.message || 'Failed to update project', 'error');
+    },
+  });
+
+  const onSubmit = (data: UpdateProjectInput) => {
+    updateMutation.mutate({ ...data, projectId });
+  };
+
+  // Photo upload
+  const handlePhotoDrop = useCallback(async (acceptedFiles: File[]) => {
+    const file = acceptedFiles[0];
+    if (!file || !organizationId) return;
+    setIsUploading(true);
+    setUploadError(null);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('organizationId', organizationId);
+      const res = await fetch('/api/project/image', { method: 'POST', body: formData });
+      if (!res.ok) {
+        const d = await res.json() as { error?: string };
+        throw new Error(d.error ?? 'Upload failed');
+      }
+      const d = await res.json() as { imageUrl: string };
+      if (uploadedUrlRef.current) cleanupUploadedImage(uploadedUrlRef.current);
+      uploadedUrlRef.current = d.imageUrl;
+      setValue('imageUrl', d.imageUrl, { shouldDirty: true });
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setIsUploading(false);
+    }
+  }, [organizationId, setValue, cleanupUploadedImage]);
+
+  const handleRemovePhoto = useCallback(() => {
+    if (uploadedUrlRef.current) cleanupUploadedImage();
+    setValue('imageUrl', undefined, { shouldDirty: true });
+    setUploadError(null);
+  }, [setValue, cleanupUploadedImage]);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop: handlePhotoDrop,
+    accept: { 'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.webp'] },
+    maxFiles: 1, maxSize: 5 * 1024 * 1024, disabled: isUploading,
+    onDropRejected: (rejections) => {
+      const error = rejections[0]?.errors[0];
+      if (error?.code === 'file-too-large') setUploadError('File size exceeds 5MB limit');
+      else if (error?.code === 'file-invalid-type') setUploadError('Only image files are allowed');
+      else setUploadError('File not accepted');
+    },
+  });
+
+  const handleSwitchToIcon = useCallback(() => {
+    setPickerMode('icon');
+    setUploadError(null);
+    if (uploadedUrlRef.current) {
+      cleanupUploadedImage();
+      setValue('imageUrl', undefined, { shouldDirty: true });
+    }
+  }, [setValue, cleanupUploadedImage]);
+
+  const handleSwitchToPhoto = useCallback(() => {
+    setPickerMode('photo');
+    setUploadError(null);
+  }, []);
+
+  const useGooglePlaces = !!GOOGLE_PLACES_API_KEY && scriptLoaded;
+  const hasChanges = isDirty || imageChanged;
+  const fieldSx = fieldSxFactory(theme);
+
+  return (
+    <>
+      {GOOGLE_PLACES_API_KEY && (
+        <Script
+          src={`https://maps.googleapis.com/maps/api/js?key=${GOOGLE_PLACES_API_KEY}&libraries=places`}
+          strategy="lazyOnload"
+          onReady={() => setScriptLoaded(true)}
+        />
+      )}
+
+      <Box sx={{ px: 3, py: 2.5 }}>
+        {/* Preview */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2.5 }}>
+          <Box sx={{
+            width: 48, height: 48, borderRadius: '12px',
+            bgcolor: imageUrl ? 'transparent' : alpha(theme.palette.primary.main, 0.08),
+            border: imageUrl ? 'none' : `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            flexShrink: 0, overflow: 'hidden',
+          }}>
+            <ProjectAvatar
+              imageUrl={imageUrl}
+              icon={selectedIcon}
+              size={imageUrl ? 48 : 24}
+              borderRadius="12px"
+              color={theme.palette.primary.main}
+            />
+          </Box>
+          <Box>
+            <Typography sx={{ fontSize: '1rem', fontWeight: 600, color: 'text.primary', lineHeight: 1.3 }}>
+              Project Details
+            </Typography>
+            <Typography sx={{ fontSize: '0.8125rem', color: 'text.secondary', mt: 0.25 }}>
+              Update your project name, location, and image
+            </Typography>
+          </Box>
+        </Box>
+
+        <form onSubmit={handleSubmit(onSubmit)} id="settings-form">
+          {/* Picker Mode Toggle */}
+          <Box
+            role="radiogroup" aria-label="Project image type"
+            sx={{
+              display: 'inline-flex', borderRadius: '8px',
+              bgcolor: alpha(theme.palette.divider, 0.08), p: '3px', mb: 1.5,
+            }}
+          >
+            {(['icon', 'photo'] as const).map((mode) => {
+              const isActive = pickerMode === mode;
+              const Icon = mode === 'icon' ? Swatches : ImageIcon;
+              return (
+                <Box key={mode} component="button" type="button" role="radio"
+                  aria-checked={isActive}
+                  onClick={mode === 'icon' ? handleSwitchToIcon : handleSwitchToPhoto}
+                  sx={{
+                    display: 'flex', alignItems: 'center', gap: 0.75,
+                    px: 1.5, py: 0.625, borderRadius: '6px', border: 'none',
+                    cursor: 'pointer', fontSize: '0.75rem', fontWeight: 600,
+                    fontFamily: 'inherit', letterSpacing: '0.02em',
+                    transition: 'all 0.15s ease',
+                    bgcolor: isActive ? 'background.paper' : 'transparent',
+                    color: isActive ? theme.palette.primary.main : theme.palette.text.secondary,
+                    boxShadow: isActive ? `0 1px 3px ${alpha('#000', 0.08)}` : 'none',
+                    '&:hover': {
+                      color: isActive ? theme.palette.primary.main : theme.palette.text.primary,
+                    },
+                  }}
+                >
+                  <Icon size={14} weight={isActive ? 'fill' : 'regular'} />
+                  {mode === 'icon' ? 'Icon' : 'Photo'}
+                </Box>
+              );
+            })}
+          </Box>
+
+          {/* Icon Picker (dropdown) */}
+          {pickerMode === 'icon' && (
+            <Controller name="icon" control={control} render={({ field }) => (
+              <>
+                <Box
+                  component="button" type="button"
+                  onClick={(e: React.MouseEvent<HTMLElement>) => setIconAnchorEl(e.currentTarget)}
+                  sx={{
+                    display: 'flex', alignItems: 'center', gap: 1,
+                    px: 1.5, py: 1, mb: 2.5, borderRadius: '8px',
+                    border: '1.5px solid', borderColor: alpha(theme.palette.divider, 0.3),
+                    bgcolor: alpha(theme.palette.divider, 0.06),
+                    cursor: 'pointer', fontFamily: 'inherit',
+                    fontSize: '0.8125rem', fontWeight: 500, color: 'text.primary',
+                    transition: 'all 0.15s ease',
+                    '&:hover': {
+                      borderColor: alpha(theme.palette.primary.main, 0.4),
+                      bgcolor: alpha(theme.palette.divider, 0.1),
+                    },
+                  }}
+                >
+                  <SelectedIconComponent size={18} weight="fill" />
+                  {selectedIconLabel}
+                  <CaretDown size={12} style={{ marginLeft: 'auto', color: theme.palette.text.secondary }} />
+                </Box>
+                <Popover
+                  open={!!iconAnchorEl} anchorEl={iconAnchorEl}
+                  onClose={() => setIconAnchorEl(null)}
+                  anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                  transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                  slotProps={{
+                    paper: {
+                      sx: {
+                        borderRadius: '10px', mt: 0.5, p: 1,
+                        boxShadow: `0 8px 24px ${alpha('#000', 0.12)}`,
+                      },
+                    },
+                  }}
+                >
+                  <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 0.5 }}>
+                    {PROJECT_ICON_OPTIONS.map(({ id, label, Icon }) => {
+                      const isSelected = (field.value ?? 'building') === id;
+                      return (
+                        <Tooltip key={id} title={label} arrow placement="top">
+                          <Box component="button" type="button"
+                            onClick={() => { field.onChange(id); setIconAnchorEl(null); }}
+                            sx={{
+                              width: 36, height: 36, display: 'flex',
+                              alignItems: 'center', justifyContent: 'center',
+                              borderRadius: '8px', border: '1.5px solid',
+                              borderColor: isSelected ? theme.palette.primary.main : 'transparent',
+                              bgcolor: isSelected ? alpha(theme.palette.primary.main, 0.08) : 'transparent',
+                              color: isSelected ? theme.palette.primary.main : theme.palette.text.secondary,
+                              cursor: 'pointer', transition: 'all 0.15s ease', p: 0,
+                              '&:hover': {
+                                bgcolor: isSelected
+                                  ? alpha(theme.palette.primary.main, 0.12)
+                                  : alpha(theme.palette.divider, 0.12),
+                                color: isSelected ? theme.palette.primary.main : theme.palette.text.primary,
+                              },
+                            }}
+                          >
+                            <Icon size={18} weight={isSelected ? 'fill' : 'regular'} />
+                          </Box>
+                        </Tooltip>
+                      );
+                    })}
+                  </Box>
+                </Popover>
+              </>
+            )} />
+          )}
+
+          {/* Photo Picker */}
+          {pickerMode === 'photo' && (
+            <Box sx={{ mb: 2.5 }}>
+              {imageUrl ? (
+                <Box sx={{ position: 'relative', '&:hover .remove-photo-btn': { opacity: 1 } }}>
+                  <Box component="img" src={imageUrl} alt="Project cover"
+                    sx={{ width: '100%', height: 120, objectFit: 'cover', borderRadius: '10px' }} />
+                  <IconButton className="remove-photo-btn" onClick={handleRemovePhoto}
+                    aria-label="Remove uploaded photo"
+                    sx={{
+                      position: 'absolute', top: 6, right: 6,
+                      bgcolor: alpha('#000', 0.5), '&:hover': { bgcolor: alpha('#000', 0.7) },
+                      opacity: 0, transition: 'opacity 0.2s', color: 'white', p: 0.5,
+                    }}>
+                    <X size={14} />
+                  </IconButton>
+                </Box>
+              ) : (
+                <Box {...getRootProps()} aria-label="Upload project photo" aria-busy={isUploading}
+                  sx={{
+                    display: 'flex', flexDirection: 'column', alignItems: 'center',
+                    justifyContent: 'center', gap: 0.75, py: 2.5,
+                    border: '1.5px dashed',
+                    borderColor: uploadError ? theme.palette.error.main
+                      : isDragActive ? theme.palette.primary.main
+                      : alpha(theme.palette.divider, 0.4),
+                    borderRadius: '10px',
+                    cursor: isUploading ? 'not-allowed' : 'pointer',
+                    bgcolor: isDragActive ? alpha(theme.palette.primary.main, 0.04) : 'transparent',
+                    opacity: isUploading ? 0.6 : 1,
+                    transition: 'all 0.15s ease',
+                    '&:hover': {
+                      borderColor: isUploading ? alpha(theme.palette.divider, 0.4) : alpha(theme.palette.primary.main, 0.4),
+                      bgcolor: isUploading ? 'transparent' : alpha(theme.palette.primary.main, 0.02),
+                    },
+                  }}>
+                  <input {...getInputProps()} />
+                  {isUploading ? <CircularProgress size={20} /> : <UploadSimple size={20} style={{ color: theme.palette.text.disabled }} />}
+                  <Typography sx={{ fontSize: '0.8125rem', color: 'text.secondary' }}>
+                    {isUploading ? 'Uploading...' : isDragActive ? 'Drop image here' : 'Drag & drop or click to upload'}
+                  </Typography>
+                  <Typography sx={{ fontSize: '0.6875rem', color: 'text.disabled' }}>
+                    PNG, JPG, WebP up to 5MB
+                  </Typography>
+                </Box>
+              )}
+              {uploadError && (
+                <Typography sx={{ fontSize: '0.75rem', color: 'error.main', mt: 0.75 }}>
+                  {uploadError}
+                </Typography>
+              )}
+            </Box>
+          )}
+
+          {/* Project Name */}
+          <Typography component="label" htmlFor="settings-name-input"
+            sx={{
+              display: 'block', fontSize: '0.75rem', fontWeight: 600,
+              color: 'text.secondary', textTransform: 'uppercase',
+              letterSpacing: '0.05em', mb: 0.75,
+            }}>
+            Project Name
+          </Typography>
+          <Controller name="name" control={control} render={({ field }) => (
+            <TextField {...field} id="settings-name-input"
+              placeholder="e.g. Downtown Tower Construction"
+              error={!!errors.name} helperText={errors.name?.message}
+              fullWidth autoComplete="off" sx={fieldSx} />
+          )} />
+
+          {/* Location */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 2.5, mb: 0.75 }}>
+            <MapPin size={13} style={{ color: theme.palette.text.secondary }} />
+            <Typography component="label"
+              sx={{
+                display: 'block', fontSize: '0.75rem', fontWeight: 600,
+                color: 'text.secondary', textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+              }}>
+              Location
+            </Typography>
+          </Box>
+          <Controller name="location" control={control} render={({ field }) =>
+            useGooglePlaces ? (
+              <LocationAutocompleteField value={field.value ?? ''} onChange={field.onChange}
+                error={!!errors.location} helperText={errors.location?.message} />
+            ) : (
+              <PlainLocationField value={field.value ?? ''} onChange={field.onChange}
+                error={!!errors.location} helperText={errors.location?.message} />
+            )
+          } />
+
+          {/* Save Button */}
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2.5 }}>
+            <Button type="submit" form="settings-form" variant="contained"
+              disabled={!hasChanges || isUploading}
+              loading={updateMutation.isPending}
+              startIcon={<FloppyDisk size={15} />}
+              sx={{
+                borderRadius: '8px', fontWeight: 600, fontSize: '0.8125rem',
+                px: 2.5, py: 1, textTransform: 'none',
+                boxShadow: `0 1px 3px ${alpha(theme.palette.primary.main, 0.3)}`,
+                '&:hover': { boxShadow: `0 4px 12px ${alpha(theme.palette.primary.main, 0.35)}` },
+              }}>
+              Save Changes
+            </Button>
+          </Box>
+        </form>
+      </Box>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Manage Page
+// ---------------------------------------------------------------------------
 
 type ManageTab = 'members' | 'pending' | 'settings';
 
@@ -41,6 +564,7 @@ export default function ManagePage() {
   );
   const canManage = currentMembership ? canInviteMembers(currentMembership.role) : false;
   const canDelete = currentMembership ? canDeleteProjects(currentMembership.role) : false;
+  const canEdit = currentMembership ? canManageProjects(currentMembership.role) : false;
 
   const pendingCount = invitations.filter((inv) => inv.status === 'pending').length;
 
@@ -56,21 +580,10 @@ export default function ManagePage() {
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4 }}
-      sx={{
-        p: 3,
-        maxWidth: 800,
-        mx: 'auto',
-      }}
+      sx={{ p: 3, maxWidth: 800, mx: 'auto' }}
     >
       {/* Header */}
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          mb: 3,
-        }}
-      >
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
         <Box>
           <Typography variant="h5" sx={{ fontWeight: 600, color: 'text.primary' }}>
             Manage
@@ -87,29 +600,22 @@ export default function ManagePage() {
           value={activeTab}
           onChange={(_, newValue) => setActiveTab(newValue)}
           sx={{
-            borderBottom: 1,
-            borderColor: 'divider',
-            '& .MuiTab-root': {
-              textTransform: 'none',
-              fontWeight: 500,
-              fontSize: '0.875rem',
-            },
+            borderBottom: 1, borderColor: 'divider',
+            '& .MuiTab-root': { textTransform: 'none', fontWeight: 500, fontSize: '0.875rem' },
           }}
         >
           <Tab label={`Members (${members.length})`} value="members" />
-          {pendingCount > 0 && (
-            <Tab label={`Pending (${pendingCount})`} value="pending" />
-          )}
+          {pendingCount > 0 && <Tab label={`Pending (${pendingCount})`} value="pending" />}
           <Tab label="Settings" value="settings" />
         </Tabs>
       </Box>
 
-      {/* Tab Content — shared wrapper prevents layout shift */}
+      {/* Tab Content */}
       <Paper
         elevation={0}
         sx={{
           border: 1,
-          borderColor: activeTab === 'settings' ? alpha(theme.palette.error.main, 0.3) : 'divider',
+          borderColor: 'divider',
           borderRadius: '12px',
           overflow: 'hidden',
           transition: 'border-color 0.2s ease',
@@ -117,41 +623,23 @@ export default function ManagePage() {
       >
         <AnimatePresence mode="wait">
           {activeTab === 'members' && (
-            <Box
-              component={motion.div}
-              key="members"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.15 }}
-              sx={{ p: 2 }}
-            >
+            <Box component={motion.div} key="members"
+              initial={{ opacity: 0 }} animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }} transition={{ duration: 0.15 }}
+              sx={{ p: 2 }}>
               {canManage && (
-                <Box
-                  onClick={() => setInviteDialogOpen(true)}
+                <Box onClick={() => setInviteDialogOpen(true)}
                   sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1.5,
-                    p: 1.75,
-                    mb: 1.5,
-                    borderRadius: '12px',
-                    cursor: 'pointer',
+                    display: 'flex', alignItems: 'center', gap: 1.5,
+                    p: 1.75, mb: 1.5, borderRadius: '12px', cursor: 'pointer',
                     transition: 'background-color 0.2s',
                     '&:hover': { bgcolor: 'action.hover' },
-                  }}
-                >
-                  <Box
-                    sx={{
-                      width: 38,
-                      height: 38,
-                      borderRadius: '50%',
-                      bgcolor: alpha(theme.palette.primary.main, 0.08),
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                    }}
-                  >
+                  }}>
+                  <Box sx={{
+                    width: 38, height: 38, borderRadius: '50%',
+                    bgcolor: alpha(theme.palette.primary.main, 0.08),
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  }}>
                     <PlusCircle size={20} weight="light" color={theme.palette.primary.main} />
                   </Box>
                   <Typography sx={{ fontWeight: 600, fontSize: '0.875rem', color: 'text.primary' }}>
@@ -164,30 +652,15 @@ export default function ManagePage() {
           )}
 
           {activeTab === 'pending' && (
-            <Box
-              component={motion.div}
-              key="pending"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.15 }}
-              sx={{ p: 2 }}
-            >
+            <Box component={motion.div} key="pending"
+              initial={{ opacity: 0 }} animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }} transition={{ duration: 0.15 }}
+              sx={{ p: 2 }}>
               {pendingCount > 0 ? (
-                <PendingInvitesList
-                  invitations={invitations}
-                  isLoading={invitationsLoading}
-                  projectId={projectId}
-                  canManage={canManage}
-                />
+                <PendingInvitesList invitations={invitations} isLoading={invitationsLoading}
+                  projectId={projectId} canManage={canManage} />
               ) : (
-                <Typography
-                  sx={{
-                    textAlign: 'center',
-                    color: 'text.disabled',
-                    py: 4,
-                  }}
-                >
+                <Typography sx={{ textAlign: 'center', color: 'text.disabled', py: 4 }}>
                   No pending invitations
                 </Typography>
               )}
@@ -195,96 +668,62 @@ export default function ManagePage() {
           )}
 
           {activeTab === 'settings' && (
-            <Box
-              component={motion.div}
-              key="settings"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.15 }}
-            >
-              {canDelete ? (
+            <Box component={motion.div} key="settings"
+              initial={{ opacity: 0 }} animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }} transition={{ duration: 0.15 }}>
+              {/* Project Details — edit form */}
+              {canEdit ? (
+                <ProjectSettingsForm projectId={projectId} organizationId={organizationId} />
+              ) : (
+                <Box sx={{ px: 3, py: 2.5 }}>
+                  <Typography sx={{ color: 'text.disabled', fontSize: '0.875rem' }}>
+                    Only project owners, admins, and project managers can edit project settings.
+                  </Typography>
+                </Box>
+              )}
+
+              {/* Danger Zone — delete */}
+              {canDelete && (
                 <>
-                  {/* Danger Zone header */}
-                  <Box
-                    sx={{
-                      px: 3,
-                      py: 1.5,
-                      bgcolor: alpha(theme.palette.error.main, 0.04),
-                      borderBottom: '1px solid',
-                      borderColor: alpha(theme.palette.error.main, 0.15),
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 1,
-                    }}
-                  >
+                  <Box sx={{
+                    px: 3, py: 1.5,
+                    bgcolor: alpha(theme.palette.error.main, 0.04),
+                    borderTop: '1px solid',
+                    borderBottom: '1px solid',
+                    borderColor: alpha(theme.palette.error.main, 0.15),
+                    display: 'flex', alignItems: 'center', gap: 1,
+                  }}>
                     <Warning size={14} color={theme.palette.error.main} />
-                    <Typography
-                      sx={{
-                        fontSize: '0.75rem',
-                        fontWeight: 600,
-                        color: 'error.main',
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.05em',
-                      }}
-                    >
+                    <Typography sx={{
+                      fontSize: '0.75rem', fontWeight: 600, color: 'error.main',
+                      textTransform: 'uppercase', letterSpacing: '0.05em',
+                    }}>
                       Danger Zone
                     </Typography>
                   </Box>
-
-                  {/* Delete project row */}
-                  <Box
-                    sx={{
-                      px: 3,
-                      py: 2.5,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between',
-                      gap: 2,
-                    }}
-                  >
+                  <Box sx={{
+                    px: 3, py: 2.5, display: 'flex', alignItems: 'center',
+                    justifyContent: 'space-between', gap: 2,
+                  }}>
                     <Box>
-                      <Typography
-                        sx={{
-                          fontSize: '0.875rem',
-                          fontWeight: 600,
-                          color: 'text.primary',
-                          mb: 0.25,
-                        }}
-                      >
+                      <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary', mb: 0.25 }}>
                         Delete this project
                       </Typography>
-                      <Typography
-                        sx={{
-                          fontSize: '0.8125rem',
-                          color: 'text.secondary',
-                          lineHeight: 1.5,
-                        }}
-                      >
+                      <Typography sx={{ fontSize: '0.8125rem', color: 'text.secondary', lineHeight: 1.5 }}>
                         Permanently delete this project and all its data. This cannot be undone.
                       </Typography>
                     </Box>
-                    <Button
-                      variant="outlined"
-                      color="error"
+                    <Button variant="outlined" color="error"
                       onClick={() => setDeleteDialogOpen(true)}
                       startIcon={<Trash size={14} />}
                       sx={{
-                        flexShrink: 0,
-                        borderRadius: '8px',
-                        fontWeight: 600,
-                        fontSize: '0.8125rem',
-                        textTransform: 'none',
-                      }}
-                    >
+                        flexShrink: 0, borderRadius: '8px', fontWeight: 600,
+                        fontSize: '0.8125rem', textTransform: 'none',
+                      }}>
                       Delete
                     </Button>
                   </Box>
                 </>
-              ) : (
-                <Typography sx={{ color: 'text.disabled', fontSize: '0.875rem', p: 2 }}>
-                  Only project owners and admins can manage project settings.
-                </Typography>
               )}
             </Box>
           )}
@@ -293,20 +732,13 @@ export default function ManagePage() {
 
       {/* Invite Dialog */}
       {canManage && (
-        <InviteDialog
-          open={inviteDialogOpen}
-          onOpenChange={setInviteDialogOpen}
-          organizationId={organizationId}
-          projectId={projectId}
-        />
+        <InviteDialog open={inviteDialogOpen} onOpenChange={setInviteDialogOpen}
+          organizationId={organizationId} projectId={projectId} />
       )}
 
       {/* Delete Project Dialog */}
-      <DeleteProjectDialog
-        open={deleteDialogOpen}
-        onOpenChange={setDeleteDialogOpen}
-        project={projectId ? { id: projectId, name: projectName } : null}
-      />
+      <DeleteProjectDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}
+        project={projectId ? { id: projectId, name: projectName } : null} />
     </Box>
   );
 }

--- a/src/components/layout/AccountSettingsModal.tsx
+++ b/src/components/layout/AccountSettingsModal.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import { useState } from 'react';
-import { X, User, Settings, CreditCard, LifeBuoy } from 'lucide-react';
+import { X, User, GearSix, CreditCard, Lifebuoy } from '@phosphor-icons/react';
 import { Dialog, Box, IconButton, Typography } from '@mui/material';
+import ProfileTabContent from './ProfileTabContent';
 
 const tabs = [
   { id: 'profile', label: 'Profile', icon: User },
-  { id: 'account', label: 'Account', icon: Settings },
+  { id: 'account', label: 'Account', icon: GearSix },
   { id: 'billing', label: 'Billing', icon: CreditCard },
-  { id: 'help', label: 'Help & Support', icon: LifeBuoy },
+  { id: 'help', label: 'Help & Support', icon: Lifebuoy },
 ] as const;
 
 type TabId = (typeof tabs)[number]['id'];
@@ -96,7 +97,7 @@ export default function AccountSettingsModal({ open, onOpenChange }: AccountSett
                   },
                 }}
               >
-                <tab.icon style={{ width: 15, height: 15 }} />
+                <tab.icon size={15} />
                 <Typography
                   sx={{
                     fontSize: '0.8125rem',
@@ -134,15 +135,19 @@ export default function AccountSettingsModal({ open, onOpenChange }: AccountSett
             size="small"
             sx={{ color: 'text.secondary', '&:hover': { color: 'text.primary' } }}
           >
-            <X style={{ width: 18, height: 18 }} />
+            <X size={18} />
           </IconButton>
         </Box>
 
         {/* Content */}
         <Box sx={{ flex: 1, px: 3, py: 3, overflow: 'auto' }}>
-          <Typography sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
-            {tabs.find((t) => t.id === activeTab)?.label} settings will appear here.
-          </Typography>
+          {activeTab === 'profile' ? (
+            <ProfileTabContent />
+          ) : (
+            <Typography sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
+              {tabs.find((t) => t.id === activeTab)?.label} settings will appear here.
+            </Typography>
+          )}
         </Box>
       </Box>
     </Dialog>

--- a/src/components/layout/ProfileTabContent.tsx
+++ b/src/components/layout/ProfileTabContent.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Box, TextField, Typography, CircularProgress } from '@mui/material';
+import { Button } from '@/components/ui/button';
+import { api } from '@/trpc/react';
+import { useSnackbar } from '@/hooks/useSnackbar';
+import { updateProfileSchema, type UpdateProfileInput } from '@/lib/validations/user';
+import { getInitials } from '@/lib/utils/formatting';
+
+export default function ProfileTabContent() {
+  const { showSnackbar } = useSnackbar();
+  const utils = api.useUtils();
+  const { data: user, isLoading } = api.user.me.useQuery();
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors, isDirty },
+  } = useForm<UpdateProfileInput>({
+    resolver: zodResolver(updateProfileSchema),
+    defaultValues: { name: '', phone: '' },
+  });
+
+  useEffect(() => {
+    if (user) {
+      reset({ name: user.name ?? '', phone: user.phone ?? '' });
+    }
+  }, [user, reset]);
+
+  const updateProfile = api.user.update.useMutation({
+    onSuccess: () => {
+      showSnackbar('Profile updated', 'success');
+      void utils.user.me.invalidate();
+    },
+    onError: (error) => {
+      showSnackbar(error.message || 'Failed to update profile', 'error');
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
+        <CircularProgress size={28} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      {/* Avatar + identity */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Box
+          sx={{
+            width: 64,
+            height: 64,
+            borderRadius: '14px',
+            background: (theme) =>
+              `linear-gradient(135deg, ${theme.palette.accent.dark}, ${theme.palette.accent.gradientEnd})`,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+            fontSize: '1.125rem',
+            fontWeight: 600,
+            color: 'common.white',
+            letterSpacing: '0.02em',
+          }}
+        >
+          {getInitials(user?.name)}
+        </Box>
+        <Box>
+          <Typography sx={{ fontSize: '1rem', fontWeight: 600, lineHeight: 1.3 }}>
+            {user?.name ?? 'User'}
+          </Typography>
+          <Typography sx={{ fontSize: '0.8125rem', color: 'text.secondary', lineHeight: 1.3, mt: 0.25 }}>
+            {user?.email}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Form */}
+      <form
+        onSubmit={handleSubmit((data) => updateProfile.mutate(data))}
+        style={{ display: 'flex', flexDirection: 'column', gap: 20 }}
+      >
+        <Controller
+          name="name"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              label="Name"
+              fullWidth
+              size="small"
+              error={!!errors.name}
+              helperText={errors.name?.message}
+            />
+          )}
+        />
+
+        <TextField
+          label="Email"
+          value={user?.email ?? ''}
+          fullWidth
+          size="small"
+          disabled
+          helperText="Email cannot be changed"
+        />
+
+        <Controller
+          name="phone"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              label="Phone"
+              fullWidth
+              size="small"
+              error={!!errors.phone}
+              helperText={errors.phone?.message}
+            />
+          )}
+        />
+
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Typography sx={{ fontSize: '0.75rem', color: 'text.disabled' }}>
+            Joined {user?.createdAt ? new Date(user.createdAt).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            }) : ''}
+          </Typography>
+
+          <Button
+            type="submit"
+            variant="contained"
+            size="small"
+            disabled={!isDirty}
+            loading={updateProfile.isPending}
+          >
+            Save changes
+          </Button>
+        </Box>
+      </form>
+    </Box>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,8 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname, useParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
-import { User, Settings, CreditCard, LifeBuoy, LogOut } from 'lucide-react';
-import { ChartBar, FolderSimple, FileMagnifyingGlass, GearSix, CaretRight, CaretLineLeft, CaretLineRight, type Icon } from '@phosphor-icons/react';
+import { User, ChartBar, FolderSimple, FileMagnifyingGlass, GearSix, CaretRight, CaretLineLeft, CaretLineRight, CreditCard, Lifebuoy, SignOut, type Icon } from '@phosphor-icons/react';
 import { Box, Typography, Tooltip } from '@mui/material';
 import {
   DropdownMenu,
@@ -32,9 +31,9 @@ const iconMap: Record<string, Icon> = {
 
 const profileMenuItems = [
   { icon: User, label: 'My Profile' },
-  { icon: Settings, label: 'Account Settings' },
+  { icon: GearSix, label: 'Account Settings' },
   { icon: CreditCard, label: 'Billing' },
-  { icon: LifeBuoy, label: 'Help & Support' },
+  { icon: Lifebuoy, label: 'Help & Support' },
 ];
 
 interface SidebarProps {
@@ -484,7 +483,7 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
                 component="button"
                 onClick={() => {
                   setProfileOpen(false);
-                  if (item.label === 'Account Settings') {
+                  if (item.label === 'Account Settings' || item.label === 'My Profile') {
                     setSettingsOpen(true);
                   }
                 }}
@@ -503,7 +502,7 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
                   '&:hover': { bgcolor: 'action.hover' },
                 }}
               >
-                <item.icon style={{ width: 14, height: 14, color: 'inherit' }} />
+                <item.icon size={14} />
                 <Typography sx={{ fontSize: '0.8125rem', color: 'text.primary' }}>
                   {item.label}
                 </Typography>
@@ -534,7 +533,7 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
               '&:disabled': { opacity: 0.5, cursor: 'not-allowed' },
             }}
           >
-            <LogOut style={{ width: 14, height: 14, color: 'inherit' }} />
+            <SignOut size={14} />
             <Typography sx={{ fontSize: '0.8125rem', fontWeight: 500, color: 'inherit' }}>
               Log out
             </Typography>

--- a/src/components/projects/ProjectFormBody.tsx
+++ b/src/components/projects/ProjectFormBody.tsx
@@ -2,7 +2,7 @@
 
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowRight, MapPin, Image as ImageIcon, Swatches, UploadSimple, X } from '@phosphor-icons/react';
+import { ArrowRight, CaretDown, MapPin, Image as ImageIcon, Swatches, UploadSimple, X } from '@phosphor-icons/react';
 import { api } from '@/trpc/react';
 import { useRouter } from 'next/navigation';
 import Script from 'next/script';
@@ -11,6 +11,7 @@ import {
   Box,
   CircularProgress,
   IconButton,
+  Popover,
   TextField,
   Tooltip,
   Typography,
@@ -27,6 +28,7 @@ import {
 } from '@/lib/validations/project';
 import {
   PROJECT_ICON_OPTIONS,
+  getProjectIcon,
 } from '@/lib/constants/projectIconComponents';
 import usePlacesAutocomplete, { getGeocode } from 'use-places-autocomplete';
 import { useState, useCallback, useEffect, useRef } from 'react';
@@ -242,6 +244,7 @@ export default function ProjectFormBody({
   const [pickerMode, setPickerMode] = useState<'icon' | 'photo'>('icon');
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [iconAnchorEl, setIconAnchorEl] = useState<HTMLElement | null>(null);
   const uploadedUrlRef = useRef<string | null>(null);
 
   const {
@@ -262,6 +265,8 @@ export default function ProjectFormBody({
   });
 
   const selectedIcon = watch('icon') ?? 'building';
+  const SelectedIconComponent = getProjectIcon(selectedIcon);
+  const selectedIconLabel = PROJECT_ICON_OPTIONS.find(o => o.id === selectedIcon)?.label ?? 'Building';
   const imageUrl = watch('imageUrl');
 
   const cleanupUploadedImage = useCallback((url?: string) => {
@@ -557,64 +562,100 @@ export default function ProjectFormBody({
             </Box>
           </Box>
 
-          {/* Icon Picker */}
+          {/* Icon Picker (dropdown) */}
           {pickerMode === 'icon' && (
             <Controller
               name="icon"
               control={control}
               render={({ field }) => (
-                <Box
-                  sx={{
-                    display: 'grid',
-                    gridTemplateColumns: 'repeat(7, 1fr)',
-                    gap: 0.75,
-                    mb: 2.5,
-                  }}
-                >
-                  {PROJECT_ICON_OPTIONS.map(({ id, label, Icon }) => {
-                    const isSelected = (field.value ?? 'building') === id;
-                    return (
-                      <Tooltip key={id} title={label} arrow placement="top">
-                        <Box
-                          component="button"
-                          type="button"
-                          onClick={() => field.onChange(id)}
-                          sx={{
-                            width: '100%',
-                            aspectRatio: '1',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            borderRadius: '10px',
-                            border: '1.5px solid',
-                            borderColor: isSelected
-                              ? theme.palette.primary.main
-                              : 'transparent',
-                            bgcolor: isSelected
-                              ? alpha(theme.palette.primary.main, 0.08)
-                              : 'transparent',
-                            color: isSelected
-                              ? theme.palette.primary.main
-                              : theme.palette.text.secondary,
-                            cursor: 'pointer',
-                            transition: 'all 0.15s ease',
-                            p: 0,
-                            '&:hover': {
-                              bgcolor: isSelected
-                                ? alpha(theme.palette.primary.main, 0.12)
-                                : alpha(theme.palette.divider, 0.12),
-                              color: isSelected
-                                ? theme.palette.primary.main
-                                : theme.palette.text.primary,
-                            },
-                          }}
-                        >
-                          <Icon size={20} weight={isSelected ? 'fill' : 'regular'} />
-                        </Box>
-                      </Tooltip>
-                    );
-                  })}
-                </Box>
+                <>
+                  <Box
+                    component="button"
+                    type="button"
+                    onClick={(e: React.MouseEvent<HTMLElement>) => setIconAnchorEl(e.currentTarget)}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      px: 1.5,
+                      py: 1,
+                      mb: 2.5,
+                      borderRadius: '8px',
+                      border: '1.5px solid',
+                      borderColor: alpha(theme.palette.divider, 0.3),
+                      bgcolor: alpha(theme.palette.divider, 0.06),
+                      cursor: 'pointer',
+                      fontFamily: 'inherit',
+                      fontSize: '0.8125rem',
+                      fontWeight: 500,
+                      color: 'text.primary',
+                      transition: 'all 0.15s ease',
+                      '&:hover': {
+                        borderColor: alpha(theme.palette.primary.main, 0.4),
+                        bgcolor: alpha(theme.palette.divider, 0.1),
+                      },
+                    }}
+                  >
+                    <SelectedIconComponent size={18} weight="fill" />
+                    {selectedIconLabel}
+                    <CaretDown size={12} style={{ marginLeft: 'auto', color: theme.palette.text.secondary }} />
+                  </Box>
+                  <Popover
+                    open={!!iconAnchorEl}
+                    anchorEl={iconAnchorEl}
+                    onClose={() => setIconAnchorEl(null)}
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                    transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                    slotProps={{
+                      paper: {
+                        sx: {
+                          borderRadius: '10px',
+                          mt: 0.5,
+                          p: 1,
+                          boxShadow: `0 8px 24px ${alpha('#000', 0.12)}`,
+                        },
+                      },
+                    }}
+                  >
+                    <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 0.5 }}>
+                      {PROJECT_ICON_OPTIONS.map(({ id, label, Icon }) => {
+                        const isSelected = (field.value ?? 'building') === id;
+                        return (
+                          <Tooltip key={id} title={label} arrow placement="top">
+                            <Box
+                              component="button"
+                              type="button"
+                              onClick={() => { field.onChange(id); setIconAnchorEl(null); }}
+                              sx={{
+                                width: 36,
+                                height: 36,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                borderRadius: '8px',
+                                border: '1.5px solid',
+                                borderColor: isSelected ? theme.palette.primary.main : 'transparent',
+                                bgcolor: isSelected ? alpha(theme.palette.primary.main, 0.08) : 'transparent',
+                                color: isSelected ? theme.palette.primary.main : theme.palette.text.secondary,
+                                cursor: 'pointer',
+                                transition: 'all 0.15s ease',
+                                p: 0,
+                                '&:hover': {
+                                  bgcolor: isSelected
+                                    ? alpha(theme.palette.primary.main, 0.12)
+                                    : alpha(theme.palette.divider, 0.12),
+                                  color: isSelected ? theme.palette.primary.main : theme.palette.text.primary,
+                                },
+                              }}
+                            >
+                              <Icon size={18} weight={isSelected ? 'fill' : 'regular'} />
+                            </Box>
+                          </Tooltip>
+                        );
+                      })}
+                    </Box>
+                  </Popover>
+                </>
               )}
             />
           )}

--- a/src/components/providers/ProjectProvider.tsx
+++ b/src/components/providers/ProjectProvider.tsx
@@ -6,6 +6,9 @@ interface ProjectContextValue {
   projectId: string;
   projectSlug: string;
   projectName: string;
+  projectIcon: string;
+  projectImageUrl: string | null;
+  projectLocation: string;
   organizationId: string;
 }
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -69,6 +69,10 @@ export function canDeleteProjects(role: string): boolean {
   return hasPermission(role, "DELETE_PROJECTS");
 }
 
+export function canManageProjects(role: string): boolean {
+  return hasPermission(role, "MANAGE_PROJECTS");
+}
+
 // Role rank for hierarchy enforcement (higher = more privileged)
 const ROLE_RANK: Record<Role, number> = {
   owner: 4,

--- a/src/lib/validations/project.ts
+++ b/src/lib/validations/project.ts
@@ -11,6 +11,14 @@ export const createProjectSchema = z.object({
 
 export type CreateProjectInput = z.infer<typeof createProjectSchema>;
 
+export const updateProjectSchema = createProjectSchema
+  .pick({ name: true, location: true, icon: true, imageUrl: true })
+  .partial()
+  .extend({ location: z.string().max(200).trim().optional() })
+  .strict();
+
+export type UpdateProjectInput = z.infer<typeof updateProjectSchema>;
+
 export const deleteProjectSchema = z.object({
   confirmName: z.string().min(1, "Please type the project name to confirm"),
 });

--- a/src/lib/validations/user.ts
+++ b/src/lib/validations/user.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const updateProfileSchema = z.object({
+  name: z.string().min(1, "Name is required").max(100).trim(),
+  phone: z.string().max(20).trim().optional().or(z.literal("")),
+});
+
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -287,8 +287,17 @@ export const ganttRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Project not found or access denied" });
       }
 
-      return ctx.db.ganttTask.update({
+      const task = await ctx.db.ganttTask.findFirst({
         where: { id: taskId, projectId },
+        select: { id: true },
+      });
+
+      if (!task) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Task not found in this project" });
+      }
+
+      return ctx.db.ganttTask.update({
+        where: { id: taskId },
         data: { csiCode },
         select: { id: true, csiCode: true },
       });

--- a/src/server/api/routers/project.ts
+++ b/src/server/api/routers/project.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { del } from "@vercel/blob";
 import { createTRPCRouter, protectedProcedure, projectProcedure } from "@/server/api/trpc";
-import { createProjectSchema, deleteProjectSchema } from "@/lib/validations/project";
-import { canDeleteProjects } from "@/lib/permissions";
+import { createProjectSchema, updateProjectSchema, deleteProjectSchema } from "@/lib/validations/project";
+import { canDeleteProjects, canManageProjects } from "@/lib/permissions";
 import { getActiveOrganizationId } from "@/server/api/helpers/getActiveOrganization";
 import { getActiveProjectId } from "@/server/api/helpers/getActiveProject";
 import { getTemplateData } from "@/server/gantt/templates";
@@ -364,6 +364,53 @@ export const projectRouter = createTRPCRouter({
       });
 
       return project;
+    }),
+
+  update: projectProcedure
+    .input(updateProjectSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!canManageProjects(ctx.projectMember.role)) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Insufficient permissions to edit projects" });
+      }
+
+      const data: Record<string, unknown> = {};
+
+      // Handle name change → regenerate slug
+      if (input.name !== undefined && input.name !== ctx.project.name) {
+        data.name = input.name;
+        data.slug = await generateUniqueProjectSlug(input.name, ctx.organization.id, ctx.db);
+      }
+
+      if (input.location !== undefined) {
+        data.location = input.location;
+      }
+
+      if (input.icon !== undefined) {
+        data.icon = input.icon;
+      }
+
+      if (input.imageUrl !== undefined) {
+        // Clean up old image blob if replacing
+        if (ctx.project.imageUrl && ctx.project.imageUrl !== input.imageUrl) {
+          try {
+            await del(ctx.project.imageUrl);
+          } catch {
+            // Silent cleanup failure
+          }
+        }
+        data.imageUrl = input.imageUrl || null;
+      }
+
+      if (Object.keys(data).length === 0) {
+        return ctx.project;
+      }
+
+      const updated = await ctx.db.project.update({
+        where: { id: ctx.project.id },
+        data,
+      });
+
+      return updated;
     }),
 
   delete: projectProcedure

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -1,4 +1,5 @@
 import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
+import { updateProfileSchema } from "@/lib/validations/user";
 
 export const userRouter = createTRPCRouter({
   me: protectedProcedure.query(async ({ ctx }) => {
@@ -15,4 +16,16 @@ export const userRouter = createTRPCRouter({
 
     return user;
   }),
+
+  update: protectedProcedure
+    .input(updateProfileSchema)
+    .mutation(async ({ ctx, input }) => {
+      return ctx.db.user.update({
+        where: { id: ctx.session.user.id },
+        data: {
+          name: input.name,
+          phone: input.phone || null,
+        },
+      });
+    }),
 });

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -75,6 +75,11 @@ export const lightTheme: Theme = createTheme({
           textTransform: 'none',
           boxShadow: 'none',
           '&:hover': { boxShadow: 'none' },
+          '&.Mui-disabled': {
+            backgroundColor: '#D9DBE1',
+            color: '#8D99AE',
+            opacity: 0.7,
+          },
           '& .MuiButton-startIcon svg, & .MuiButton-endIcon svg': { width: 16, height: 16 },
           '&.MuiButton-sizeLarge .MuiButton-startIcon svg, &.MuiButton-sizeLarge .MuiButton-endIcon svg': { width: 18, height: 18 },
           '&.MuiButton-sizeSmall .MuiButton-startIcon svg, &.MuiButton-sizeSmall .MuiButton-endIcon svg': { width: 14, height: 14 },


### PR DESCRIPTION
## Summary
- Adds a project settings form on the manage page for editing name, location, icon, and cover image (gated behind `canManageProjects` permission)
- Adds a user profile edit tab in the account settings modal with name and phone fields
- Adds `project.update` and `user.update` tRPC mutations with proper permission checks and blob cleanup
- Migrates remaining Lucide icons to Phosphor in Sidebar and AccountSettingsModal
- Fixes slug comparison bug in post-update navigation and location validation on the update schema