### PR TITLE
Add optional version name and description fields

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "vercel link --project construction-web --scope celn --yes && vercel env pull .env.local --environment development --scope celn --yes && sed -i '' \"s|^construction_POSTGRES_PRISMA_URL=.*|construction_POSTGRES_PRISMA_URL=\\\"postgresql://$USER@localhost:5432/construction\\\"|\" .env.local && sed -i '' \"s|^construction_POSTGRES_URL_NON_POOLING=.*|construction_POSTGRES_URL_NON_POOLING=\\\"postgresql://$USER@localhost:5432/construction\\\"|\" .env.local && sed -i '' 's|\\\\n\"|\"| ' .env.local && (grep -q '^NODE_OPTIONS=' .env.local || echo 'NODE_OPTIONS=\"--max-old-space-size=8192\"' >> .env.local) && npm install",
+    "setup": "vercel link --project construction-web --scope celn --yes && vercel env pull .env.local --environment development --scope celn --yes && PG_PORT=$(sed -n '4p' \"$(brew --prefix)/var/postgresql@17/postmaster.pid\" 2>/dev/null); PG_PORT=${PG_PORT:-5432} && sed -i '' \"s|^construction_POSTGRES_PRISMA_URL=.*|construction_POSTGRES_PRISMA_URL=\\\"postgresql://$USER@localhost:${PG_PORT}/construction\\\"|\" .env.local && sed -i '' \"s|^construction_POSTGRES_URL_NON_POOLING=.*|construction_POSTGRES_URL_NON_POOLING=\\\"postgresql://$USER@localhost:${PG_PORT}/construction\\\"|\" .env.local && sed -i '' 's|\\\\n\"|\"| ' .env.local && (grep -q '^NODE_OPTIONS=' .env.local || echo 'NODE_OPTIONS=\"--max-old-space-size=8192\"' >> .env.local) && npm install",
     "run": "npm run dev",
     "archive": "rm -f .env.local && rm -rf .vercel && rm -rf node_modules && rm -rf .next"
   }

--- a/prisma/migrations/20260403000000_optional_version_name_description/migration.sql
+++ b/prisma/migrations/20260403000000_optional_version_name_description/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ScheduleVersion" ALTER COLUMN "name" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "ScheduleVersion" ADD COLUMN "description" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -358,7 +358,8 @@ model GanttTimeRange {
 model ScheduleVersion {
     id          String   @id @default(cuid())
     projectId   String
-    name        String
+    name        String?
+    description String?
     snapshot    Json
     createdById String
     createdAt   DateTime @default(now())

--- a/src/components/bryntum/components/SaveVersionDialog.tsx
+++ b/src/components/bryntum/components/SaveVersionDialog.tsx
@@ -3,7 +3,9 @@
 import { useState, useCallback } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Dialog, DialogTitle, DialogContent, DialogActions, TextField } from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogActions, TextField, Box, Typography } from '@mui/material';
+import { CalendarBlank, Clock } from '@phosphor-icons/react';
+import { format } from 'date-fns';
 import { Button } from '@/components/ui/button';
 import { api } from '@/trpc/react';
 import { useSnackbar } from '@/hooks/useSnackbar';
