### PR TITLE
Redesign CSI selector as slide-in panel and improve task popover UX

### DIFF
--- a/claudedocs/components-guide.md
+++ b/claudedocs/components-guide.md
@@ -245,6 +245,7 @@ bryntum/
       TrackableFolderContent.tsx
       RequirementCounter.tsx
       FilePreviewPanel.tsx
+      CsiCodePanel.tsx
   hooks/
     useTaskPopover.ts
     useBryntumThemeAssets.ts

--- a/claudedocs/csi-codes.md
+++ b/claudedocs/csi-codes.md
@@ -43,15 +43,17 @@ The final JSON was validated against the AGC Austin PDF (official MasterFormat 2
 |------|---------|
 | `src/lib/constants/csiCodes.json` | Raw data: `[{ code, name, subdivisions: [{ code, name }] }]` |
 | `src/lib/constants/csiCodes.ts` | TypeScript layer: exports `CSI_MASTERFORMAT`, `CSI_DIVISIONS`, `CSI_DIVISION_MAP`, `CSI_SUBDIVISION_MAP`, `formatCsiCode()` |
-| `src/components/bryntum/components/CsiCodeSelector.tsx` | React UI: accordion menu with search, optimistic updates |
+| `src/components/bryntum/components/CsiCodeSelector.tsx` | Display-only trigger button showing current CSI code; calls `onOpen` to open the panel |
+| `src/components/bryntum/components/task-popover/CsiCodePanel.tsx` | Slide-in panel: accordion menu with search, optimistic updates, code selection |
 | `src/server/api/routers/gantt.ts` | tRPC mutation `updateCsiCode` with Zod `.refine()` validation |
 
 ### Data flow
 
 1. **Static JSON** loaded at module init, TypeScript builds O(1) lookup Maps
-2. **UI**: `CsiCodeSelector` reads from `CSI_MASTERFORMAT`, filters client-side, shows accordion by division
-3. **Save**: User selects code -> optimistic update -> `gantt.updateCsiCode` mutation -> validates code exists in `CSI_SUBDIVISION_MAP` or `CSI_DIVISION_MAP` -> saves string to `GanttTask.csiCode`
-4. **Display**: `formatCsiCode(code)` resolves `"03 30 00"` -> `"03 30 00 - Cast-in-Place Concrete"`
+2. **Trigger**: `CsiCodeSelector` displays the current code and opens the `CsiCodePanel` slide-in panel
+3. **Selection**: `CsiCodePanel` reads from `CSI_MASTERFORMAT`, filters client-side, shows accordion by division
+4. **Save**: User selects code -> optimistic update -> `gantt.updateCsiCode` mutation -> validates code exists in `CSI_SUBDIVISION_MAP` or `CSI_DIVISION_MAP` -> saves string to `GanttTask.csiCode`
+5. **Display**: `formatCsiCode(code)` resolves `"03 30 00"` -> `"03 30 00 - Cast-in-Place Concrete"`
 
 ### Why static JSON (not database)
 
@@ -68,10 +70,10 @@ Move to a database table only if: tenants need custom code lists, you need usage
 | Optimization | Where | What it prevents |
 |------|-------|-----------------|
 | **Pre-lowercased names** | `csiCodes.ts` — `nameLower` field on divisions and subdivisions | 1,482 `.toLowerCase()` string allocations per keystroke during search |
-| **`useMemo` filtering** | `CsiCodeSelector.tsx` — `displayDivisions` keyed on `query` | Full `.map()` + `.filter()` recomputation on unrelated state changes (expand toggle, anchor, optimistic code) |
-| **`React.memo` SubdivisionItem** | `CsiCodeSelector.tsx` — extracted memoized component | Re-rendering every visible MenuItem when only one item's `isSelected` changes |
-| **Stable `useCallback`** | `CsiCodeSelector.tsx` — `handleSelectSubdivision` | New closure per subdivision per render (breaks `React.memo`) |
-| **Search result cap (15/div)** | `CsiCodeSelector.tsx` — `displayDivisions` slice | Rendering 500+ MUI MenuItems during broad searches |
+| **`useMemo` filtering** | `CsiCodePanel.tsx` — `displayDivisions` keyed on `query` | Full `.map()` + `.filter()` recomputation on unrelated state changes (expand toggle, optimistic code) |
+| **`React.memo` SubdivisionItem** | `CsiCodePanel.tsx` — extracted memoized component | Re-rendering every visible MenuItem when only one item's `isSelected` changes |
+| **Stable `useCallback`** | `CsiCodePanel.tsx` — `handleSelectSubdivision` | New closure per subdivision per render (breaks `React.memo`) |
+| **Search result cap (15/div)** | `CsiCodePanel.tsx` — `displayDivisions` slice | Rendering 500+ MUI MenuItems during broad searches |
 | **O(1) lookup Maps** | `csiCodes.ts` — `CSI_DIVISION_MAP`, `CSI_SUBDIVISION_MAP` | Linear scans for code display and validation |
 
 **Not needed at this scale** (1,482 items): debouncing (filtering is sub-ms), virtualization (accordion caps visible items), Web Workers (serialization overhead exceeds compute), dynamic imports (15KB gzipped is noise).

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -450,6 +450,22 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const onCellClick = ({ record, column, event }: { record: any; column: { type: string }; event: MouseEvent }) => {
       const target = event.target as HTMLElement;
+
+      // Scroll-to-task button — centers the timeline on the task's start date.
+      // NOTE: scrollTaskIntoView corrupts the time axis header virtual renderer,
+      // so we use the timeAxis subgrid's scrollable to scroll horizontally instead.
+      const scrollBtn = target.closest('.gantt-row-scroll-btn') as HTMLElement | null;
+      if (scrollBtn && column.type === 'name') {
+        event.stopPropagation();
+        const taskRecord = record as BryntumTaskRecord;
+        const startDate = taskRecord.startDate as Date | undefined;
+        if (startDate) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
+          (gantt as any).scrollToDate(startDate, { block: 'center', animate: 300 });
+        }
+        return;
+      }
+
       const btn = target.closest('.gantt-row-actions-btn') as HTMLElement | null;
       if (!btn || column.type !== 'name') return;
 
@@ -586,6 +602,24 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         }
         .gantt-row-actions-btn:hover {
           background: rgba(0, 0, 0, 0.04);
+        }
+        /* Scroll-to-task button — left of the ⋮ button, uses FA crosshairs icon */
+        .gantt-row-scroll-btn {
+          flex-shrink: 0;
+          background: none;
+          border: none;
+          box-shadow: none;
+          min-width: 0;
+          padding: 4px 4px;
+          cursor: pointer;
+          border-radius: 4px;
+          color: var(--text-secondary, #8D99AE);
+          font-size: 13px;
+          line-height: 1;
+        }
+        .gantt-row-scroll-btn:hover {
+          background: rgba(0, 0, 0, 0.04);
+          color: var(--text-primary, #2B2D42);
         }
         /* Row actions dropdown menu — clean card style */
         .b-menu:has(.gantt-action-danger) {

--- a/src/components/bryntum/components/CsiCodeSelector.tsx
+++ b/src/components/bryntum/components/CsiCodeSelector.tsx
@@ -1,374 +1,122 @@
 'use client';
 
-import { useState, useEffect, useMemo, memo, useCallback } from 'react';
-import { Tag, CaretDown, CaretRight, Plus, MagnifyingGlass } from '@phosphor-icons/react';
-import { Box, Typography, Menu, MenuItem, TextField, InputAdornment } from '@mui/material';
-import { api } from '@/trpc/react';
-import { useSnackbar } from '@/hooks/useSnackbar';
-import {
-  formatCsiCode,
-  CSI_MASTERFORMAT,
-  CSI_SUBDIVISION_MAP,
-  type CsiSubdivision,
-} from '@/lib/constants/csiCodes';
-
-interface SubdivisionItemProps {
-  sub: CsiSubdivision;
-  isSelected: boolean;
-  onSelect: (code: string) => void;
-}
-
-const SubdivisionItem = memo(function SubdivisionItem({
-  sub,
-  isSelected,
-  onSelect,
-}: SubdivisionItemProps) {
-  return (
-    <MenuItem
-      selected={isSelected}
-      onClick={() => onSelect(sub.code)}
-      sx={{
-        fontSize: 12,
-        gap: 0.75,
-        pl: 4.5,
-        py: 0.5,
-      }}
-    >
-      <Typography
-        component="span"
-        sx={{
-          fontSize: 12,
-          fontWeight: 600,
-          color: 'text.secondary',
-          minWidth: 56,
-          flexShrink: 0,
-        }}
-      >
-        {sub.code}
-      </Typography>
-      <Typography
-        component="span"
-        sx={{
-          fontSize: 12,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {sub.name}
-      </Typography>
-    </MenuItem>
-  );
-});
+import { Tag, CaretRight } from '@phosphor-icons/react';
+import { Box, Typography } from '@mui/material';
+import { CSI_SUBDIVISION_MAP } from '@/lib/constants/csiCodes';
 
 interface CsiCodeSelectorProps {
   csiCode: string | null | undefined;
-  organizationId: string;
-  projectId: string;
-  taskId: string;
+  onOpen: () => void;
 }
 
-export default function CsiCodeSelector({
-  csiCode,
-  organizationId,
-  projectId,
-  taskId,
-}: CsiCodeSelectorProps) {
-  const { showSnackbar } = useSnackbar();
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  const [search, setSearch] = useState('');
-  const [expandedDivision, setExpandedDivision] = useState<string | null>(null);
-  const [optimisticCode, setOptimisticCode] = useState<string | null | undefined>(undefined);
-
-  const utils = api.useUtils();
-
-  const updateCsiCode = api.gantt.updateCsiCode.useMutation({
-    onSuccess: () => {
-      void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId });
-    },
-    onError: (error) => {
-      setOptimisticCode(undefined);
-      showSnackbar(error.message || 'Failed to update CSI code', 'error');
-    },
-  });
-
-  // Clear optimistic value once the server prop catches up
-  useEffect(() => {
-    if (optimisticCode !== undefined && csiCode === optimisticCode) {
-      setOptimisticCode(undefined);
-    }
-  }, [csiCode, optimisticCode]);
-
-  // Use optimistic value while mutation is in flight, otherwise use server value
-  const displayCode = optimisticCode !== undefined ? optimisticCode : csiCode;
-
-  // Auto-expand parent division when menu opens with an existing code
-  useEffect(() => {
-    if (anchorEl && displayCode) {
-      const subEntry = CSI_SUBDIVISION_MAP.get(displayCode);
-      if (subEntry) {
-        setExpandedDivision(subEntry.division.code);
-      }
-    }
-  }, [anchorEl, displayCode]);
-
-  const query = search.toLowerCase();
-  const isSearching = query.length > 0;
-
-  // Memoize filtering to avoid recomputing when unrelated state changes (expandedDivision, anchorEl, etc.)
-  const displayDivisions = useMemo(() => {
-    const filtered = CSI_MASTERFORMAT.map((div) => {
-      const divMatches =
-        !query || div.code.includes(query) || div.nameLower.includes(query);
-      const matchingSubs = div.subdivisions.filter(
-        (sub) =>
-          !query || sub.code.includes(query) || sub.nameLower.includes(query),
-      );
-
-      if (!query) return { div, matchingSubs: div.subdivisions, show: true };
-      if (divMatches) return { div, matchingSubs: div.subdivisions, show: true };
-      if (matchingSubs.length > 0) return { div, matchingSubs, show: true };
-      return { div, matchingSubs: [], show: false };
-    }).filter((entry) => entry.show);
-
-    // Cap visible subdivisions per division during search to prevent rendering hundreds of MenuItems
-    return isSearching
-      ? filtered.map((entry) => ({
-          ...entry,
-          matchingSubs: entry.matchingSubs.slice(0, 15),
-        }))
-      : filtered;
-  }, [query, isSearching]);
-  const handleSelectSubdivision = useCallback(
-    (code: string) => {
-      setOptimisticCode(code);
-      updateCsiCode.mutate({
-        organizationId,
-        projectId,
-        taskId,
-        csiCode: code,
-      });
-      setAnchorEl(null);
-    },
-    [organizationId, projectId, taskId, updateCsiCode],
-  );
-
-  const hasCode = !!displayCode;
+export default function CsiCodeSelector({ csiCode, onOpen }: CsiCodeSelectorProps) {
+  const hasCode = !!csiCode;
+  const subEntry = hasCode ? CSI_SUBDIVISION_MAP.get(csiCode!) : null;
+  const divisionName = subEntry ? subEntry.division.name : null;
+  const subdivisionName = subEntry ? subEntry.subdivision.name : null;
 
   return (
-    <>
-      <Box
-        component="button"
-        onClick={(e) => {
-          setAnchorEl(e.currentTarget as HTMLElement);
-          setSearch('');
-          if (!displayCode) setExpandedDivision(null);
-        }}
-        sx={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          alignSelf: 'flex-start',
-          gap: '5px',
-          borderWidth: '1px',
-          borderStyle: hasCode ? 'solid' : 'dashed',
-          borderColor: hasCode ? 'divider' : 'text.disabled',
-          borderRadius: '6px',
-          bgcolor: 'transparent',
-          cursor: 'pointer',
-          px: 1,
-          py: '3px',
-          maxWidth: '100%',
-          transition: 'background-color 0.15s, border-color 0.15s, opacity 0.15s',
-          '&:hover': {
-            bgcolor: 'action.hover',
-            borderColor: hasCode ? 'text.disabled' : 'text.secondary',
-            borderStyle: 'solid',
-          },
-        }}
-      >
-        <Tag
-          size={12}
-          color={hasCode ? 'var(--mui-palette-text-secondary)' : 'var(--mui-palette-text-disabled)'}
-          style={{ flexShrink: 0 }}
-        />
-        {hasCode ? (
-          <Typography
-            sx={{
-              fontSize: '0.6875rem',
-              fontWeight: 600,
-              color: 'text.primary',
-              lineHeight: 1,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {formatCsiCode(displayCode!)}
-          </Typography>
-        ) : (
-          <Typography
-            sx={{
-              fontSize: '0.6875rem',
-              fontWeight: 500,
-              color: 'text.disabled',
-              lineHeight: 1,
-            }}
-          >
-            CSI Code
-          </Typography>
-        )}
-        {hasCode ? (
-          <CaretDown
-            size={10}
-            color="var(--mui-palette-text-disabled)"
-            style={{ flexShrink: 0 }}
-          />
-        ) : (
-          <Plus
-            size={10}
-            color="var(--mui-palette-text-disabled)"
-            style={{ flexShrink: 0 }}
-          />
-        )}
-      </Box>
-
-      <Menu
-        anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
-        onClose={() => setAnchorEl(null)}
-        slotProps={{
-          paper: {
-            sx: {
-              maxHeight: 380,
-              width: 380,
-              borderRadius: '12px',
-              mt: 0.5,
-            },
-          },
-        }}
-      >
-        <Box sx={{ px: 1.5, py: 1, position: 'sticky', top: 0, bgcolor: 'background.paper', zIndex: 1 }}>
-          <TextField
-            size="small"
-            placeholder="Search CSI codes…"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            autoFocus
-            fullWidth
-            slotProps={{
-              input: {
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <MagnifyingGlass size={14} />
-                  </InputAdornment>
-                ),
-                sx: { fontSize: 13 },
-              },
-            }}
-            onKeyDown={(e) => e.stopPropagation()}
-          />
-        </Box>
-
-        {hasCode && (
-          <MenuItem
-            onClick={() => {
-              setOptimisticCode(null);
-              updateCsiCode.mutate({
-                organizationId,
-                projectId,
-                taskId,
-                csiCode: null,
-              });
-              setAnchorEl(null);
-            }}
-            sx={{
-              fontSize: 12,
-              color: 'error.main',
-              fontStyle: 'italic',
-            }}
-          >
-            Remove CSI Code
-          </MenuItem>
-        )}
-
-        {displayDivisions.map(({ div, matchingSubs }) => {
-          const isExpanded = isSearching || expandedDivision === div.code;
-
-          return (
-            <Box key={div.code}>
-              {/* Division header — non-selectable, toggles expand */}
-              <MenuItem
-                onClick={() => {
-                  if (isSearching) return;
-                  setExpandedDivision(expandedDivision === div.code ? null : div.code);
-                }}
+    <Box
+      component="button"
+      onClick={onOpen}
+      sx={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 1,
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: '8px',
+        bgcolor: hasCode ? 'action.selected' : 'transparent',
+        cursor: 'pointer',
+        px: 1.25,
+        py: hasCode ? '8px' : '5px',
+        width: '100%',
+        textAlign: 'left',
+        transition: 'background-color 0.15s, border-color 0.15s',
+        '&:hover': {
+          bgcolor: 'action.hover',
+          borderColor: 'text.disabled',
+        },
+      }}
+    >
+      <Tag
+        size={14}
+        weight={hasCode ? 'fill' : 'regular'}
+        color={hasCode ? 'var(--mui-palette-text-secondary)' : 'var(--mui-palette-text-disabled)'}
+        style={{ flexShrink: 0, marginTop: hasCode ? 1 : 0 }}
+      />
+      {hasCode ? (
+        <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: '2px' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+            <Typography
+              component="span"
+              sx={{
+                fontSize: '0.6875rem',
+                fontWeight: 700,
+                color: 'text.primary',
+                lineHeight: 1,
+                fontVariantNumeric: 'tabular-nums',
+                letterSpacing: '0.02em',
+                flexShrink: 0,
+              }}
+            >
+              {csiCode}
+            </Typography>
+            {divisionName && (
+              <Typography
+                component="span"
                 sx={{
-                  fontSize: 12,
-                  fontWeight: 600,
-                  color: 'text.secondary',
-                  gap: 0.75,
-                  py: 0.75,
-                  cursor: isSearching ? 'default' : 'pointer',
-                  '&:hover': {
-                    bgcolor: isSearching ? 'transparent' : 'action.hover',
-                  },
+                  fontSize: '0.5625rem',
+                  fontWeight: 500,
+                  color: 'text.disabled',
+                  lineHeight: 1,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.06em',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  minWidth: 0,
                 }}
               >
-                {isSearching ? (
-                  <CaretDown
-                    size={12}
-                    color="var(--mui-palette-text-disabled)"
-                    style={{ flexShrink: 0 }}
-                  />
-                ) : isExpanded ? (
-                  <CaretDown
-                    size={12}
-                    color="var(--mui-palette-text-disabled)"
-                    style={{ flexShrink: 0 }}
-                  />
-                ) : (
-                  <CaretRight
-                    size={12}
-                    color="var(--mui-palette-text-disabled)"
-                    style={{ flexShrink: 0 }}
-                  />
-                )}
-                <Typography
-                  component="span"
-                  sx={{
-                    fontSize: 12,
-                    fontWeight: 700,
-                    color: 'text.secondary',
-                    minWidth: 20,
-                  }}
-                >
-                  {div.code}
-                </Typography>
-                {div.name}
-              </MenuItem>
-
-              {/* Subdivision items — only when expanded or searching */}
-              {isExpanded &&
-                matchingSubs.map((sub) => (
-                  <SubdivisionItem
-                    key={sub.code}
-                    sub={sub}
-                    isSelected={displayCode === sub.code}
-                    onSelect={handleSelectSubdivision}
-                  />
-                ))}
-            </Box>
-          );
-        })}
-
-        {displayDivisions.length === 0 && (
-          <Box sx={{ px: 2, py: 1.5 }}>
-            <Typography sx={{ fontSize: 12, color: 'text.disabled' }}>
-              No CSI codes match &ldquo;{search}&rdquo;
-            </Typography>
+                {divisionName}
+              </Typography>
+            )}
           </Box>
-        )}
-      </Menu>
-    </>
+          {subdivisionName && (
+            <Typography
+              sx={{
+                fontSize: '0.75rem',
+                fontWeight: 500,
+                color: 'text.secondary',
+                lineHeight: 1.2,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                minWidth: 0,
+              }}
+            >
+              {subdivisionName}
+            </Typography>
+          )}
+        </Box>
+      ) : (
+        <Typography
+          sx={{
+            fontSize: '0.75rem',
+            fontWeight: 500,
+            color: 'text.disabled',
+            lineHeight: 1,
+            flex: 1,
+          }}
+        >
+          CSI Code
+        </Typography>
+      )}
+      <CaretRight
+        size={11}
+        color="var(--mui-palette-text-disabled)"
+        style={{ flexShrink: 0, marginTop: hasCode ? 2 : 0 }}
+      />
+    </Box>
   );
 }

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -5,7 +5,7 @@ import { useDrag } from '@use-gesture/react';
 import { Box, Popover, Typography, Divider } from '@mui/material';
 
 import { POPOVER_WIDTH, POPOVER_EXPANDED_WIDTH } from '../constants';
-import { folderData, expandFolderIds } from '@/lib/folders';
+import { folderData, expandFolderIds, type Folder } from '@/lib/folders';
 import { useProjectContext } from '@/components/providers/ProjectProvider';
 import { useOrgContext } from '@/components/providers/OrgProvider';
 import UploadDialog from '@/components/documents/UploadDialog';
@@ -18,6 +18,9 @@ import TaskHeader from './task-popover/TaskHeader';
 import CoverImageBanner from './task-popover/CoverImageBanner';
 import FolderRow from './task-popover/FolderRow';
 import FilePreviewPanel from './task-popover/FilePreviewPanel';
+import CsiCodePanel from './task-popover/CsiCodePanel';
+
+type RightPanel = { type: 'preview'; doc: PreviewDoc } | { type: 'csi' } | null;
 
 type TaskDetailsPopoverProps = {
   open: boolean;
@@ -40,7 +43,7 @@ export function TaskDetailsPopover({
 
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
   const [uploadFolder, setUploadFolder] = useState<{ id: string; name: string } | null>(null);
-  const [previewDoc, setPreviewDoc] = useState<PreviewDoc | null>(null);
+  const [rightPanel, setRightPanel] = useState<RightPanel>(null);
 
   // ── Drag state ──
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
@@ -101,6 +104,19 @@ export function TaskDetailsPopover({
     [taskId, organizationId, projectId, updateRequirementMutation]
   );
 
+  // ── Right panel helpers ──
+  const openCsiPanel = useCallback(() => {
+    setRightPanel({ type: 'csi' });
+  }, []);
+
+  const openPreview = useCallback((doc: PreviewDoc) => {
+    setRightPanel({ type: 'preview', doc });
+  }, []);
+
+  const closeRightPanel = useCallback(() => {
+    setRightPanel(null);
+  }, []);
+
   // ── Callbacks ──
   const toggleFolder = useCallback((folderId: string) => {
     setExpandedFolders((prev) => {
@@ -128,11 +144,24 @@ export function TaskDetailsPopover({
 
   const handleClose = () => {
     setExpandedFolders(new Set());
-    setPreviewDoc(null);
+    setRightPanel(null);
     onClose();
   };
 
+  // Compute current upload counts for trackable folders (submittals & inspections)
+  const getTrackableCount = (folder: Folder) => {
+    const allIds = expandFolderIds(folder.id);
+    return allIds.reduce((sum, id) => sum + (counts?.[id] ?? 0), 0);
+  };
+  const submittalsFolder = folderData.find((f) => f.id === 'submittals');
+  const inspectionsFolder = folderData.find((f) => f.id === 'inspections');
+  const submittalsCurrent = submittalsFolder ? getTrackableCount(submittalsFolder) : 0;
+  const inspectionsCurrent = inspectionsFolder ? getTrackableCount(inspectionsFolder) : 0;
+
   const coverImageUrl = taskDetail?.coverImageUrl ?? null;
+  const hasRightPanel = rightPanel !== null;
+  const previewDoc = rightPanel?.type === 'preview' ? rightPanel.doc : null;
+  const selectedDocId = previewDoc?.id ?? null;
 
   return (
     <>
@@ -154,7 +183,7 @@ export function TaskDetailsPopover({
               borderColor: 'divider',
               boxShadow: '0 24px 64px -12px rgba(0,0,0,0.12), 0 8px 20px -8px rgba(0,0,0,0.04)',
               maxHeight: '85vh',
-              width: previewDoc ? POPOVER_EXPANDED_WIDTH : POPOVER_WIDTH,
+              width: hasRightPanel ? POPOVER_EXPANDED_WIDTH : POPOVER_WIDTH,
               transition: isDragging ? 'none' : 'width 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
               marginLeft: `${dragOffset.x}px`,
               marginTop: `${dragOffset.y}px`,
@@ -195,12 +224,12 @@ export function TaskDetailsPopover({
 
             <TaskHeader
               taskName={taskName}
-              taskId={taskId}
-              organizationId={organizationId}
-              projectId={projectId}
               taskDetail={taskDetail}
               taskDetailLoading={taskDetailLoading}
               onClose={handleClose}
+              onOpenCsiPanel={openCsiPanel}
+              submittalsCurrent={submittalsCurrent}
+              inspectionsCurrent={inspectionsCurrent}
             />
 
             <CoverImageBanner
@@ -213,7 +242,7 @@ export function TaskDetailsPopover({
             <Divider sx={{ mx: 2 }} />
 
             {/* ── DOCUMENTS SECTION ── */}
-            <Box sx={{ p: '12px 16px 14px 16px', display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Box sx={{ p: '14px 16px 16px', display: 'flex', flexDirection: 'column', gap: 1 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <Typography
                   sx={{
@@ -282,7 +311,7 @@ export function TaskDetailsPopover({
                 </Box>
               </Box>
 
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
                 {folderData.map((folder) => {
                   const count = counts?.[folder.id] ?? 0;
                   const folderDocs = ((allDocs ?? []) as DocumentItem[]).filter(
@@ -307,8 +336,8 @@ export function TaskDetailsPopover({
                       count={count}
                       docs={folderDocs}
                       onUpload={setUploadFolder}
-                      onSelectDoc={setPreviewDoc}
-                      selectedDocId={previewDoc?.id ?? null}
+                      onSelectDoc={openPreview}
+                      selectedDocId={selectedDocId}
                       // Tracking props
                       required={trackingRequired}
                       current={trackingCurrent}
@@ -326,11 +355,21 @@ export function TaskDetailsPopover({
             </Box>
           </Box>
 
-          {/* ── RIGHT PREVIEW PANEL ── */}
-          {previewDoc && (
+          {/* ── RIGHT PANEL ── */}
+          {rightPanel && (
             <>
               <Divider orientation="vertical" flexItem />
-              <FilePreviewPanel previewDoc={previewDoc} />
+              {rightPanel.type === 'preview' ? (
+                <FilePreviewPanel previewDoc={rightPanel.doc} />
+              ) : (
+                <CsiCodePanel
+                  csiCode={taskDetail?.csiCode}
+                  organizationId={organizationId}
+                  projectId={projectId}
+                  taskId={taskId!}
+                  onClose={closeRightPanel}
+                />
+              )}
             </>
           )}
         </Box>

--- a/src/components/bryntum/components/task-popover/BaseFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/BaseFolderContent.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { Box, Typography } from '@mui/material';
-import { FileText, Plus } from '@phosphor-icons/react';
+import { FileText, CloudArrowUp } from '@phosphor-icons/react';
 import type { FolderContentProps, PreviewDoc } from './types';
 
 function BaseFolderContentInner({
@@ -20,26 +20,47 @@ function BaseFolderContentInner({
           ml: '36px',
           mr: 0.75,
           my: 0.75,
-          py: 1.5,
+          py: 2.5,
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
-          gap: 0.5,
+          gap: 1,
           border: '1.5px dashed',
           borderColor: 'divider',
-          borderRadius: '8px',
+          borderRadius: '10px',
+          bgcolor: 'rgba(0,0,0,0.015)',
           cursor: 'pointer',
-          transition: 'border-color 0.15s, background-color 0.15s',
+          transition: 'border-color 0.2s, background-color 0.2s',
           '&:hover': {
             borderColor: 'primary.main',
-            bgcolor: 'rgba(0,0,0,0.02)',
+            bgcolor: 'rgba(43, 45, 66, 0.05)',
+            '& .dropzone-icon': {
+              transform: 'translateY(-2px)',
+              bgcolor: 'rgba(43, 45, 66, 0.12)',
+            },
           },
         }}
       >
-        <Plus size={16} color="var(--mui-palette-text-disabled)" />
-        <Typography sx={{ fontSize: 11, color: 'text.disabled' }}>
-          Drop files or click to upload
-        </Typography>
+        <Box
+          className="dropzone-icon"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 36,
+            height: 36,
+            borderRadius: '50%',
+            bgcolor: 'rgba(0,0,0,0.06)',
+            transition: 'transform 0.2s, background-color 0.2s',
+          }}
+        >
+          <CloudArrowUp size={20} weight="bold" color="var(--mui-palette-text-secondary)" />
+        </Box>
+        <Box sx={{ textAlign: 'center' }}>
+          <Typography sx={{ fontSize: 11, fontWeight: 500, color: 'text.secondary', lineHeight: 1.2 }}>
+            Drop files or click to upload
+          </Typography>
+        </Box>
       </Box>
     );
   }
@@ -102,7 +123,6 @@ function BaseFolderContentInner({
                   fontSize: 11,
                   color: 'text.secondary',
                   flexShrink: 0,
-                  opacity: 0.7,
                 }}
               >
                 {new Date(doc.createdAt).toLocaleDateString(

--- a/src/components/bryntum/components/task-popover/CsiCodePanel.tsx
+++ b/src/components/bryntum/components/task-popover/CsiCodePanel.tsx
@@ -1,0 +1,547 @@
+'use client';
+
+import { useState, useEffect, useMemo, memo, useCallback } from 'react';
+import {
+  Tag,
+  CaretDown,
+  CaretRight,
+  MagnifyingGlass,
+  Check,
+  X,
+  Prohibit,
+} from '@phosphor-icons/react';
+import { Box, Typography, IconButton, InputBase, Divider } from '@mui/material';
+import { api } from '@/trpc/react';
+import { useSnackbar } from '@/hooks/useSnackbar';
+import {
+  CSI_MASTERFORMAT,
+  CSI_SUBDIVISION_MAP,
+  type CsiSubdivision,
+} from '@/lib/constants/csiCodes';
+
+// ─── Subdivision row ────────────────────────────────────────────────
+interface SubdivisionItemProps {
+  sub: CsiSubdivision;
+  isSelected: boolean;
+  onSelect: (code: string) => void;
+}
+
+const SubdivisionItem = memo(function SubdivisionItem({
+  sub,
+  isSelected,
+  onSelect,
+}: SubdivisionItemProps) {
+  return (
+    <Box
+      component="div"
+      role="option"
+      aria-selected={isSelected}
+      tabIndex={0}
+      onClick={() => onSelect(sub.code)}
+      onKeyDown={(e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect(sub.code);
+        }
+      }}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.75,
+        pl: 4.5,
+        pr: 2,
+        py: '6px',
+        cursor: 'pointer',
+        position: 'relative',
+        transition: 'background-color 0.1s',
+        bgcolor: isSelected ? 'action.selected' : 'transparent',
+        '&:hover': {
+          bgcolor: isSelected ? 'action.selected' : 'action.hover',
+        },
+        '&::before': isSelected
+          ? {
+              content: '""',
+              position: 'absolute',
+              left: 0,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              width: '2.5px',
+              height: 16,
+              borderRadius: '0 2px 2px 0',
+              bgcolor: 'sidebar.indicator',
+            }
+          : undefined,
+      }}
+    >
+      <Typography
+        component="span"
+        sx={{
+          fontSize: '0.6875rem',
+          fontWeight: 500,
+          color: isSelected ? 'text.primary' : 'text.secondary',
+          minWidth: 52,
+          flexShrink: 0,
+          fontVariantNumeric: 'tabular-nums',
+          letterSpacing: '0.02em',
+        }}
+      >
+        {sub.code}
+      </Typography>
+      <Typography
+        component="span"
+        sx={{
+          fontSize: '0.75rem',
+          fontWeight: isSelected ? 550 : 400,
+          color: isSelected ? 'text.primary' : 'text.secondary',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          flex: 1,
+          minWidth: 0,
+        }}
+      >
+        {sub.name}
+      </Typography>
+      {isSelected && (
+        <Check
+          size={12}
+          weight="bold"
+          color="var(--mui-palette-sidebar-indicator)"
+          style={{ flexShrink: 0 }}
+        />
+      )}
+    </Box>
+  );
+});
+
+// ─── Main panel ─────────────────────────────────────────────────────
+interface CsiCodePanelProps {
+  csiCode: string | null | undefined;
+  organizationId: string;
+  projectId: string;
+  taskId: string;
+  onClose: () => void;
+}
+
+export default function CsiCodePanel({
+  csiCode,
+  organizationId,
+  projectId,
+  taskId,
+  onClose,
+}: CsiCodePanelProps) {
+  const { showSnackbar } = useSnackbar();
+  const [search, setSearch] = useState('');
+  const [expandedDivision, setExpandedDivision] = useState<string | null>(null);
+  const [optimisticCode, setOptimisticCode] = useState<string | null | undefined>(undefined);
+
+  const utils = api.useUtils();
+
+  const updateCsiCode = api.gantt.updateCsiCode.useMutation({
+    onSuccess: () => {
+      void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId });
+    },
+    onError: (error) => {
+      setOptimisticCode(undefined);
+      showSnackbar(error.message || 'Failed to update CSI code', 'error');
+    },
+  });
+
+  useEffect(() => {
+    if (optimisticCode !== undefined && csiCode === optimisticCode) {
+      setOptimisticCode(undefined);
+    }
+  }, [csiCode, optimisticCode]);
+
+  const displayCode = optimisticCode !== undefined ? optimisticCode : csiCode;
+
+  // Auto-expand the division containing the current code
+  useEffect(() => {
+    if (displayCode) {
+      const subEntry = CSI_SUBDIVISION_MAP.get(displayCode);
+      if (subEntry) {
+        setExpandedDivision(subEntry.division.code);
+      }
+    }
+  }, [displayCode]);
+
+  const query = search.toLowerCase();
+  const isSearching = query.length > 0;
+
+  const displayDivisions = useMemo(() => {
+    const filtered = CSI_MASTERFORMAT.map((div) => {
+      const divMatches =
+        !query || div.code.includes(query) || div.nameLower.includes(query);
+      const matchingSubs = div.subdivisions.filter(
+        (sub) =>
+          !query || sub.code.includes(query) || sub.nameLower.includes(query),
+      );
+
+      if (!query) return { div, matchingSubs: div.subdivisions, show: true };
+      if (divMatches) return { div, matchingSubs: div.subdivisions, show: true };
+      if (matchingSubs.length > 0) return { div, matchingSubs, show: true };
+      return { div, matchingSubs: [], show: false };
+    }).filter((entry) => entry.show);
+
+    return isSearching
+      ? filtered.map((entry) => ({
+          ...entry,
+          matchingSubs: entry.matchingSubs.slice(0, 15),
+        }))
+      : filtered;
+  }, [query, isSearching]);
+
+  const handleSelectSubdivision = useCallback(
+    (code: string) => {
+      setOptimisticCode(code);
+      updateCsiCode.mutate({
+        organizationId,
+        projectId,
+        taskId,
+        csiCode: code,
+      });
+    },
+    [organizationId, projectId, taskId, updateCsiCode],
+  );
+
+  const handleRemoveCode = useCallback(() => {
+    setOptimisticCode(null);
+    updateCsiCode.mutate({
+      organizationId,
+      projectId,
+      taskId,
+      csiCode: null,
+    });
+  }, [organizationId, projectId, taskId, updateCsiCode]);
+
+  const hasCode = !!displayCode;
+  const subEntry = hasCode ? CSI_SUBDIVISION_MAP.get(displayCode!) : null;
+
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        bgcolor: 'background.paper',
+        minWidth: 0,
+        maxHeight: '85vh',
+        animation: 'slideInRight 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+        '@keyframes slideInRight': {
+          from: { opacity: 0, transform: 'translateX(12px)' },
+          to: { opacity: 1, transform: 'translateX(0)' },
+        },
+      }}
+    >
+      {/* ── Header ── */}
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: '16px', py: '12px' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+          <Tag size={14} weight="bold" color="var(--mui-palette-text-secondary)" style={{ flexShrink: 0 }} />
+          <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, color: 'text.primary', lineHeight: 1 }}>
+            CSI Classification
+          </Typography>
+        </Box>
+        <Box
+          component="button"
+          onClick={onClose}
+          sx={{
+            width: 26,
+            height: 26,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: '6px',
+            border: 'none',
+            bgcolor: 'transparent',
+            cursor: 'pointer',
+            color: 'text.secondary',
+            flexShrink: 0,
+            '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
+            transition: 'background-color 0.15s, color 0.15s',
+          }}
+          aria-label="Close CSI panel"
+        >
+          <X size={13} />
+        </Box>
+      </Box>
+
+      {/* ── Current selection ── */}
+      {hasCode && subEntry && (
+        <Box
+          sx={{
+            mx: '16px',
+            mb: 1.5,
+            px: 1.5,
+            py: 1.25,
+            borderRadius: '8px',
+            bgcolor: 'action.selected',
+            border: '1px solid',
+            borderColor: 'divider',
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 1,
+          }}
+        >
+          <Check size={13} weight="bold" color="var(--mui-palette-sidebar-indicator)" style={{ flexShrink: 0, marginTop: 1 }} />
+          <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: '3px' }}>
+            <Typography
+              sx={{
+                fontSize: '0.6875rem',
+                fontWeight: 700,
+                color: 'text.primary',
+                lineHeight: 1,
+                fontVariantNumeric: 'tabular-nums',
+                letterSpacing: '0.02em',
+              }}
+            >
+              {displayCode}
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: '0.75rem',
+                fontWeight: 500,
+                color: 'text.secondary',
+                lineHeight: 1.3,
+              }}
+            >
+              {subEntry.subdivision.name}
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: '0.5625rem',
+                fontWeight: 500,
+                color: 'text.disabled',
+                lineHeight: 1,
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                mt: '1px',
+              }}
+            >
+              {subEntry.division.name}
+            </Typography>
+          </Box>
+          <Box
+            component="button"
+            onClick={handleRemoveCode}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 22,
+              height: 22,
+              borderRadius: '5px',
+              border: 'none',
+              bgcolor: 'transparent',
+              cursor: 'pointer',
+              color: 'text.disabled',
+              flexShrink: 0,
+              '&:hover': { bgcolor: 'action.hover', color: 'text.secondary' },
+              transition: 'background-color 0.15s, color 0.15s',
+            }}
+            aria-label="Remove classification"
+          >
+            <Prohibit size={12} weight="bold" />
+          </Box>
+        </Box>
+      )}
+
+      <Divider />
+
+      {/* ── Search bar ── */}
+      <Box
+        sx={{
+          px: 1.5,
+          py: 1,
+          position: 'sticky',
+          top: 0,
+          bgcolor: 'background.paper',
+          zIndex: 1,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
+        }}
+      >
+        <MagnifyingGlass
+          size={14}
+          color="var(--mui-palette-text-secondary)"
+          style={{ flexShrink: 0 }}
+        />
+        <InputBase
+          placeholder="Search divisions or codes…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          autoFocus
+          fullWidth
+          sx={{
+            fontSize: '0.8125rem',
+            '& .MuiInputBase-input': {
+              p: 0,
+              '&::placeholder': {
+                color: 'text.disabled',
+                opacity: 1,
+              },
+            },
+          }}
+        />
+        {isSearching && (
+          <IconButton
+            size="small"
+            onClick={() => setSearch('')}
+            sx={{ p: 0.25, flexShrink: 0 }}
+            aria-label="Clear search"
+          >
+            <X size={12} weight="bold" />
+          </IconButton>
+        )}
+      </Box>
+
+      {/* ── Division list ── */}
+      <Box
+        component="ul"
+        role="listbox"
+        sx={{ listStyle: 'none', m: 0, p: 0, overflowY: 'auto', flex: 1 }}
+      >
+        {displayDivisions.map(({ div, matchingSubs }, idx) => {
+          const isExpanded = isSearching || expandedDivision === div.code;
+
+          return (
+            <Box component="li" key={div.code} sx={{ listStyle: 'none' }}>
+              {/* Division header */}
+              <Box
+                role="button"
+                tabIndex={isSearching ? -1 : 0}
+                onClick={() => {
+                  if (isSearching) return;
+                  setExpandedDivision(expandedDivision === div.code ? null : div.code);
+                }}
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (isSearching) return;
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setExpandedDivision(expandedDivision === div.code ? null : div.code);
+                  }
+                }}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 0.75,
+                  px: 1.5,
+                  py: '8px',
+                  cursor: isSearching ? 'default' : 'pointer',
+                  borderTop: idx > 0 ? '1px solid' : 'none',
+                  borderColor: 'divider',
+                  transition: 'background-color 0.1s',
+                  userSelect: 'none',
+                  '&:hover': {
+                    bgcolor: isSearching ? 'transparent' : 'action.hover',
+                  },
+                }}
+              >
+                {isSearching || isExpanded ? (
+                  <CaretDown size={11} color="var(--mui-palette-text-secondary)" style={{ flexShrink: 0 }} />
+                ) : (
+                  <CaretRight size={11} color="var(--mui-palette-text-secondary)" style={{ flexShrink: 0 }} />
+                )}
+                <Box
+                  sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    bgcolor: 'action.selected',
+                    borderRadius: '4px',
+                    px: 0.625,
+                    py: '1px',
+                    flexShrink: 0,
+                  }}
+                >
+                  <Typography
+                    component="span"
+                    sx={{
+                      fontSize: '0.625rem',
+                      fontWeight: 700,
+                      color: 'text.secondary',
+                      fontVariantNumeric: 'tabular-nums',
+                      lineHeight: 1.4,
+                      letterSpacing: '0.04em',
+                    }}
+                  >
+                    {div.code}
+                  </Typography>
+                </Box>
+                <Typography
+                  component="span"
+                  sx={{
+                    fontSize: '0.75rem',
+                    fontWeight: 600,
+                    color: 'text.primary',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {div.name}
+                </Typography>
+                <Typography
+                  component="span"
+                  sx={{
+                    fontSize: '0.5625rem',
+                    fontWeight: 500,
+                    color: 'text.disabled',
+                    ml: 'auto',
+                    flexShrink: 0,
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {matchingSubs.length}
+                </Typography>
+              </Box>
+
+              {/* Subdivision items */}
+              {isExpanded &&
+                matchingSubs.map((sub) => (
+                  <SubdivisionItem
+                    key={sub.code}
+                    sub={sub}
+                    isSelected={displayCode === sub.code}
+                    onSelect={handleSelectSubdivision}
+                  />
+                ))}
+            </Box>
+          );
+        })}
+      </Box>
+
+      {/* ── Empty state ── */}
+      {displayDivisions.length === 0 && (
+        <Box
+          sx={{
+            px: 3,
+            py: 4,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 1,
+          }}
+        >
+          <MagnifyingGlass
+            size={20}
+            color="var(--mui-palette-text-secondary)"
+          />
+          <Typography
+            sx={{
+              fontSize: '0.75rem',
+              color: 'text.disabled',
+              textAlign: 'center',
+              lineHeight: 1.4,
+            }}
+          >
+            No codes match &ldquo;{search}&rdquo;
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/components/bryntum/components/task-popover/FolderRow.tsx
+++ b/src/components/bryntum/components/task-popover/FolderRow.tsx
@@ -19,6 +19,7 @@ import type { Folder } from '@/lib/folders';
 import type { DocumentItem, PreviewDoc, FolderContentProps } from './types';
 import BaseFolderContent from './BaseFolderContent';
 import PhotosFolderContent from './PhotosFolderContent';
+import TrackableFolderContent from './TrackableFolderContent';
 import RequirementCounter from './RequirementCounter';
 
 const folderIconMap: Record<string, PhosphorIcon> = {
@@ -79,6 +80,17 @@ function FolderRowInner({
   const renderContent = () => {
     if (!isExpanded) return null;
 
+    // Trackable folders (submittals, inspections) get numbered slot dropzones
+    if (isTrackable) {
+      return (
+        <TrackableFolderContent
+          {...contentProps}
+          required={required ?? null}
+          folderColor={folder.color}
+        />
+      );
+    }
+
     const SpecificContent = FOLDER_CONTENT_MAP[folder.id];
     if (SpecificContent) {
       return <SpecificContent {...contentProps} />;
@@ -106,9 +118,9 @@ function FolderRowInner({
         onClick={onToggle}
       >
         {isExpanded ? (
-          <CaretDown size={14} color="var(--mui-palette-text-disabled)" style={{ flexShrink: 0 }} />
+          <CaretDown size={14} color="var(--mui-palette-text-secondary)" style={{ flexShrink: 0 }} />
         ) : (
-          <CaretRight size={14} color="var(--mui-palette-text-disabled)" style={{ flexShrink: 0 }} />
+          <CaretRight size={14} color="var(--mui-palette-text-secondary)" style={{ flexShrink: 0 }} />
         )}
         <FolderIcon size={14} color={folder.color} style={{ flexShrink: 0 }} />
         <Typography

--- a/src/components/bryntum/components/task-popover/PhotosFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/PhotosFolderContent.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import { Box, Typography } from '@mui/material';
-import { SquaresFour, List, FileText, Plus } from '@phosphor-icons/react';
+import { SquaresFour, List, FileText, CloudArrowUp } from '@phosphor-icons/react';
 import type { FolderContentProps, PreviewDoc } from './types';
 
 function PhotosFolderContentInner({
@@ -21,26 +21,47 @@ function PhotosFolderContentInner({
           ml: '36px',
           mr: 0.75,
           my: 0.75,
-          py: 1.5,
+          py: 2.5,
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
-          gap: 0.5,
+          gap: 1,
           border: '1.5px dashed',
           borderColor: 'divider',
-          borderRadius: '8px',
+          borderRadius: '10px',
+          bgcolor: 'rgba(0,0,0,0.015)',
           cursor: 'pointer',
-          transition: 'border-color 0.15s, background-color 0.15s',
+          transition: 'border-color 0.2s, background-color 0.2s',
           '&:hover': {
             borderColor: 'primary.main',
-            bgcolor: 'rgba(0,0,0,0.02)',
+            bgcolor: 'rgba(43, 45, 66, 0.05)',
+            '& .dropzone-icon': {
+              transform: 'translateY(-2px)',
+              bgcolor: 'rgba(43, 45, 66, 0.12)',
+            },
           },
         }}
       >
-        <Plus size={16} color="var(--mui-palette-text-disabled)" />
-        <Typography sx={{ fontSize: 11, color: 'text.disabled' }}>
-          Drop files or click to upload
-        </Typography>
+        <Box
+          className="dropzone-icon"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 36,
+            height: 36,
+            borderRadius: '50%',
+            bgcolor: 'rgba(0,0,0,0.06)',
+            transition: 'transform 0.2s, background-color 0.2s',
+          }}
+        >
+          <CloudArrowUp size={20} weight="bold" color="var(--mui-palette-text-secondary)" />
+        </Box>
+        <Box sx={{ textAlign: 'center' }}>
+          <Typography sx={{ fontSize: 11, fontWeight: 500, color: 'text.secondary', lineHeight: 1.2 }}>
+            Drop files or click to upload
+          </Typography>
+        </Box>
       </Box>
     );
   }

--- a/src/components/bryntum/components/task-popover/RequirementCounter.tsx
+++ b/src/components/bryntum/components/task-popover/RequirementCounter.tsx
@@ -64,14 +64,14 @@ export default function RequirementCounter({
       >
         <CircleDashed
           size={11}
-          color="var(--mui-palette-text-disabled)"
+          color="var(--mui-palette-text-secondary)"
           style={{ flexShrink: 0 }}
         />
         <Typography
           sx={{
             fontSize: '0.5625rem',
             fontWeight: 500,
-            color: 'text.disabled',
+            color: 'text.secondary',
             lineHeight: 1,
           }}
         >
@@ -170,7 +170,7 @@ export default function RequirementCounter({
                 width: 18,
                 height: 18,
                 borderRadius: 0,
-                color: 'text.disabled',
+                color: 'text.secondary',
                 '&:hover': { color: 'text.primary', bgcolor: 'action.hover' },
                 '&.Mui-disabled': { color: 'action.disabled' },
               }}
@@ -188,7 +188,7 @@ export default function RequirementCounter({
                 width: 18,
                 height: 18,
                 borderRadius: 0,
-                color: 'text.disabled',
+                color: 'text.secondary',
                 '&:hover': { color: 'text.primary', bgcolor: 'action.hover' },
                 '&.Mui-disabled': { color: 'action.disabled' },
               }}

--- a/src/components/bryntum/components/task-popover/TaskHeader.tsx
+++ b/src/components/bryntum/components/task-popover/TaskHeader.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box, Typography, Skeleton } from '@mui/material';
-import { X, CalendarBlank, Timer } from '@phosphor-icons/react';
+import { X, CalendarBlank, Timer, CircleDashed } from '@phosphor-icons/react';
 import type { Theme } from '@mui/material/styles';
 import { useTheme } from '@mui/material/styles';
 import CsiCodeSelector from '@/components/bryntum/components/CsiCodeSelector';
@@ -30,9 +30,6 @@ function formatDuration(duration: number | null | undefined, unit: string): stri
 
 interface TaskHeaderProps {
   taskName: string;
-  taskId?: string;
-  organizationId: string;
-  projectId: string;
   taskDetail: {
     startDate?: Date | string | null;
     endDate?: Date | string | null;
@@ -40,22 +37,36 @@ interface TaskHeaderProps {
     durationUnit?: string;
     csiCode?: string | null;
     percentDone?: number;
+    requiredSubmittals?: number | null;
+    requiredInspections?: number | null;
   } | null | undefined;
   taskDetailLoading: boolean;
   onClose: () => void;
+  onOpenCsiPanel: () => void;
+  /** Number of documents uploaded across all submittal folders */
+  submittalsCurrent?: number;
+  /** Number of documents uploaded across all inspection folders */
+  inspectionsCurrent?: number;
 }
 
 export default function TaskHeader({
   taskName,
-  taskId,
-  organizationId,
-  projectId,
   taskDetail,
   taskDetailLoading,
   onClose,
+  onOpenCsiPanel,
+  submittalsCurrent = 0,
+  inspectionsCurrent = 0,
 }: TaskHeaderProps) {
   const theme = useTheme();
-  const percentDone = taskDetail?.percentDone ?? 0;
+
+  // Calculate progress from submittals + inspections requirements
+  const requiredSubmittals = taskDetail?.requiredSubmittals ?? 0;
+  const requiredInspections = taskDetail?.requiredInspections ?? 0;
+  const totalRequired = requiredSubmittals + requiredInspections;
+  const hasRequirements = totalRequired > 0;
+  const totalUploaded = Math.min(submittalsCurrent, requiredSubmittals) + Math.min(inspectionsCurrent, requiredInspections);
+  const percentDone = hasRequirements ? Math.round((totalUploaded / totalRequired) * 100) : 0;
   const statusInfo = getStatusInfo(percentDone, theme.palette);
 
   const metaDateRange = [
@@ -71,10 +82,10 @@ export default function TaskHeader({
   );
 
   return (
-    <Box sx={{ p: '8px 14px 12px', display: 'flex', flexDirection: 'column', gap: 1.25 }}>
+    <Box sx={{ p: '12px 16px 14px', display: 'flex', flexDirection: 'column', gap: 1.5 }}>
       {/* Title row */}
       <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-        <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+        <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 0.75 }}>
           <Typography
             sx={{
               fontWeight: 600,
@@ -117,12 +128,10 @@ export default function TaskHeader({
                   )}
                 </Box>
               )}
-              {taskId && (
+              {taskDetail && (
                 <CsiCodeSelector
-                  csiCode={taskDetail?.csiCode}
-                  organizationId={organizationId}
-                  projectId={projectId}
-                  taskId={taskId}
+                  csiCode={taskDetail.csiCode}
+                  onOpen={onOpenCsiPanel}
                 />
               )}
             </>
@@ -172,7 +181,7 @@ export default function TaskHeader({
           </Typography>
           {taskDetailLoading ? (
             <Skeleton variant="text" width={24} height={12} sx={{ borderRadius: '3px' }} />
-          ) : (
+          ) : hasRequirements ? (
             <Typography
               sx={{
                 fontSize: '0.625rem',
@@ -184,11 +193,11 @@ export default function TaskHeader({
             >
               {Math.round(percentDone)}%
             </Typography>
-          )}
+          ) : null}
         </Box>
         {taskDetailLoading ? (
           <Skeleton variant="rounded" width="100%" height={4} sx={{ borderRadius: '999px' }} />
-        ) : (
+        ) : hasRequirements ? (
           <Box
             sx={{
               width: '100%',
@@ -207,6 +216,31 @@ export default function TaskHeader({
                 transition: 'width 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
               }}
             />
+          </Box>
+        ) : (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '5px',
+              py: '2px',
+            }}
+          >
+            <CircleDashed
+              size={11}
+              color="var(--mui-palette-text-disabled)"
+              style={{ flexShrink: 0 }}
+            />
+            <Typography
+              sx={{
+                fontSize: '0.625rem',
+                fontWeight: 500,
+                color: 'text.disabled',
+                lineHeight: 1,
+              }}
+            >
+              Set submittal or inspection requirements to track progress
+            </Typography>
           </Box>
         )}
       </Box>

--- a/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
@@ -1,49 +1,186 @@
 'use client';
 
-import { Box } from '@mui/material';
-import BaseFolderContent from './BaseFolderContent';
-import RequirementCounter from './RequirementCounter';
-import type { FolderContentProps } from './types';
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { CloudArrowUp, FileText, CheckCircle } from '@phosphor-icons/react';
+import type { FolderContentProps, PreviewDoc } from './types';
 
 interface TrackableFolderContentProps extends FolderContentProps {
   required: number | null;
-  current: number;
-  canManage: boolean;
-  onSave: (count: number | null) => void;
-  isPending: boolean;
   folderColor: string;
 }
 
-export default function TrackableFolderContent({
+function TrackableFolderContentInner({
   docs,
   onSelectDoc,
   selectedDocId,
   onUpload,
   folderName,
   required,
-  current,
-  canManage,
-  onSave,
-  isPending,
   folderColor,
 }: TrackableFolderContentProps) {
+  // No requirement set — empty state (no dropzones until a requirement is configured)
+  if (required === null || required === 0) {
+    return (
+      <Box
+        sx={{
+          ml: '36px',
+          mr: 0.75,
+          my: 0.75,
+          py: 1.5,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 0.5,
+        }}
+      >
+        <Typography sx={{ fontSize: 11, color: 'text.disabled', lineHeight: 1.2 }}>
+          No {folderName.toLowerCase()} required
+        </Typography>
+        <Typography sx={{ fontSize: 10, color: 'text.disabled', lineHeight: 1.2 }}>
+          Set a requirement to start tracking
+        </Typography>
+      </Box>
+    );
+  }
+
+  // Requirement is set — render N slots
+  const singularName = folderName.replace(/s$/i, '');
+  const slots = Array.from({ length: required }, (_, i) => {
+    const doc = docs[i] ?? null;
+    return { index: i, doc };
+  });
+
   return (
-    <Box>
-      <RequirementCounter
-        current={current}
-        required={required}
-        canManage={canManage}
-        onSave={onSave}
-        isPending={isPending}
-        folderColor={folderColor}
-      />
-      <BaseFolderContent
-        docs={docs}
-        onSelectDoc={onSelectDoc}
-        selectedDocId={selectedDocId}
-        onUpload={onUpload}
-        folderName={folderName}
-      />
+    <Box sx={{ pl: '20px', display: 'flex', flexDirection: 'column', gap: '4px', py: 0.75 }}>
+      {slots.map(({ index, doc }) => {
+        const slotNum = index + 1;
+        const isFilled = !!doc;
+        const isSelected = isFilled && selectedDocId === doc.id;
+
+        if (isFilled) {
+          const preview: PreviewDoc = {
+            id: doc.id,
+            name: doc.name,
+            blobUrl: doc.blobUrl,
+            mimeType: doc.mimeType,
+            size: doc.size,
+            createdAt: doc.createdAt,
+            uploadedBy: doc.uploadedBy ?? null,
+          };
+
+          return (
+            <Box
+              key={doc.id}
+              onClick={() => onSelectDoc(preview)}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.75,
+                py: '5px',
+                px: 1,
+                borderRadius: '8px',
+                cursor: 'pointer',
+                bgcolor: isSelected ? 'action.selected' : 'transparent',
+                '&:hover': { bgcolor: isSelected ? 'action.selected' : 'action.hover' },
+                transition: 'background-color 0.15s',
+              }}
+            >
+              {/* Slot number badge — filled */}
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 18,
+                  height: 18,
+                  borderRadius: '50%',
+                  bgcolor: `${folderColor}18`,
+                  flexShrink: 0,
+                }}
+              >
+                <CheckCircle size={11} weight="fill" color={folderColor} />
+              </Box>
+
+              <FileText
+                size={14}
+                color={isSelected ? 'var(--mui-palette-primary-main)' : 'var(--mui-palette-text-secondary)'}
+                style={{ flexShrink: 0 }}
+              />
+              <Typography
+                sx={{
+                  fontSize: 12,
+                  fontWeight: isSelected ? 500 : 400,
+                  flex: 1,
+                  color: 'text.primary',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  minWidth: 0,
+                }}
+              >
+                {doc.name}
+              </Typography>
+              {doc.createdAt != null && (
+                <Typography sx={{ fontSize: 11, color: 'text.secondary', flexShrink: 0 }}>
+                  {new Date(doc.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                </Typography>
+              )}
+            </Box>
+          );
+        }
+
+        // Empty slot — mini dropzone
+        return (
+          <Box
+            key={`empty-${index}`}
+            onClick={onUpload}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.75,
+              py: '6px',
+              px: 1,
+              borderRadius: '8px',
+              border: '1.5px dashed',
+              borderColor: 'divider',
+              bgcolor: 'rgba(0,0,0,0.012)',
+              cursor: 'pointer',
+              transition: 'border-color 0.2s, background-color 0.2s',
+              '&:hover': {
+                borderColor: folderColor,
+                bgcolor: `${folderColor}06`,
+              },
+            }}
+          >
+            {/* Slot number badge — empty */}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 18,
+                height: 18,
+                borderRadius: '50%',
+                bgcolor: 'rgba(0,0,0,0.04)',
+                flexShrink: 0,
+              }}
+            >
+              <Typography sx={{ fontSize: 9, fontWeight: 600, color: 'text.disabled', lineHeight: 1 }}>
+                {slotNum}
+              </Typography>
+            </Box>
+
+            <CloudArrowUp size={14} color="var(--mui-palette-text-disabled)" style={{ flexShrink: 0 }} />
+            <Typography sx={{ fontSize: 11, color: 'text.disabled', lineHeight: 1 }}>
+              {singularName} {slotNum}
+            </Typography>
+          </Box>
+        );
+      })}
     </Box>
   );
 }
+
+const TrackableFolderContent = React.memo(TrackableFolderContentInner);
+export default TrackableFolderContent;

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -50,6 +50,7 @@ export function createGanttConfig(
     project: {
       autoLoad: true,
       autoSync: false,
+      writeAllFields: true,
       taskModelClass: VersionedTaskModel,
 
       transport: projectId
@@ -101,10 +102,17 @@ export function createGanttConfig(
               { tag: 'span', class: 'gantt-name-text', text: String(value ?? '') },
               {
                 tag: 'button',
+                class: 'gantt-row-scroll-btn',
+                type: 'button',
+                dataset: { taskId: String(record.id) },
+                html: '<i class="fa-solid fa-arrow-right-to-bracket"></i>',
+              },
+              {
+                tag: 'button',
                 class: 'gantt-row-actions-btn',
                 type: 'button',
                 dataset: { taskId: String(record.id) },
-                text: '⋮',
+                html: '<i class="fa-solid fa-ellipsis-vertical"></i>',
               },
             ],
           };

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -176,6 +176,7 @@ export type GanttConfig = {
   project: {
     autoLoad: boolean;
     autoSync?: boolean;
+    writeAllFields?: boolean;
     taskModelClass?: typeof TaskModel;
     delayCalculation?: boolean;
     transport: {

--- a/src/components/layout/ProjectShell.tsx
+++ b/src/components/layout/ProjectShell.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, type ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
 import dynamic from 'next/dynamic';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Tooltip } from '@mui/material';
 import { CalendarDots } from '@phosphor-icons/react';
 import { differenceInCalendarDays } from 'date-fns';
 import FilesContent from '@/components/files/FilesContent';
@@ -32,28 +32,32 @@ interface ProjectShellProps {
   projectName: string;
 }
 
+const SCHEDULE_TOOLTIP = 'Based on the latest task end date in your schedule';
+
 function SchedulePill({ endDate }: { endDate: string | null }) {
   if (!endDate) {
     return (
-      <Box
-        sx={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 0.625,
-          height: 34,
-          px: 1.25,
-          borderRadius: '10px',
-          bgcolor: 'var(--bg-card)',
-          border: '1px solid var(--border-color)',
-          boxShadow: '0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)',
-          flexShrink: 0,
-        }}
-      >
-        <CalendarDots size={13} style={{ flexShrink: 0, opacity: 0.4 }} />
-        <Typography sx={{ fontSize: '0.6875rem', fontWeight: 500, color: 'text.disabled', lineHeight: 1, whiteSpace: 'nowrap' }}>
-          No end date
-        </Typography>
-      </Box>
+      <Tooltip title="Add tasks with end dates to track your project timeline" arrow placement="bottom">
+        <Box
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.625,
+            height: 34,
+            px: 1.25,
+            borderRadius: '10px',
+            bgcolor: 'var(--bg-card)',
+            border: '1px solid var(--border-color)',
+            boxShadow: '0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)',
+            flexShrink: 0,
+          }}
+        >
+          <CalendarDots size={13} style={{ flexShrink: 0, opacity: 0.4 }} />
+          <Typography sx={{ fontSize: '0.6875rem', fontWeight: 500, color: 'text.disabled', lineHeight: 1, whiteSpace: 'nowrap' }}>
+            No end date
+          </Typography>
+        </Box>
+      </Tooltip>
     );
   }
 
@@ -68,25 +72,27 @@ function SchedulePill({ endDate }: { endDate: string | null }) {
     daysLeft > 0 ? 'text.secondary' : daysLeft === 0 ? 'var(--status-amber)' : 'var(--status-red)';
 
   return (
-    <Box
-      sx={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 0.625,
-        height: 34,
-        px: 1.25,
-        borderRadius: '10px',
-        bgcolor: 'var(--bg-card)',
-        border: '1px solid var(--border-color)',
-        boxShadow: '0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)',
-        flexShrink: 0,
-      }}
-    >
-      <CalendarDots size={13} style={{ flexShrink: 0, opacity: 0.5 }} />
-      <Typography sx={{ fontSize: '0.6875rem', fontWeight: 600, color, lineHeight: 1, whiteSpace: 'nowrap', letterSpacing: '-0.01em' }}>
-        {label}
-      </Typography>
-    </Box>
+    <Tooltip title={SCHEDULE_TOOLTIP} arrow placement="bottom">
+      <Box
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.625,
+          height: 34,
+          px: 1.25,
+          borderRadius: '10px',
+          bgcolor: 'var(--bg-card)',
+          border: '1px solid var(--border-color)',
+          boxShadow: '0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)',
+          flexShrink: 0,
+        }}
+      >
+        <CalendarDots size={13} style={{ flexShrink: 0, opacity: 0.5 }} />
+        <Typography sx={{ fontSize: '0.6875rem', fontWeight: 600, color, lineHeight: 1, whiteSpace: 'nowrap', letterSpacing: '-0.01em' }}>
+          {label}
+        </Typography>
+      </Box>
+    </Tooltip>
   );
 }
 
@@ -136,7 +142,7 @@ export default function ProjectShell({ children, projectId, projectName }: Proje
                   uploaded={reqStats?.totalUploaded ?? 0}
                   required={reqStats?.totalRequired ?? 0}
                 />
-                <SchedulePill endDate={currentProject.endDate as string | null} />
+                <SchedulePill endDate={reqStats?.latestEndDate ? String(reqStats.latestEndDate) : null} />
               </>
             )}
             <Box sx={{ flex: 1 }}>

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -348,24 +348,30 @@ export const ganttRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Project not found or access denied" });
       }
 
-      // Get all tasks that have requirements set
-      const tasksWithReqs = await ctx.db.ganttTask.findMany({
-        where: {
-          projectId,
-          OR: [
-            { requiredSubmittals: { not: null } },
-            { requiredInspections: { not: null } },
-          ],
-        },
-        select: {
-          id: true,
-          requiredSubmittals: true,
-          requiredInspections: true,
-        },
-      });
+      // Get the latest task end date and all tasks with requirements in parallel
+      const [latestEndDate, tasksWithReqs] = await Promise.all([
+        ctx.db.ganttTask.aggregate({
+          where: { projectId, endDate: { not: null } },
+          _max: { endDate: true },
+        }),
+        ctx.db.ganttTask.findMany({
+          where: {
+            projectId,
+            OR: [
+              { requiredSubmittals: { not: null } },
+              { requiredInspections: { not: null } },
+            ],
+          },
+          select: {
+            id: true,
+            requiredSubmittals: true,
+            requiredInspections: true,
+          },
+        }),
+      ]);
 
       if (tasksWithReqs.length === 0) {
-        return { totalRequired: 0, totalUploaded: 0 };
+        return { totalRequired: 0, totalUploaded: 0, latestEndDate: latestEndDate._max.endDate ?? null };
       }
 
       // Sum all required counts
@@ -418,6 +424,6 @@ export const ganttRouter = createTRPCRouter({
         }
       }
 
-      return { totalRequired, totalUploaded };
+      return { totalRequired, totalUploaded, latestEndDate: latestEndDate._max.endDate ?? null };
     }),
 });

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -42,8 +42,8 @@ export const lightTheme: Theme = createTheme({
     },
     text: {
       primary: '#1A1A2E',  // $--foreground
-      secondary: '#8D99AE', // $--muted-foreground
-      disabled: '#B0B8C4',
+      secondary: '#6B7280', // $--muted-foreground (darkened for contrast)
+      disabled: '#9CA3AF',
     },
     divider: '#D9DBE1', // $--border
     action: {


### PR DESCRIPTION
## Summary
- Replaces the inline CSI code dropdown with a new slide-in `CsiCodePanel`, turning `CsiCodeSelector` into a display-only trigger button
- Redesigns task header progress bar to compute completion from submittal/inspection requirements instead of the Bryntum `percentDone` field
- Rewrites `TrackableFolderContent` with numbered slot dropzones showing filled/empty states per requirement
- Adds a scroll-to-task button in Gantt rows and switches the actions button to a Font Awesome icon
- Uses `reqStats.latestEndDate` (from actual task data) for the schedule pill instead of the project record's `endDate`
- Polishes upload dropzone empty states, improves text contrast via theme color adjustments, and updates claudedocs

## Test plan
- [ ] Open task popover and verify CSI code panel slides in from the right when clicking the CSI row
- [ ] Verify progress bar reflects submittal + inspection completion, shows hint when no requirements set
- [ ] Set submittal/inspection requirements and confirm numbered slots render correctly with upload functionality
- [ ] Click scroll-to-task button on a Gantt row and verify it scrolls to the task's start date
- [ ] Check schedule pill in project header shows correct days remaining based on latest task end date