### PR TITLE
Fix logout overlay disappearing during redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@
 
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
-construction_POSTGRES_PRISMA_URL="postgresql://USER@localhost:5432/construction?schema=public"
+construction_POSTGRES_PRISMA_URL="postgresql://USER@localhost:5433/construction?schema=public"
 
 # Better Auth
 # Generate a strong secret with: openssl rand -hex 32

--- a/claudedocs/vercel.md
+++ b/claudedocs/vercel.md
@@ -51,7 +51,7 @@ These must be set correctly per environment via Vercel CLI:
 
 `construction_POSTGRES_PRISMA_URL` and related `construction_POSTGRES_*` vars are managed by the Vercel-Neon integration for preview and production environments. `BLOB_READ_WRITE_TOKEN` and all `POSTGRES_*` / `PG*` vars are also managed by Vercel integrations. Do not overwrite these manually in Vercel.
 
-**Local dev overrides**: The `conductor.json` setup script and manual setup both override `construction_POSTGRES_PRISMA_URL` and `construction_POSTGRES_URL_NON_POOLING` in `.env.local` to point to a local PostgreSQL instance (`postgresql://$USER@localhost:5432/construction`) for faster development.
+**Local dev overrides**: The `conductor.json` setup script and manual setup both override `construction_POSTGRES_PRISMA_URL` and `construction_POSTGRES_URL_NON_POOLING` in `.env.local` to point to a local PostgreSQL instance (`postgresql://$USER@localhost:5433/construction`) for faster development.
 
 ## Database Branching
 

--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "vercel link --project construction-web --scope celn --yes && vercel env pull .env.local --environment development --scope celn --yes && sed -i '' \"s|^construction_POSTGRES_PRISMA_URL=.*|construction_POSTGRES_PRISMA_URL=\\\"postgresql://$USER@localhost:5432/construction\\\"|\" .env.local && sed -i '' \"s|^construction_POSTGRES_URL_NON_POOLING=.*|construction_POSTGRES_URL_NON_POOLING=\\\"postgresql://$USER@localhost:5432/construction\\\"|\" .env.local && sed -i '' 's|\\\\n\"|\"| ' .env.local && (grep -q '^NODE_OPTIONS=' .env.local || echo 'NODE_OPTIONS=\"--max-old-space-size=8192\"' >> .env.local) && npm install",
+    "setup": "vercel link --project construction-web --scope celn --yes && vercel env pull .env.local --environment development --scope celn --yes && sed -i '' \"s|^construction_POSTGRES_PRISMA_URL=.*|construction_POSTGRES_PRISMA_URL=\\\"postgresql://$USER@localhost:5433/construction\\\"|\" .env.local && sed -i '' \"s|^construction_POSTGRES_URL_NON_POOLING=.*|construction_POSTGRES_URL_NON_POOLING=\\\"postgresql://$USER@localhost:5433/construction\\\"|\" .env.local && sed -i '' 's|\\\\n\"|\"| ' .env.local && (grep -q '^NODE_OPTIONS=' .env.local || echo 'NODE_OPTIONS=\"--max-old-space-size=8192\"' >> .env.local) && npm install",
     "run": "npm run dev",
     "archive": "rm -f .env.local && rm -rf .vercel && rm -rf node_modules && rm -rf .next"
   }

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -18,6 +18,7 @@ import OrgSwitcher from './OrgSwitcher';
 import { authClient, signOut } from '@/lib/auth-client';
 import { getInitials } from '@/lib/utils/formatting';
 import LoadingSpinner from '@/components/ui/loading-spinner';