@@ -20,16 +22,18 @@ export default function SaveVersionDialog({ open, onOpenChange, projectId }: Sav
   const { showSnackbar } = useSnackbar();
   const [isSyncing, setIsSyncing] = useState(false);
 
-  const { control, handleSubmit, reset, formState: { errors } } = useForm<SaveVersionInput>({
+  const { control, handleSubmit, reset, formState: { errors }, watch } = useForm<SaveVersionInput>({
     resolver: zodResolver(saveVersionSchema),
-    defaultValues: { name: '' },
+    defaultValues: { name: '', description: '' },
   });
+
+  const nameValue = watch('name');
+  const now = new Date();
 
   const saveMutation = api.schedule.saveVersion.useMutation({
     onSuccess: (data) => {
       void utils.schedule.listVersions.invalidate({ projectId });
-      // Reset the frontend change tracker
-      window.dispatchEvent(new CustomEvent('gantt-version-saved', { detail: { name: data.name } }));
+      window.dispatchEvent(new CustomEvent('gantt-version-saved', { detail: { name: data.name, id: data.id } }));
       showSnackbar('Version saved', 'success');
       reset();
       onOpenChange(false);
@@ -59,7 +63,6 @@ export default function SaveVersionDialog({ open, onOpenChange, projectId }: Sav
     timeoutId = setTimeout(() => {
       cleanup();
       setIsSyncing(false);
-      // Proceed with save even if sync event was not received
       saveMutation.mutate({ ...data, projectId });
     }, SYNC_TIMEOUT_MS);
 
@@ -75,22 +78,70 @@ export default function SaveVersionDialog({ open, onOpenChange, projectId }: Sav
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
       <form onSubmit={handleSubmit(handleSave)}>
-        <DialogTitle sx={{ fontSize: 16, fontWeight: 600, pb: 1 }}>Save Version</DialogTitle>
-        <DialogContent>
+        <DialogTitle sx={{ fontSize: 16, fontWeight: 600, pb: 0.5 }}>Save Version</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {/* Date & time pill */}
+          <Box
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 1.5,
+              px: 1.5,
+              py: 1,
+              mt: 1,
+              borderRadius: '8px',
+              bgcolor: 'action.hover',
+              border: '1px solid',
+              borderColor: 'divider',
+              alignSelf: 'flex-start',
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <CalendarBlank size={13} weight="bold" style={{ opacity: 0.5 }} />
+              <Typography sx={{ fontSize: '0.6875rem', fontWeight: 500, color: 'text.secondary', lineHeight: 1 }}>
+                {format(now, 'MMM d, yyyy')}
+              </Typography>
+            </Box>
+            <Box sx={{ width: '1px', height: 12, bgcolor: 'divider' }} />
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Clock size={13} weight="bold" style={{ opacity: 0.5 }} />
+              <Typography sx={{ fontSize: '0.6875rem', fontWeight: 500, color: 'text.secondary', lineHeight: 1 }}>
+                {format(now, 'h:mm a')}
+              </Typography>
+            </Box>
+          </Box>
+
           <Controller
             name="name"
             control={control}
             render={({ field }) => (
               <TextField
                 {...field}
-                label="Version name"
+                label="Version name (optional)"
                 placeholder="e.g. Baseline v1 — March 31"
                 fullWidth
                 autoFocus
                 size="small"
                 error={!!errors.name}
-                helperText={errors.name?.message}
-                sx={{ mt: 1 }}
+                helperText={errors.name?.message ?? (!nameValue ? 'Date & time will be used as the label' : undefined)}
+              />
+            )}
+          />
+          <Controller
+            name="description"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Description (optional)"
+                placeholder="What changed in this version?"
+                fullWidth
+                multiline
+                minRows={2}
+                maxRows={4}
+                size="small"
+                error={!!errors.description}
+                helperText={errors.description?.message}
               />
             )}
           />

--- a/src/components/bryntum/components/VersionControlBar.tsx
+++ b/src/components/bryntum/components/VersionControlBar.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from 'react';
 import { Box, Typography, Popover, Tooltip } from '@mui/material';
 import { ClockCounterClockwise, FloppyDisk, GitDiff, CheckCircle } from '@phosphor-icons/react';
+import { format } from 'date-fns';
 import { useGanttChangesStore, useGanttChangesListener } from '@/store/ganttChangesStore';
 import { useProjectContext } from '@/components/providers/ProjectProvider';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
@@ -28,8 +29,12 @@ export default function VersionControlBar() {
     { projectId },
     { enabled: !!projectId },
   );
-  // Use context's activeVersionName (set on save/restore) if available, else fall back to latest from query
-  const displayVersionName = activeVersionName ?? versions?.[0]?.name ?? null;
+  // Use context's activeVersionName (set on save/restore) if available, else fall back to latest version
+  const latestVersion = versions?.[0];
+  const latestLabel = latestVersion
+    ? latestVersion.name ?? format(new Date(latestVersion.createdAt), 'MMM d · h:mm a')
+    : null;
+  const displayVersionName = activeVersionName ?? latestLabel;
 
   const handleChangesClick = () => {
     if (hasChanges && changesRef.current) {

--- a/src/components/bryntum/components/VersionHistoryDrawer.tsx
+++ b/src/components/bryntum/components/VersionHistoryDrawer.tsx
@@ -22,11 +22,23 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { formatDistanceToNow } from 'date-fns';
+import { format, formatDistanceToNow } from 'date-fns';
 import { api } from '@/trpc/react';
 import { useSnackbar } from '@/hooks/useSnackbar';
 import { hasPermission } from '@/lib/permissions';
 import type { Role } from '@/lib/permissions';
+import { useGanttChangesStore } from '@/store/ganttChangesStore';
+
+/** Format a date for display as a version label */
+function formatVersionDate(date: Date): string {
+  return format(date, 'MMM d, yyyy · h:mm a');
+}
+
+/** Get the display label for a version (name or formatted date) */
+function getVersionLabel(version: { name: string | null; createdAt: Date | string }): string {
+  if (version.name) return version.name;
+  return formatVersionDate(new Date(version.createdAt));
+}
 
 interface VersionHistoryDrawerProps {
   open: boolean;
@@ -46,8 +58,9 @@ export default function VersionHistoryDrawer({
   const utils = api.useUtils();
   const { showSnackbar } = useSnackbar();
   const canManage = hasPermission(memberRole, 'MANAGE_PROJECTS');
+  const { activeVersionId } = useGanttChangesStore();
 
-  const [confirmAction, setConfirmAction] = useState<{ type: 'restore' | 'delete'; versionId: string; versionName: string } | null>(null);
+  const [confirmAction, setConfirmAction] = useState<{ type: 'restore' | 'delete'; versionId: string; versionLabel: string } | null>(null);
 
   const { data: versions = [], isLoading } = api.schedule.listVersions.useQuery(
     { projectId },
@@ -69,11 +82,12 @@ export default function VersionHistoryDrawer({
     onSuccess: () => {
       void utils.schedule.listVersions.invalidate({ projectId });
       showSnackbar('Version restored', 'success');
-      const restoredName = confirmAction?.versionName ?? '';
+      const restoredLabel = confirmAction?.versionLabel ?? '';
+      const restoredId = confirmAction?.versionId ?? '';
       setConfirmAction(null);
       onOpenChange(false);
-      // Trigger Gantt reload and notify store of restored version name
-      window.dispatchEvent(new CustomEvent('gantt-version-restored', { detail: { name: restoredName } }));
+      // Trigger Gantt reload and notify store of restored version
+      window.dispatchEvent(new CustomEvent('gantt-version-restored', { detail: { name: restoredLabel, id: restoredId } }));
       window.dispatchEvent(new Event('gantt-reload'));
       onRestore?.();
     },
@@ -141,61 +155,126 @@ export default function VersionHistoryDrawer({
             </Box>
           ) : (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-              {versions.map((version) => (
-                <Box
-                  key={version.id}
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1,
-                    px: 1.5,
-                    py: 1.25,
-                    borderRadius: '8px',
-                    '&:hover': { bgcolor: 'action.hover' },
-                  }}
-                >
-                  <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <Typography
-                      sx={{
-                        fontSize: 13,
-                        fontWeight: 500,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {version.name}
-                    </Typography>
-                    <Typography sx={{ fontSize: 11, color: 'text.secondary', mt: 0.25 }}>
-                      {version.createdBy.name ?? version.createdBy.email} · {formatDistanceToNow(new Date(version.createdAt), { addSuffix: true })}
-                    </Typography>
-                  </Box>
+              {versions.map((version, index) => {
+                const label = getVersionLabel(version);
+                // Active = explicitly tracked version, or latest (first) by default
+                const isActive = activeVersionId ? version.id === activeVersionId : index === 0;
+                return (
+                  <Box
+                    key={version.id}
+                    sx={{
+                      position: 'relative',
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      gap: 1,
+                      px: 1.5,
+                      py: 1.25,
+                      borderRadius: '8px',
+                      bgcolor: isActive ? 'action.selected' : 'transparent',
+                      '&:hover': { bgcolor: isActive ? 'action.selected' : 'action.hover' },
+                    }}
+                  >
+                    {/* Active indicator bar */}
+                    {isActive && (
+                      <Box
+                        sx={{
+                          position: 'absolute',
+                          left: 0,
+                          top: '50%',
+                          transform: 'translateY(-50%)',
+                          width: '2.5px',
+                          height: 16,
+                          borderRadius: '0 2px 2px 0',
+                          bgcolor: 'primary.main',
+                        }}
+                      />
+                    )}
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0 }}>
+                        <Typography
+                          sx={{
+                            fontSize: 13,
+                            fontWeight: isActive ? 600 : 500,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            minWidth: 0,
+                          }}
+                        >
+                          {label}
+                        </Typography>
+                        {isActive && (
+                          <Typography
+                            sx={{
+                              fontSize: 9,
+                              fontWeight: 600,
+                              color: 'primary.main',
+                              textTransform: 'uppercase',
+                              letterSpacing: '0.08em',
+                              lineHeight: 1,
+                              flexShrink: 0,
+                              px: 0.75,
+                              py: 0.25,
+                              borderRadius: '4px',
+                              bgcolor: 'rgba(43, 45, 66, 0.08)',
+                            }}
+                          >
+                            Current
+                          </Typography>
+                        )}
+                      </Box>
+                      <Typography sx={{ fontSize: 11, color: 'text.secondary', mt: 0.25, lineHeight: 1.2 }}>
+                        {version.createdBy.name ?? version.createdBy.email} · {formatDistanceToNow(new Date(version.createdAt), { addSuffix: true })}
+                      </Typography>
+                      {/* Always show the full date & time */}
+                      <Typography sx={{ fontSize: 10, color: 'text.disabled', mt: 0.25, lineHeight: 1 }}>
+                        {formatVersionDate(new Date(version.createdAt))}
+                      </Typography>
+                      {version.description && (
+                        <Typography
+                          sx={{
+                            fontSize: 11,
+                            color: 'text.disabled',
+                            mt: 0.5,
+                            lineHeight: 1.3,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            display: '-webkit-box',
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: 'vertical',
+                          }}
+                        >
+                          {version.description}
+                        </Typography>
+                      )}
+                    </Box>
 
-                  {canManage && (
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <IconButton size="small" sx={{ p: 0.5, flexShrink: 0 }}>
-                          <DotsThreeVertical size={16} weight="bold" />
-                        </IconButton>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem
-                          onClick={() => setConfirmAction({ type: 'restore', versionId: version.id, versionName: version.name })}
-                        >
-                          <ClockCounterClockwise size={14} style={{ marginRight: 8 }} />
-                          Restore
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() => setConfirmAction({ type: 'delete', versionId: version.id, versionName: version.name })}
-                        >
-                          <Trash size={14} style={{ marginRight: 8 }} />
-                          Delete
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  )}
-                </Box>
-              ))}
+                    {canManage && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <IconButton size="small" sx={{ p: 0.5, flexShrink: 0, mt: 0.25 }}>
+                            <DotsThreeVertical size={16} weight="bold" />
+                          </IconButton>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={() => setConfirmAction({ type: 'restore', versionId: version.id, versionLabel: label })}
+                          >
+                            <ClockCounterClockwise size={14} style={{ marginRight: 8 }} />
+                            Restore
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => setConfirmAction({ type: 'delete', versionId: version.id, versionLabel: label })}
+                          >
+                            <Trash size={14} style={{ marginRight: 8 }} />
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
+                  </Box>
+                );
+              })}
             </Box>
           )}
         </Box>
@@ -209,8 +288,8 @@ export default function VersionHistoryDrawer({
         <DialogContent>
           <DialogContentText sx={{ fontSize: 13 }}>
             {confirmAction?.type === 'restore'
-              ? `This will replace your current schedule with "${confirmAction.versionName}". This cannot be undone.`
-              : `Are you sure you want to delete "${confirmAction?.versionName}"? This cannot be undone.`}
+              ? `This will replace your current schedule with "${confirmAction.versionLabel}". This cannot be undone.`
+              : `Are you sure you want to delete "${confirmAction?.versionLabel}"? This cannot be undone.`}
           </DialogContentText>
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 2 }}>

--- a/src/lib/validations/schedule.ts
+++ b/src/lib/validations/schedule.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
 export const saveVersionSchema = z.object({
-  name: z.string().min(1, "Version name is required").max(100).trim(),
+  name: z.string().max(100).trim().optional(),
+  description: z.string().max(500).trim().optional(),
 });
 
 export type SaveVersionInput = z.infer<typeof saveVersionSchema>;

--- a/src/server/api/routers/schedule.ts
+++ b/src/server/api/routers/schedule.ts
@@ -65,8 +65,6 @@ export const scheduleRouter = createTRPCRouter({
     .input(saveVersionSchema)
     .mutation(async ({ ctx, input }) => {
       const projectId = ctx.project.id;
-      const { name } = input;
-
       // Check version cap
       const versionCount = await ctx.db.scheduleVersion.count({
         where: { projectId },
@@ -84,13 +82,15 @@ export const scheduleRouter = createTRPCRouter({
       const result = await ctx.db.scheduleVersion.create({
         data: {
           projectId,
-          name,
+          name: input.name || null,
+          description: input.description || null,
           snapshot: snapshot as unknown as Prisma.InputJsonValue,
           createdById: ctx.session.user.id,
         },
         select: {
           id: true,
           name: true,
+          description: true,
           createdAt: true,
         },
       });
@@ -107,6 +107,7 @@ export const scheduleRouter = createTRPCRouter({
         select: {
           id: true,
           name: true,
+          description: true,
           createdAt: true,
           createdBy: {
             select: { id: true, name: true, email: true },
@@ -127,6 +128,7 @@ export const scheduleRouter = createTRPCRouter({
         select: {
           id: true,
           name: true,
+          description: true,
           snapshot: true,
           createdAt: true,
           projectId: true,

--- a/src/store/ganttChangesStore.ts
+++ b/src/store/ganttChangesStore.ts
@@ -21,7 +21,9 @@ interface GanttChangesStore {
   modified: string[];
   removed: string[];
   activeVersionName: string | null;
+  activeVersionId: string | null;
   setActiveVersionName: (name: string | null) => void;
+  setActiveVersionId: (id: string | null) => void;
   handleTaskChange: (type: 'add' | 'remove' | 'update', tasks: TaskEntry[]) => void;
   reset: () => void;
 }
@@ -48,8 +50,10 @@ export const useGanttChangesStore = create<GanttChangesStore>((set) => {
     modified: [],
     removed: [],
     activeVersionName: null,
+    activeVersionId: null,
 
     setActiveVersionName: (name) => set({ activeVersionName: name }),
+    setActiveVersionId: (id) => set({ activeVersionId: id }),
 
     handleTaskChange: (type, tasks) => {
       const added = new Map(internal.added);
@@ -94,7 +98,7 @@ export const useGanttChangesStore = create<GanttChangesStore>((set) => {
  * Call this once in a component that mounts early (e.g., the app layout).
  */
 export function useGanttChangesListener() {
-  const { handleTaskChange, reset, setActiveVersionName } = useGanttChangesStore();
+  const { handleTaskChange, reset, setActiveVersionName, setActiveVersionId } = useGanttChangesStore();
 
   useEffect(() => {
     const onTaskChange = (e: Event) => {
@@ -106,14 +110,16 @@ export function useGanttChangesListener() {
     };
 
     const onVersionSaved = (e: Event) => {
-      const name = (e as CustomEvent<{ name?: string }>).detail?.name;
-      if (name) setActiveVersionName(name);
+      const detail = (e as CustomEvent<{ name?: string; id?: string }>).detail;
+      if (detail?.name) setActiveVersionName(detail.name);
+      if (detail?.id) setActiveVersionId(detail.id);
       reset();
     };
 
     const onVersionRestored = (e: Event) => {
-      const name = (e as CustomEvent<{ name?: string }>).detail?.name;
-      if (name) setActiveVersionName(name);
+      const detail = (e as CustomEvent<{ name?: string; id?: string }>).detail;
+      if (detail?.name) setActiveVersionName(detail.name);
+      if (detail?.id) setActiveVersionId(detail.id);
       reset();
     };
 
@@ -129,5 +135,5 @@ export function useGanttChangesListener() {
       window.removeEventListener('gantt-version-restored', onVersionRestored);
       window.removeEventListener('gantt-reload', onReload);
     };
-  }, [handleTaskChange, reset, setActiveVersionName]);
+  }, [handleTaskChange, reset, setActiveVersionName, setActiveVersionId]);
 }

--- a/src/store/ganttChangesStore.ts
+++ b/src/store/ganttChangesStore.ts
@@ -111,14 +111,14 @@ export function useGanttChangesListener() {
 
     const onVersionSaved = (e: Event) => {
       const detail = (e as CustomEvent<{ name?: string; id?: string }>).detail;
-      if (detail?.name) setActiveVersionName(detail.name);
+      setActiveVersionName(detail?.name ?? null);
       if (detail?.id) setActiveVersionId(detail.id);
       reset();
     };
 
     const onVersionRestored = (e: Event) => {
       const detail = (e as CustomEvent<{ name?: string; id?: string }>).detail;
-      if (detail?.name) setActiveVersionName(detail.name);
+      setActiveVersionName(detail?.name ?? null);
       if (detail?.id) setActiveVersionId(detail.id);
       reset();
     };


### PR DESCRIPTION
## Summary

- Makes the version name optional when saving a Gantt schedule version, falling back to a formatted date/time label
- Adds an optional description field (max 500 chars) to schedule versions
- Updates SaveVersionDialog, VersionControlBar, and VersionHistoryDrawer to display nameless versions with date-based labels, descriptions, and an active version indicator
- Fixes a bug where the version control bar would show a stale name when saving a version without one
- Includes Prisma migration making `ScheduleVersion.name` nullable and adding `description` column