+import { useLoading } from '@/components/providers/LoadingProvider';
 import AccountSettingsModal from './AccountSettingsModal';
 
 const iconMap: Record<string, Icon> = {
@@ -47,6 +48,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
 
   const { data: session } = authClient.useSession();
   const user = session?.user;
+  const { showLoading, hideLoading } = useLoading();
 
   const [profileOpen, setProfileOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
@@ -58,6 +60,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
 
   const handleLogout = async () => {
     setIsLoggingOut(true);
+    showLoading('Logging out...');
     try {
       await signOut({
         fetchOptions: {
@@ -71,6 +74,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
     } catch (error) {
       console.error('Logout failed:', error);
       setIsLoggingOut(false);
+      hideLoading();
     }
   };
 
@@ -435,8 +439,6 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
           </Box>
         </DropdownMenuContent>
       </DropdownMenu>
-
-      {isLoggingOut && <LoadingSpinner size="lg" fullScreen text="Logging out..." />}
 
       <AccountSettingsModal open={settingsOpen} onOpenChange={setSettingsOpen} />
     </Drawer>

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -65,6 +65,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
       await signOut({
         fetchOptions: {
           onSuccess: () => {
+            hideLoading();
             setProfileOpen(false);
             router.push('/sign-in');
             router.refresh();

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -68,6 +68,7 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
       await signOut({
         fetchOptions: {
           onSuccess: () => {
+            hideLoading();
             setProfileOpen(false);
             router.push('/sign-in');
             router.refresh();

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -17,6 +17,7 @@ import OrgSwitcher from './OrgSwitcher';
 import { authClient, signOut } from '@/lib/auth-client';
 import { getInitials } from '@/lib/utils/formatting';
 import LoadingSpinner from '@/components/ui/loading-spinner';
+import { useLoading } from '@/components/providers/LoadingProvider';
 import AccountSettingsModal from './AccountSettingsModal';
 
 const SIDEBAR_WIDTH = 240;
@@ -49,6 +50,7 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
 
   const { data: session } = authClient.useSession();
   const user = session?.user;
+  const { showLoading, hideLoading } = useLoading();
 
   const [profileOpen, setProfileOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
@@ -61,6 +63,7 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
 
   const handleLogout = async () => {
     setIsLoggingOut(true);
+    showLoading('Logging out...');
     try {
       await signOut({
         fetchOptions: {
@@ -74,6 +77,7 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
     } catch (error) {
       console.error('Logout failed:', error);
       setIsLoggingOut(false);
+      hideLoading();
     }
   };
 
@@ -540,8 +544,6 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
           </Box>
         </DropdownMenuContent>
       </DropdownMenu>
-
-      {isLoggingOut && <LoadingSpinner size="lg" fullScreen text="Logging out..." />}
 
       <AccountSettingsModal open={settingsOpen} onOpenChange={setSettingsOpen} />
     </Box>

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -7,6 +7,7 @@ import { Box, Menu, MenuItem, Typography, Divider, Avatar } from '@mui/material'
 import { ImageWithFallback } from '@/components/ui/image-with-fallback';
 import { signOut, useSession } from '@/lib/auth-client';
 import LoadingSpinner from '@/components/ui/loading-spinner';
+import { useLoading } from '@/components/providers/LoadingProvider';
 
 export default function UserMenu() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -14,6 +15,7 @@ export default function UserMenu() {
   const open = Boolean(anchorEl);
   const router = useRouter();
   const { data: session } = useSession();
+  const { showLoading, hideLoading } = useLoading();
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -25,6 +27,7 @@ export default function UserMenu() {
 
   const handleLogout = async () => {
     setIsLoggingOut(true);
+    showLoading('Logging out...');
     try {
       await signOut({
         fetchOptions: {
@@ -38,6 +41,7 @@ export default function UserMenu() {
     } catch (error) {
       console.error('Logout failed:', error);
       setIsLoggingOut(false);
+      hideLoading();
     }
   };
 
@@ -136,10 +140,6 @@ export default function UserMenu() {
         </MenuItem>
       </Menu>
 
-      {/* Full-screen loading overlay during logout */}
-      {isLoggingOut && (
-        <LoadingSpinner size="lg" fullScreen text="Logging out..." />
-      )}
     </>
   );
 }

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -32,6 +32,7 @@ export default function UserMenu() {
       await signOut({
         fetchOptions: {
           onSuccess: () => {
+            hideLoading();
             handleClose();
             router.push('/sign-in');
             router.refresh();


### PR DESCRIPTION
## Summary
- Replace component-local full-screen spinners with the global `LoadingProvider` overlay for logout in Sidebar, MobileDrawer, and UserMenu. This prevents the overlay from disappearing when components unmount during navigation.
- Update local dev Postgres port from 5432 to 5433 in `.env.example`, `claudedocs/vercel.md`, and `conductor.json` to match the documented convention (port 5432 is reserved for OrbStack).