### PR TITLE
Add E2E tests for auth and onboarding flows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
         env:
           construction_POSTGRES_PRISMA_URL: postgresql://postgres:postgres@localhost:5432/construction_test
           construction_POSTGRES_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/construction_test
-          BETTER_AUTH_SECRET: test-secret-for-ci-only
+          BETTER_AUTH_SECRET: test-secret-for-ci-e2e-runner-only-0123456789
           APP_URL: http://localhost:3000
           SKIP_ENV_VALIDATION: true
           BASE_URL: http://localhost:3000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  typecheck-and-unit:
+    name: Typecheck & Unit Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -17,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies
@@ -26,11 +27,8 @@ jobs:
       - name: Run type check
         run: npm run typecheck
 
-      - name: Run tests
+      - name: Run unit tests
         run: npm run test
-        env:
-          construction_POSTGRES_PRISMA_URL: file:./test.db
-          construction_POSTGRES_URL_NON_POOLING: file:./test.db
 
       - name: Build
         run: npx prisma generate && npx next build
@@ -39,3 +37,72 @@ jobs:
           construction_POSTGRES_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/test
           NODE_ENV: production
           SKIP_ENV_VALIDATION: true
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: construction_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Enable pgvector and pg_trgm extensions
+        run: |
+          psql -h localhost -U postgres -d construction_test -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          psql -h localhost -U postgres -d construction_test -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+        env:
+          PGPASSWORD: postgres
+
+      - name: Push database schema
+        run: npx prisma db push
+        env:
+          construction_POSTGRES_PRISMA_URL: postgresql://postgres:postgres@localhost:5432/construction_test
+          construction_POSTGRES_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/construction_test
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npx playwright test --reporter=github,html
+        env:
+          construction_POSTGRES_PRISMA_URL: postgresql://postgres:postgres@localhost:5432/construction_test
+          construction_POSTGRES_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/construction_test
+          BETTER_AUTH_SECRET: test-secret-for-ci-only
+          APP_URL: http://localhost:3000
+          SKIP_ENV_VALIDATION: true
+          BASE_URL: http://localhost:3000
+          BETA_ACCESS_CODE: buildtrack-beta-2026
+          CI: true
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
 
 # database
 /prisma/db.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /coverage
 /test-results/
 /playwright-report/
+/playwright/.auth/
 
 # database
 /prisma/db.sqlite

--- a/claudedocs/testing-guide.md
+++ b/claudedocs/testing-guide.md
@@ -140,12 +140,20 @@ Auth bypass for tests: middleware skips session checks when the `x-playwright-te
 ```
 tests/
   fixtures/
+    index.ts           # Custom `test` with auto-cleanup fixtures and POM injection
     db.ts              # Standalone Prisma client for test DB
     otp.ts             # OTP code reader from verification table
     test-user.ts       # User seeding (createTestUser, createVerifiedUser, createUserWithOrg) and cleanup
     auth.ts            # signInTestUser() — signs in via Better Auth API
   helpers/
     otp-input.ts       # MUI OTP input filler (fills 6 individual <input> elements)
+  pages/               # Page Object Models — centralized selectors and actions
+    sign-up.page.ts
+    sign-in.page.ts
+    onboarding.page.ts
+    verify-email.page.ts
+    forgot-password.page.ts  # includes ResetPasswordPage
+  global-teardown.ts   # Safety-net cleanup of @e2e.local users after all tests
   smoke/
     full-journey.spec.ts   # Golden path: sign-up → OTP → onboarding → dashboard
   auth/
@@ -159,7 +167,11 @@ tests/
 
 ### Key patterns
 
-**Test user isolation**: Each test generates unique emails (`test-{uuid}@e2e.local`). Cleanup in `afterAll` deletes users and cascaded records.
+**Custom fixtures (import from `../fixtures`)**: All spec files import `{ test, expect }` from `tests/fixtures/index.ts` instead of `@playwright/test`. This provides auto-cleanup user fixtures (`testUser`, `verifiedUser`, `userWithOrg`) and auto-instantiated Page Object Models (`signUpPage`, `signInPage`, `onboardingPage`, etc.). Fixture teardown is guaranteed even when tests throw.
+
+**Page Object Models**: Selectors and common actions live in `tests/pages/*.page.ts`. Tests use POM methods instead of inline selectors — one UI change only requires one update.
+
+**Test user isolation**: Each test generates unique emails (`test-{uuid}@e2e.local`). Fixture teardown deletes users and cascaded records. A `global-teardown.ts` safety net removes any orphaned `@e2e.local` users after the entire suite.
 
 **OTP codes**: Read directly from the `verification` table (identifier: `email-verification-otp-{email}`, value format: `{otp}:{attemptCount}`). The `getOtpForEmail()` helper polls with retries.
 
@@ -168,16 +180,14 @@ tests/
 **Password reset tokens**: Read from `verification` table (identifier: `password-reset:{userId}`).
 
 ```ts
-// Example: test requiring authenticated user
-import { createVerifiedUser, cleanupUser } from "../fixtures/test-user";
-import { signInTestUser } from "../fixtures/auth";
+// Example: test with auto-cleanup fixtures and POMs
+import { test, expect, signInTestUser } from "../fixtures";
 
-test("authenticated user can access onboarding", async ({ page }) => {
-  const user = await createVerifiedUser({ onboardingComplete: false });
-  await signInTestUser(page, user.email, user.password);
-  await page.goto("/onboarding");
-  await expect(page.getByText("Welcome to BuildTrack Pro")).toBeVisible();
-  // cleanup in afterAll
+test("verified user sees onboarding", async ({ verifiedUser, page, onboardingPage }) => {
+  await signInTestUser(page, verifiedUser.email, verifiedUser.password);
+  await onboardingPage.goto();
+  await expect(onboardingPage.heading).toBeVisible();
+  // cleanup is automatic via fixture teardown
 });
 ```
 

--- a/claudedocs/testing-guide.md
+++ b/claudedocs/testing-guide.md
@@ -131,21 +131,63 @@ screen.getByTestId("submit-btn")   // fragile, not meaningful to users
 
 ## E2E Tests (Playwright)
 
-E2E tests live in `tests/` (currently empty). The dev server starts automatically on `localhost:5050`.
+E2E tests live in `tests/`. The dev server must be running on `localhost:3000` (or set `BASE_URL` env var). Playwright config will auto-start it if not running.
 
 Auth bypass for tests: middleware skips session checks when the `x-playwright-test: true` header is present (non-production only). This is set automatically via `playwright.config.ts` `extraHTTPHeaders`.
 
-```ts
-// tests/example.spec.ts
-import { test, expect } from "@playwright/test";
+### Directory structure
 
-test("user can sign in and reach dashboard", async ({ page }) => {
-  await page.goto("/sign-in");
-  await page.getByLabel(/email/i).fill("user@example.com");
-  await page.getByLabel(/password/i).fill("password");
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL(/\/[\w-]+/); // org slug route
+```
+tests/
+  fixtures/
+    db.ts              # Standalone Prisma client for test DB
+    otp.ts             # OTP code reader from verification table
+    test-user.ts       # User seeding (createTestUser, createVerifiedUser, createUserWithOrg) and cleanup
+    auth.ts            # signInTestUser() — signs in via Better Auth API
+  helpers/
+    otp-input.ts       # MUI OTP input filler (fills 6 individual <input> elements)
+  smoke/
+    full-journey.spec.ts   # Golden path: sign-up → OTP → onboarding → dashboard
+  auth/
+    sign-up.spec.ts
+    sign-in.spec.ts
+    forgot-password.spec.ts
+    verify-email.spec.ts
+  onboarding/
+    wizard.spec.ts
+```
+
+### Key patterns
+
+**Test user isolation**: Each test generates unique emails (`test-{uuid}@e2e.local`). Cleanup in `afterAll` deletes users and cascaded records.
+
+**OTP codes**: Read directly from the `verification` table (identifier: `email-verification-otp-{email}`, value format: `{otp}:{attemptCount}`). The `getOtpForEmail()` helper polls with retries.
+
+**Authenticated tests**: Use `signInTestUser(page, email, password)` to sign in via the Better Auth API endpoint. This creates a real signed session cookie. Do NOT inject raw session tokens — Better Auth signs cookies and will reject unsigned values.
+
+**Password reset tokens**: Read from `verification` table (identifier: `password-reset:{userId}`).
+
+```ts
+// Example: test requiring authenticated user
+import { createVerifiedUser, cleanupUser } from "../fixtures/test-user";
+import { signInTestUser } from "../fixtures/auth";
+
+test("authenticated user can access onboarding", async ({ page }) => {
+  const user = await createVerifiedUser({ onboardingComplete: false });
+  await signInTestUser(page, user.email, user.password);
+  await page.goto("/onboarding");
+  await expect(page.getByText("Welcome to BuildTrack Pro")).toBeVisible();
+  // cleanup in afterAll
 });
+```
+
+### Running E2E tests
+
+```bash
+npx playwright test                    # all E2E tests
+npx playwright test tests/smoke/      # smoke tests only
+npx playwright test --ui               # interactive UI mode
+npx playwright show-report             # view last HTML report
 ```
 
 ---
@@ -154,14 +196,16 @@ test("user can sign in and reach dashboard", async ({ page }) => {
 
 | Area | Unit | E2E |
 |------|------|-----|
-| Auth forms (sign-in, sign-up, forgot/reset password) | ✅ | ❌ |
-| Middleware routing | ✅ | ❌ |
+| Auth forms (sign-in, sign-up, forgot/reset password) | ✅ | ✅ |
+| Middleware routing | ✅ | ✅ (via auth flow tests) |
+| Email verification (OTP) | ❌ | ✅ |
+| Onboarding flow | ❌ | ✅ |
+| Password reset (full flow) | ❌ | ✅ |
 | tRPC routers | ❌ | ❌ |
-| Onboarding flow | ❌ | ❌ |
-| Org / project creation | ❌ | ❌ |
+| Org / project creation | ❌ | ✅ (via onboarding) |
 | Invitation accept flow | ❌ | ❌ |
 | Gantt sync | ❌ | ❌ |
 | Document upload | ❌ | ❌ |
 | Permissions enforcement | ❌ | ❌ |
 
-**Priority gaps:** E2E for the invite→join flow, org creation, and Gantt sync are the highest-value additions given zero current coverage of those paths.
+**Priority gaps:** E2E for the invite→join flow, Gantt sync, and document upload are the highest-value additions.

--- a/claudedocs/testing-guide.md
+++ b/claudedocs/testing-guide.md
@@ -5,7 +5,7 @@
 | Layer | Tool | Location |
 |-------|------|----------|
 | Unit / component | Vitest + React Testing Library | `src/**/*.test.{ts,tsx}` |
-| E2E | Playwright (Chromium) | `tests/` *(currently empty)* |
+| E2E | Playwright (Chromium) | `tests/` |
 | Type checking | `tsc --noEmit` | — |
 
 ---

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,10 +5,10 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 1 : 2,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:5050',
+    baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
@@ -25,7 +25,7 @@ export default defineConfig({
   ],
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:5050',
+    url: process.env.BASE_URL ?? 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,12 +6,20 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : 2,
-  reporter: 'html',
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['github']]
+    : 'html',
+  globalTeardown: './tests/global-teardown.ts',
+
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+
   use: {
     baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    actionTimeout: 15_000,
     // Add custom header to bypass auth in test mode
     extraHTTPHeaders: {
       'x-playwright-test': 'true',
@@ -28,5 +36,7 @@ export default defineConfig({
     url: process.env.BASE_URL ?? 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
+    stdout: 'pipe',
+    stderr: 'pipe',
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
     url: process.env.BASE_URL ?? 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
-    stdout: 'pipe',
+    stdout: process.env.CI ? 'ignore' : 'pipe',
     stderr: 'pipe',
   },
 });

--- a/tests/auth/forgot-password.spec.ts
+++ b/tests/auth/forgot-password.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+import {
+  createVerifiedUser,
+  cleanupUser,
+  cleanupVerifications,
+} from "../fixtures/test-user";
+import { getPasswordResetToken } from "../fixtures/otp";
+
+test.describe("Forgot / Reset password flow", () => {
+  const emails: string[] = [];
+
+  test.afterAll(async () => {
+    for (const email of emails) {
+      await cleanupUser(email);
+      await cleanupVerifications(email);
+    }
+  });
+
+  test("submit forgot password shows success message", async ({ page }) => {
+    const user = await createVerifiedUser();
+    emails.push(user.email);
+
+    await page.goto("/forgot-password");
+
+    await page.getByLabel("Email address").fill(user.email);
+    await page.getByRole("button", { name: "Send reset link" }).click();
+
+    await expect(page.getByText("Check your email")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("non-existent email still shows success (no enumeration)", async ({ page }) => {
+    await page.goto("/forgot-password");
+
+    await page.getByLabel("Email address").fill("nonexistent@example.com");
+    await page.getByRole("button", { name: "Send reset link" }).click();
+
+    await expect(page.getByText("Check your email")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("full reset flow: request → token → new password → sign in", async ({ page }) => {
+    const user = await createVerifiedUser({ onboardingComplete: true });
+    emails.push(user.email);
+    const newPassword = "NewSecurePass456!";
+
+    // Step 1: Request password reset
+    await page.goto("/forgot-password");
+    await page.getByLabel("Email address").fill(user.email);
+    await page.getByRole("button", { name: "Send reset link" }).click();
+
+    await expect(page.getByText("Check your email")).toBeVisible({ timeout: 10000 });
+
+    // Step 2: Get reset token from DB
+    const token = await getPasswordResetToken(user.id);
+
+    // Step 3: Visit reset page with token
+    await page.goto(`/reset-password?token=${token}`);
+
+    await page.getByLabel("New password", { exact: true }).fill(newPassword);
+    await page.getByLabel("Confirm new password").fill(newPassword);
+    await page.getByRole("button", { name: "Reset password" }).click();
+
+    // Should show success state
+    await expect(page.getByText("Password reset!")).toBeVisible({ timeout: 10000 });
+
+    // Click the button/link to go to sign-in
+    await page.getByRole("button", { name: /continue to sign in/i }).click();
+    await page.waitForURL("**/sign-in", { timeout: 15000 });
+
+    // Step 4: Sign in with new password
+    await page.getByLabel("Email address").fill(user.email);
+    await page.getByLabel("Password").fill(newPassword);
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    // Should navigate away from sign-in (to onboarding or dashboard)
+    await page.waitForURL(
+      (url) => !url.pathname.includes("/sign-in"),
+      { timeout: 15000 }
+    );
+  });
+});

--- a/tests/auth/forgot-password.spec.ts
+++ b/tests/auth/forgot-password.spec.ts
@@ -1,80 +1,61 @@
-import { test, expect } from "@playwright/test";
-import {
-  createVerifiedUser,
-  cleanupUser,
-  cleanupVerifications,
-} from "../fixtures/test-user";
+import { test, expect } from "../fixtures";
+import { createVerifiedUser, cleanupUser, cleanupVerifications } from "../fixtures/test-user";
 import { getPasswordResetToken } from "../fixtures/otp";
 
 test.describe("Forgot / Reset password flow", () => {
-  const emails: string[] = [];
-
-  test.afterAll(async () => {
-    for (const email of emails) {
-      await cleanupUser(email);
-      await cleanupVerifications(email);
-    }
+  test("submit forgot password shows success message", async ({
+    verifiedUser,
+    forgotPasswordPage,
+  }) => {
+    await forgotPasswordPage.goto();
+    await forgotPasswordPage.requestReset(verifiedUser.email);
+    await expect(forgotPasswordPage.successHeading).toBeVisible({ timeout: 10000 });
   });
 
-  test("submit forgot password shows success message", async ({ page }) => {
-    const user = await createVerifiedUser();
-    emails.push(user.email);
-
-    await page.goto("/forgot-password");
-
-    await page.getByLabel("Email address").fill(user.email);
-    await page.getByRole("button", { name: "Send reset link" }).click();
-
-    await expect(page.getByText("Check your email")).toBeVisible({ timeout: 10000 });
+  test("non-existent email still shows success (no enumeration)", async ({
+    forgotPasswordPage,
+  }) => {
+    await forgotPasswordPage.goto();
+    await forgotPasswordPage.requestReset("nonexistent@example.com");
+    await expect(forgotPasswordPage.successHeading).toBeVisible({ timeout: 10000 });
   });
 
-  test("non-existent email still shows success (no enumeration)", async ({ page }) => {
-    await page.goto("/forgot-password");
-
-    await page.getByLabel("Email address").fill("nonexistent@example.com");
-    await page.getByRole("button", { name: "Send reset link" }).click();
-
-    await expect(page.getByText("Check your email")).toBeVisible({ timeout: 10000 });
-  });
-
-  test("full reset flow: request → token → new password → sign in", async ({ page }) => {
+  test("full reset flow: request → token → new password → sign in", async ({
+    page,
+    forgotPasswordPage,
+    resetPasswordPage,
+    signInPage,
+  }) => {
     const user = await createVerifiedUser({ onboardingComplete: true });
-    emails.push(user.email);
     const newPassword = "NewSecurePass456!";
 
-    // Step 1: Request password reset
-    await page.goto("/forgot-password");
-    await page.getByLabel("Email address").fill(user.email);
-    await page.getByRole("button", { name: "Send reset link" }).click();
+    try {
+      // Step 1: Request password reset
+      await forgotPasswordPage.goto();
+      await forgotPasswordPage.requestReset(user.email);
+      await expect(forgotPasswordPage.successHeading).toBeVisible({ timeout: 10000 });
 
-    await expect(page.getByText("Check your email")).toBeVisible({ timeout: 10000 });
+      // Step 2: Get reset token from DB
+      const token = await getPasswordResetToken(user.id);
 
-    // Step 2: Get reset token from DB
-    const token = await getPasswordResetToken(user.id);
+      // Step 3: Visit reset page with token and reset password
+      await resetPasswordPage.goto(token);
+      await resetPasswordPage.resetPassword(newPassword);
+      await expect(resetPasswordPage.successHeading).toBeVisible({ timeout: 10000 });
 
-    // Step 3: Visit reset page with token
-    await page.goto(`/reset-password?token=${token}`);
+      // Step 4: Navigate to sign-in
+      await resetPasswordPage.continueToSignInButton.click();
+      await page.waitForURL("**/sign-in", { timeout: 15000 });
 
-    await page.getByLabel("New password", { exact: true }).fill(newPassword);
-    await page.getByLabel("Confirm new password").fill(newPassword);
-    await page.getByRole("button", { name: "Reset password" }).click();
-
-    // Should show success state
-    await expect(page.getByText("Password reset!")).toBeVisible({ timeout: 10000 });
-
-    // Click the button/link to go to sign-in
-    await page.getByRole("button", { name: /continue to sign in/i }).click();
-    await page.waitForURL("**/sign-in", { timeout: 15000 });
-
-    // Step 4: Sign in with new password
-    await page.getByLabel("Email address").fill(user.email);
-    await page.getByLabel("Password").fill(newPassword);
-    await page.getByRole("button", { name: "Sign in" }).click();
-
-    // Should navigate away from sign-in (to onboarding or dashboard)
-    await page.waitForURL(
-      (url) => !url.pathname.includes("/sign-in"),
-      { timeout: 15000 }
-    );
+      // Step 5: Sign in with new password
+      await signInPage.signIn(user.email, newPassword);
+      await page.waitForURL(
+        (url) => !url.pathname.includes("/sign-in"),
+        { timeout: 15000 }
+      );
+    } finally {
+      await cleanupUser(user.email);
+      await cleanupVerifications(user.email);
+    }
   });
 });

--- a/tests/auth/sign-in.spec.ts
+++ b/tests/auth/sign-in.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+import {
+  createVerifiedUser,
+  createUserWithOrg,
+  cleanupUser,
+  cleanupVerifications,
+} from "../fixtures/test-user";
+
+test.describe("Sign-in flow", () => {
+  const emails: string[] = [];
+
+  test.afterAll(async () => {
+    for (const email of emails) {
+      await cleanupUser(email);
+      await cleanupVerifications(email);
+    }
+  });
+
+  test("sign in with verified user (no org) redirects to onboarding", async ({ page }) => {
+    const user = await createVerifiedUser({ onboardingComplete: false });
+    emails.push(user.email);
+
+    await page.goto("/sign-in");
+    await expect(page.getByText("Welcome back")).toBeVisible();
+
+    await page.getByLabel("Email address").fill(user.email);
+    await page.getByLabel("Password").fill(user.password);
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    await page.waitForURL("**/onboarding", { timeout: 15000 });
+  });
+
+  test("sign in with verified user (has org) redirects to dashboard", async ({ page }) => {
+    const { user, organization } = await createUserWithOrg();
+    emails.push(user.email);
+
+    await page.goto("/sign-in");
+
+    await page.getByLabel("Email address").fill(user.email);
+    await page.getByLabel("Password").fill(user.password);
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    // Should redirect away from sign-in to org dashboard or new-project page
+    await page.waitForURL(
+      (url) => {
+        const path = url.pathname;
+        return (
+          path.includes(organization.slug) ||
+          path.includes("/new-project") ||
+          path.includes("/onboarding")
+        );
+      },
+      { timeout: 30000 }
+    );
+  });
+
+  test("invalid credentials shows error", async ({ page }) => {
+    await page.goto("/sign-in");
+
+    await page.getByLabel("Email address").fill("nonexistent@example.com");
+    await page.getByLabel("Password").fill("WrongPass123!");
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    await expect(page.getByRole("alert")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("callbackUrl redirect works after sign-in", async ({ page }) => {
+    const user = await createVerifiedUser({ onboardingComplete: true });
+    emails.push(user.email);
+
+    // Create an org so the user won't be redirected to onboarding
+    // (use createUserWithOrg instead for a cleaner approach)
+    await cleanupUser(user.email);
+    const { user: orgUser, organization } = await createUserWithOrg();
+    // Replace the tracked email
+    emails[emails.length - 1] = orgUser.email;
+
+    await page.goto(`/sign-in?callbackUrl=/${organization.slug}`);
+
+    await page.getByLabel("Email address").fill(orgUser.email);
+    await page.getByLabel("Password").fill(orgUser.password);
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    await page.waitForURL(`**/${organization.slug}**`, { timeout: 15000 });
+  });
+
+  test("forgot password link navigates correctly", async ({ page }) => {
+    await page.goto("/sign-in");
+
+    await page.getByRole("link", { name: "Forgot password?" }).click();
+    await page.waitForURL("**/forgot-password");
+  });
+});

--- a/tests/auth/sign-in.spec.ts
+++ b/tests/auth/sign-in.spec.ts
@@ -1,51 +1,30 @@
-import { test, expect } from "@playwright/test";
-import {
-  createVerifiedUser,
-  createUserWithOrg,
-  cleanupUser,
-  cleanupVerifications,
-} from "../fixtures/test-user";
+import { test, expect } from "../fixtures";
+import { createUserWithOrg, cleanupUser, cleanupVerifications } from "../fixtures/test-user";
 
 test.describe("Sign-in flow", () => {
-  const emails: string[] = [];
+  test("sign in with verified user (no org) redirects to onboarding", async ({
+    verifiedUser,
+    signInPage,
+  }) => {
+    await signInPage.goto();
+    await expect(signInPage.heading).toBeVisible();
+    await signInPage.signIn(verifiedUser.email, verifiedUser.password);
 
-  test.afterAll(async () => {
-    for (const email of emails) {
-      await cleanupUser(email);
-      await cleanupVerifications(email);
-    }
+    await signInPage.page.waitForURL("**/onboarding", { timeout: 15000 });
   });
 
-  test("sign in with verified user (no org) redirects to onboarding", async ({ page }) => {
-    const user = await createVerifiedUser({ onboardingComplete: false });
-    emails.push(user.email);
+  test("sign in with verified user (has org) redirects to dashboard", async ({
+    userWithOrg,
+    signInPage,
+  }) => {
+    await signInPage.goto();
+    await signInPage.signIn(userWithOrg.user.email, userWithOrg.user.password);
 
-    await page.goto("/sign-in");
-    await expect(page.getByText("Welcome back")).toBeVisible();
-
-    await page.getByLabel("Email address").fill(user.email);
-    await page.getByLabel("Password").fill(user.password);
-    await page.getByRole("button", { name: "Sign in" }).click();
-
-    await page.waitForURL("**/onboarding", { timeout: 15000 });
-  });
-
-  test("sign in with verified user (has org) redirects to dashboard", async ({ page }) => {
-    const { user, organization } = await createUserWithOrg();
-    emails.push(user.email);
-
-    await page.goto("/sign-in");
-
-    await page.getByLabel("Email address").fill(user.email);
-    await page.getByLabel("Password").fill(user.password);
-    await page.getByRole("button", { name: "Sign in" }).click();
-
-    // Should redirect away from sign-in to org dashboard or new-project page
-    await page.waitForURL(
+    await signInPage.page.waitForURL(
       (url) => {
         const path = url.pathname;
         return (
-          path.includes(organization.slug) ||
+          path.includes(userWithOrg.organization.slug) ||
           path.includes("/new-project") ||
           path.includes("/onboarding")
         );
@@ -54,40 +33,30 @@ test.describe("Sign-in flow", () => {
     );
   });
 
-  test("invalid credentials shows error", async ({ page }) => {
-    await page.goto("/sign-in");
+  test("invalid credentials shows error", async ({ signInPage }) => {
+    await signInPage.goto();
+    await signInPage.signIn("nonexistent@example.com", "WrongPass123!");
 
-    await page.getByLabel("Email address").fill("nonexistent@example.com");
-    await page.getByLabel("Password").fill("WrongPass123!");
-    await page.getByRole("button", { name: "Sign in" }).click();
-
-    await expect(page.getByRole("alert")).toBeVisible({ timeout: 10000 });
+    await expect(signInPage.page.getByRole("alert")).toBeVisible({ timeout: 10000 });
   });
 
-  test("callbackUrl redirect works after sign-in", async ({ page }) => {
-    const user = await createVerifiedUser({ onboardingComplete: true });
-    emails.push(user.email);
+  test("callbackUrl redirect works after sign-in", async ({ signInPage }) => {
+    const { user, organization } = await createUserWithOrg();
 
-    // Create an org so the user won't be redirected to onboarding
-    // (use createUserWithOrg instead for a cleaner approach)
-    await cleanupUser(user.email);
-    const { user: orgUser, organization } = await createUserWithOrg();
-    // Replace the tracked email
-    emails[emails.length - 1] = orgUser.email;
+    try {
+      await signInPage.goto(`callbackUrl=/${organization.slug}`);
+      await signInPage.signIn(user.email, user.password);
 
-    await page.goto(`/sign-in?callbackUrl=/${organization.slug}`);
-
-    await page.getByLabel("Email address").fill(orgUser.email);
-    await page.getByLabel("Password").fill(orgUser.password);
-    await page.getByRole("button", { name: "Sign in" }).click();
-
-    await page.waitForURL(`**/${organization.slug}**`, { timeout: 15000 });
+      await signInPage.page.waitForURL(`**/${organization.slug}**`, { timeout: 15000 });
+    } finally {
+      await cleanupUser(user.email);
+      await cleanupVerifications(user.email);
+    }
   });
 
-  test("forgot password link navigates correctly", async ({ page }) => {
-    await page.goto("/sign-in");
-
-    await page.getByRole("link", { name: "Forgot password?" }).click();
-    await page.waitForURL("**/forgot-password");
+  test("forgot password link navigates correctly", async ({ signInPage }) => {
+    await signInPage.goto();
+    await signInPage.forgotPasswordLink.click();
+    await signInPage.page.waitForURL("**/forgot-password");
   });
 });

--- a/tests/auth/sign-up.spec.ts
+++ b/tests/auth/sign-up.spec.ts
@@ -1,9 +1,5 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures";
 import { uniqueEmail, cleanupUser, cleanupVerifications } from "../fixtures/test-user";
-import { getOtpForEmail } from "../fixtures/otp";
-import { fillOtpInput } from "../helpers/otp-input";
-
-const BETA_CODE = process.env.BETA_ACCESS_CODE ?? "buildtrack-beta-2026";
 
 test.describe("Sign-up flow", () => {
   const emails: string[] = [];
@@ -15,59 +11,40 @@ test.describe("Sign-up flow", () => {
     }
   });
 
-  test("valid sign-up shows OTP verification step", async ({ page }) => {
+  test("valid sign-up shows OTP verification step", async ({ signUpPage }) => {
     const email = uniqueEmail();
     emails.push(email);
 
-    await page.goto("/sign-up");
+    await signUpPage.goto();
+    await signUpPage.fillAndSubmit("Test User", email, "TestPass123!");
 
-    await page.getByLabel("Full name").fill("Test User");
-    await page.getByLabel("Email address").fill(email);
-    await page.getByLabel("Password").fill("TestPass123!");
-    await page.getByLabel("Beta access code").fill(BETA_CODE);
-    await page.getByRole("button", { name: "Create account" }).click();
-
-    await expect(page.getByText("Verify your email")).toBeVisible({ timeout: 30000 });
-    await expect(page.getByText(email)).toBeVisible();
+    await expect(signUpPage.verifyHeading).toBeVisible({ timeout: 30000 });
+    await expect(signUpPage.page.getByText(email)).toBeVisible();
   });
 
-  test("invalid beta code shows error", async ({ page }) => {
-    await page.goto("/sign-up");
+  test("invalid beta code shows error", async ({ signUpPage }) => {
+    await signUpPage.goto();
+    await signUpPage.fillAndSubmit("Test User", uniqueEmail(), "TestPass123!", "wrong-code");
 
-    await page.getByLabel("Full name").fill("Test User");
-    await page.getByLabel("Email address").fill(uniqueEmail());
-    await page.getByLabel("Password").fill("TestPass123!");
-    await page.getByLabel("Beta access code").fill("wrong-code");
-    await page.getByRole("button", { name: "Create account" }).click();
-
-    await expect(page.getByRole("alert")).toBeVisible({ timeout: 10000 });
+    await expect(signUpPage.page.getByRole("alert")).toBeVisible({ timeout: 10000 });
   });
 
-  test("OTP verification redirects to onboarding", async ({ page }) => {
+  test("OTP verification redirects to onboarding", async ({ signUpPage, onboardingPage }) => {
     const email = uniqueEmail();
     emails.push(email);
 
-    await page.goto("/sign-up");
+    await signUpPage.goto();
+    await signUpPage.fillAndSubmit("Test User", email, "TestPass123!");
+    await expect(signUpPage.verifyHeading).toBeVisible({ timeout: 30000 });
 
-    await page.getByLabel("Full name").fill("Test User");
-    await page.getByLabel("Email address").fill(email);
-    await page.getByLabel("Password").fill("TestPass123!");
-    await page.getByLabel("Beta access code").fill(BETA_CODE);
-    await page.getByRole("button", { name: "Create account" }).click();
+    await signUpPage.verifyOtp(email);
 
-    await expect(page.getByText("Verify your email")).toBeVisible({ timeout: 30000 });
-
-    const otp = await getOtpForEmail(email);
-    await fillOtpInput(page, otp);
-    await page.getByRole("button", { name: "Verify email" }).click();
-
-    await page.waitForURL("**/onboarding", { timeout: 15000 });
-    await expect(page.getByText("Welcome to BuildTrack Pro")).toBeVisible();
+    await signUpPage.page.waitForURL("**/onboarding", { timeout: 15000 });
+    await expect(onboardingPage.heading).toBeVisible();
   });
 
   test("sign-up link navigates to sign-in page", async ({ page }) => {
     await page.goto("/sign-up");
-
     await page.getByRole("link", { name: "Sign in" }).click();
     await page.waitForURL("**/sign-in");
   });

--- a/tests/auth/sign-up.spec.ts
+++ b/tests/auth/sign-up.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "@playwright/test";
+import { uniqueEmail, cleanupUser, cleanupVerifications } from "../fixtures/test-user";
+import { getOtpForEmail } from "../fixtures/otp";
+import { fillOtpInput } from "../helpers/otp-input";
+
+const BETA_CODE = process.env.BETA_ACCESS_CODE ?? "buildtrack-beta-2026";
+
+test.describe("Sign-up flow", () => {
+  const emails: string[] = [];
+
+  test.afterAll(async () => {
+    for (const email of emails) {
+      await cleanupUser(email);
+      await cleanupVerifications(email);
+    }
+  });
+
+  test("valid sign-up shows OTP verification step", async ({ page }) => {
+    const email = uniqueEmail();
+    emails.push(email);
+
+    await page.goto("/sign-up");
+
+    await page.getByLabel("Full name").fill("Test User");
+    await page.getByLabel("Email address").fill(email);
+    await page.getByLabel("Password").fill("TestPass123!");
+    await page.getByLabel("Beta access code").fill(BETA_CODE);
+    await page.getByRole("button", { name: "Create account" }).click();
+
+    await expect(page.getByText("Verify your email")).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText(email)).toBeVisible();
+  });
+
+  test("invalid beta code shows error", async ({ page }) => {
+    await page.goto("/sign-up");
+
+    await page.getByLabel("Full name").fill("Test User");
+    await page.getByLabel("Email address").fill(uniqueEmail());
+    await page.getByLabel("Password").fill("TestPass123!");
+    await page.getByLabel("Beta access code").fill("wrong-code");
+    await page.getByRole("button", { name: "Create account" }).click();
+
+    await expect(page.getByRole("alert")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("OTP verification redirects to onboarding", async ({ page }) => {
+    const email = uniqueEmail();
+    emails.push(email);
+
+    await page.goto("/sign-up");
+
+    await page.getByLabel("Full name").fill("Test User");
+    await page.getByLabel("Email address").fill(email);
+    await page.getByLabel("Password").fill("TestPass123!");
+    await page.getByLabel("Beta access code").fill(BETA_CODE);
+    await page.getByRole("button", { name: "Create account" }).click();
+
+    await expect(page.getByText("Verify your email")).toBeVisible({ timeout: 30000 });
+
+    const otp = await getOtpForEmail(email);
+    await fillOtpInput(page, otp);
+    await page.getByRole("button", { name: "Verify email" }).click();
+
+    await page.waitForURL("**/onboarding", { timeout: 15000 });
+    await expect(page.getByText("Welcome to BuildTrack Pro")).toBeVisible();
+  });
+
+  test("sign-up link navigates to sign-in page", async ({ page }) => {
+    await page.goto("/sign-up");
+
+    await page.getByRole("link", { name: "Sign in" }).click();
+    await page.waitForURL("**/sign-in");
+  });
+});

--- a/tests/auth/verify-email.spec.ts
+++ b/tests/auth/verify-email.spec.ts
@@ -1,66 +1,29 @@
-import { test, expect } from "@playwright/test";
-import {
-  createTestUser,
-  createVerifiedUser,
-  cleanupUser,
-  cleanupVerifications,
-} from "../fixtures/test-user";
-import { signInTestUser } from "../fixtures/auth";
-import { getOtpForEmail } from "../fixtures/otp";
-import { fillOtpInput } from "../helpers/otp-input";
+import { test, expect, signInTestUser } from "../fixtures";
 
 test.describe("Verify email page", () => {
-  const emails: string[] = [];
+  test("unverified user can send and verify OTP", async ({
+    testUser,
+    page,
+    verifyEmailPage,
+  }) => {
+    await signInTestUser(page, testUser.email, testUser.password);
+    await verifyEmailPage.goto();
 
-  test.afterAll(async () => {
-    for (const email of emails) {
-      await cleanupUser(email);
-      await cleanupVerifications(email);
-    }
-  });
+    await verifyEmailPage.sendCodeIfNeeded();
+    await expect(verifyEmailPage.otpInput).toBeVisible({ timeout: 15000 });
 
-  test("unverified user can send and verify OTP", async ({ page }) => {
-    const user = await createTestUser({ emailVerified: false });
-    emails.push(user.email);
+    await verifyEmailPage.verifyOtp(testUser.email);
 
-    // Sign in via API to get a real session cookie
-    await signInTestUser(page, user.email, user.password);
-    await page.goto("/verify-email");
-
-    // Wait for either the "Send verification code" button or OTP inputs
-    // (Better Auth may auto-send OTP during sign-in for unverified users)
-    const sendButton = page.getByRole("button", { name: "Send verification code" });
-    const otpInput = page.locator('input[inputmode="numeric"]').first();
-
-    // Try to click send if it exists, otherwise OTP inputs are already shown
-    try {
-      await sendButton.click({ timeout: 5000 });
-    } catch {
-      // OTP was already sent — inputs should be visible
-    }
-
-    // Wait for OTP inputs
-    await expect(otpInput).toBeVisible({ timeout: 15000 });
-
-    // Read OTP and fill
-    const otp = await getOtpForEmail(user.email);
-    await fillOtpInput(page, otp);
-
-    await page.getByRole("button", { name: "Verify email" }).click();
-
-    // Should redirect to onboarding
     await page.waitForURL("**/onboarding", { timeout: 15000 });
   });
 
-  test("already verified user is redirected away", async ({ page }) => {
-    const user = await createVerifiedUser({ onboardingComplete: false });
-    emails.push(user.email);
-
-    // Sign in via API
-    await signInTestUser(page, user.email, user.password);
+  test("already verified user is redirected away", async ({
+    verifiedUser,
+    page,
+  }) => {
+    await signInTestUser(page, verifiedUser.email, verifiedUser.password);
     await page.goto("/verify-email");
 
-    // Should auto-redirect to onboarding since email is already verified
     await page.waitForURL("**/onboarding", { timeout: 15000 });
   });
 });

--- a/tests/auth/verify-email.spec.ts
+++ b/tests/auth/verify-email.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+import {
+  createTestUser,
+  createVerifiedUser,
+  cleanupUser,
+  cleanupVerifications,
+} from "../fixtures/test-user";
+import { signInTestUser } from "../fixtures/auth";
+import { getOtpForEmail } from "../fixtures/otp";
+import { fillOtpInput } from "../helpers/otp-input";
+
+test.describe("Verify email page", () => {
+  const emails: string[] = [];
+
+  test.afterAll(async () => {
+    for (const email of emails) {
+      await cleanupUser(email);
+      await cleanupVerifications(email);
+    }
+  });
+
+  test("unverified user can send and verify OTP", async ({ page }) => {
+    const user = await createTestUser({ emailVerified: false });
+    emails.push(user.email);
+
+    // Sign in via API to get a real session cookie
+    await signInTestUser(page, user.email, user.password);
+    await page.goto("/verify-email");
+
+    // Wait for either the "Send verification code" button or OTP inputs
+    // (Better Auth may auto-send OTP during sign-in for unverified users)
+    const sendButton = page.getByRole("button", { name: "Send verification code" });
+    const otpInput = page.locator('input[inputmode="numeric"]').first();
+
+    // Try to click send if it exists, otherwise OTP inputs are already shown
+    try {
+      await sendButton.click({ timeout: 5000 });
+    } catch {
+      // OTP was already sent — inputs should be visible
+    }
+
+    // Wait for OTP inputs
+    await expect(otpInput).toBeVisible({ timeout: 15000 });
+
+    // Read OTP and fill
+    const otp = await getOtpForEmail(user.email);
+    await fillOtpInput(page, otp);
+
+    await page.getByRole("button", { name: "Verify email" }).click();
+
+    // Should redirect to onboarding
+    await page.waitForURL("**/onboarding", { timeout: 15000 });
+  });
+
+  test("already verified user is redirected away", async ({ page }) => {
+    const user = await createVerifiedUser({ onboardingComplete: false });
+    emails.push(user.email);
+
+    // Sign in via API
+    await signInTestUser(page, user.email, user.password);
+    await page.goto("/verify-email");
+
+    // Should auto-redirect to onboarding since email is already verified
+    await page.waitForURL("**/onboarding", { timeout: 15000 });
+  });
+});

--- a/tests/fixtures/auth.ts
+++ b/tests/fixtures/auth.ts
@@ -1,0 +1,25 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Signs in a test user via the Better Auth API endpoint.
+ * This creates a real session with properly signed cookies.
+ *
+ * After calling this, the page's browser context will have the
+ * session cookie set, so subsequent navigations will be authenticated.
+ */
+export async function signInTestUser(
+  page: Page,
+  email: string,
+  password: string
+): Promise<void> {
+  // Call Better Auth's sign-in endpoint directly via page.request
+  // This sets the session cookie on the browser context automatically
+  const response = await page.request.post("/api/auth/sign-in/email", {
+    data: { email, password },
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`Failed to sign in test user ${email}: ${response.status()} ${body}`);
+  }
+}

--- a/tests/fixtures/auth.ts
+++ b/tests/fixtures/auth.ts
@@ -12,10 +12,16 @@ export async function signInTestUser(
   email: string,
   password: string
 ): Promise<void> {
-  // Call Better Auth's sign-in endpoint directly via page.request
-  // This sets the session cookie on the browser context automatically
+  // Call Better Auth's sign-in endpoint directly via page.request.
+  // Must include Origin header — page.request.post() doesn't send it
+  // automatically, and Better Auth rejects POST requests without Origin
+  // when cookies are present (CSRF protection).
+  const origin = process.env.BASE_URL ?? "http://localhost:3000";
   const response = await page.request.post("/api/auth/sign-in/email", {
     data: { email, password },
+    headers: {
+      Origin: origin,
+    },
   });
 
   if (!response.ok()) {

--- a/tests/fixtures/db.ts
+++ b/tests/fixtures/db.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from "../../generated/prisma/index.js";
+
+/**
+ * Standalone Prisma client for E2E test seeding and cleanup.
+ * Connects to the same local PostgreSQL instance as the dev server.
+ */
+export const testDb = new PrismaClient({
+  datasources: {
+    db: {
+      url:
+        process.env.construction_POSTGRES_PRISMA_URL ??
+        `postgresql://${process.env.USER}@localhost:5433/construction`,
+    },
+  },
+});

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -1,0 +1,98 @@
+import { test as base } from "@playwright/test";
+import {
+  createTestUser,
+  createVerifiedUser,
+  createUserWithOrg,
+  cleanupUser,
+  cleanupVerifications,
+  type TestUser,
+  type TestUserWithOrg,
+} from "./test-user";
+import { signInTestUser } from "./auth";
+import { SignUpPage } from "../pages/sign-up.page";
+import { SignInPage } from "../pages/sign-in.page";
+import { OnboardingPage } from "../pages/onboarding.page";
+import { VerifyEmailPage } from "../pages/verify-email.page";
+import { ForgotPasswordPage, ResetPasswordPage } from "../pages/forgot-password.page";
+
+type TestFixtures = {
+  // Data fixtures — auto-seed and auto-cleanup
+  testUser: TestUser;
+  verifiedUser: TestUser;
+  userWithOrg: TestUserWithOrg;
+
+  // Page Object Models — auto-instantiated
+  signUpPage: SignUpPage;
+  signInPage: SignInPage;
+  onboardingPage: OnboardingPage;
+  verifyEmailPage: VerifyEmailPage;
+  forgotPasswordPage: ForgotPasswordPage;
+  resetPasswordPage: ResetPasswordPage;
+};
+
+/**
+ * Custom test object with auto-cleanup fixtures and Page Object Models.
+ *
+ * Usage:
+ *   import { test, expect } from "../fixtures";
+ *
+ *   test("example", async ({ verifiedUser, signInPage }) => {
+ *     await signInPage.goto();
+ *     await signInPage.signIn(verifiedUser.email, verifiedUser.password);
+ *   });
+ */
+export const test = base.extend<TestFixtures>({
+  // ─── Data Fixtures ───
+
+  testUser: async ({}, use) => {
+    const user = await createTestUser();
+    await use(user);
+    await cleanupUser(user.email);
+    await cleanupVerifications(user.email);
+  },
+
+  verifiedUser: async ({}, use) => {
+    const user = await createVerifiedUser({ onboardingComplete: false });
+    await use(user);
+    await cleanupUser(user.email);
+    await cleanupVerifications(user.email);
+  },
+
+  userWithOrg: async ({}, use) => {
+    const result = await createUserWithOrg();
+    await use(result);
+    await cleanupUser(result.user.email);
+    await cleanupVerifications(result.user.email);
+  },
+
+  // ─── Page Object Models ───
+
+  signUpPage: async ({ page }, use) => {
+    await use(new SignUpPage(page));
+  },
+
+  signInPage: async ({ page }, use) => {
+    await use(new SignInPage(page));
+  },
+
+  onboardingPage: async ({ page }, use) => {
+    await use(new OnboardingPage(page));
+  },
+
+  verifyEmailPage: async ({ page }, use) => {
+    await use(new VerifyEmailPage(page));
+  },
+
+  forgotPasswordPage: async ({ page }, use) => {
+    await use(new ForgotPasswordPage(page));
+  },
+
+  resetPasswordPage: async ({ page }, use) => {
+    await use(new ResetPasswordPage(page));
+  },
+});
+
+export { expect } from "@playwright/test";
+
+// Re-export signInTestUser for tests that need API-based auth
+export { signInTestUser } from "./auth";

--- a/tests/fixtures/otp.ts
+++ b/tests/fixtures/otp.ts
@@ -1,0 +1,64 @@
+import { testDb } from "./db";
+
+/**
+ * Reads the OTP code for a given email from the verification table.
+ * Better Auth stores OTP codes with identifier `email-verification-otp-{email}`
+ * and value format `{otp}:{attemptCount}`.
+ *
+ * Polls with retries since the OTP may not be written instantly after the sign-up request.
+ */
+export async function getOtpForEmail(
+  email: string,
+  { maxRetries = 10, delayMs = 500 } = {}
+): Promise<string> {
+  const identifier = `email-verification-otp-${email}`;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const record = await testDb.verification.findFirst({
+      where: { identifier },
+      orderBy: { createdAt: "desc" },
+    });
+
+    if (record?.value) {
+      // Value format: "123456:0" (otp:attemptCount)
+      const otp = record.value.split(":")[0];
+      if (otp && otp.length === 6) {
+        return otp;
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  throw new Error(
+    `OTP not found for ${email} after ${maxRetries} retries`
+  );
+}
+
+/**
+ * Reads a password reset token from the verification table.
+ * Stored with identifier `password-reset:{userId}`.
+ */
+export async function getPasswordResetToken(
+  userId: string,
+  { maxRetries = 10, delayMs = 500 } = {}
+): Promise<string> {
+  const identifier = `password-reset:${userId}`;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const record = await testDb.verification.findFirst({
+      where: { identifier },
+      orderBy: { createdAt: "desc" },
+    });
+
+    if (record?.value) {
+      return record.value;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  throw new Error(
+    `Password reset token not found for user ${userId} after ${maxRetries} retries`
+  );
+}

--- a/tests/fixtures/test-user.ts
+++ b/tests/fixtures/test-user.ts
@@ -10,11 +10,16 @@ interface CreateTestUserOptions {
   onboardingComplete?: boolean;
 }
 
-interface TestUser {
+export interface TestUser {
   id: string;
   name: string;
   email: string;
   password: string;
+}
+
+export interface TestUserWithOrg {
+  user: TestUser;
+  organization: { id: string; name: string; slug: string };
 }
 
 /**

--- a/tests/fixtures/test-user.ts
+++ b/tests/fixtures/test-user.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "crypto";
+import { hashPassword } from "better-auth/crypto";
+import { testDb } from "./db";
+
+interface CreateTestUserOptions {
+  name?: string;
+  email?: string;
+  password?: string;
+  emailVerified?: boolean;
+  onboardingComplete?: boolean;
+}
+
+interface TestUser {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+}
+
+/**
+ * Creates a test user with a credential account in the database.
+ * Returns the user record with the plaintext password for sign-in tests.
+ */
+export async function createTestUser(
+  options: CreateTestUserOptions = {}
+): Promise<TestUser> {
+  const uid = randomUUID().slice(0, 8);
+  const name = options.name ?? `Test User ${uid}`;
+  const email = options.email ?? `test-${uid}@e2e.local`;
+  const password = options.password ?? "TestPass123!";
+  const hashedPassword = await hashPassword(password);
+
+  const user = await testDb.user.create({
+    data: {
+      name,
+      email,
+      emailVerified: options.emailVerified ?? false,
+      onboardingComplete: options.onboardingComplete ?? false,
+    },
+  });
+
+  await testDb.account.create({
+    data: {
+      accountId: user.id,
+      providerId: "credential",
+      userId: user.id,
+      password: hashedPassword,
+    },
+  });
+
+  return { id: user.id, name, email, password };
+}
+
+/**
+ * Creates a verified test user (email verified, ready for onboarding).
+ */
+export async function createVerifiedUser(
+  options: CreateTestUserOptions = {}
+): Promise<TestUser> {
+  return createTestUser({ ...options, emailVerified: true });
+}
+
+/**
+ * Creates a verified user with an organization and owner membership.
+ * Returns the user and organization details.
+ */
+export async function createUserWithOrg(
+  options: CreateTestUserOptions & { orgName?: string } = {}
+) {
+  const user = await createTestUser({
+    ...options,
+    emailVerified: true,
+    onboardingComplete: true,
+  });
+
+  const orgName = options.orgName ?? `Test Org ${randomUUID().slice(0, 8)}`;
+  const slug = orgName.toLowerCase().replace(/\s+/g, "-");
+
+  const organization = await testDb.organization.create({
+    data: { name: orgName, slug },
+  });
+
+  await testDb.membership.create({
+    data: {
+      role: "owner",
+      userId: user.id,
+      organizationId: organization.id,
+    },
+  });
+
+  await testDb.user.update({
+    where: { id: user.id },
+    data: { activeOrganizationId: organization.id },
+  });
+
+  return { user, organization: { id: organization.id, name: orgName, slug } };
+}
+
+/**
+ * Generates a unique email address for test isolation.
+ */
+export function uniqueEmail(): string {
+  return `test-${randomUUID().slice(0, 8)}@e2e.local`;
+}
+
+/**
+ * Deletes a test user and all cascaded records (sessions, accounts, memberships, etc.).
+ */
+export async function cleanupUser(email: string): Promise<void> {
+  const user = await testDb.user.findUnique({ where: { email } });
+  if (!user) return;
+
+  // Delete orgs where user is the only member (test orgs)
+  const memberships = await testDb.membership.findMany({
+    where: { userId: user.id },
+    select: { organizationId: true },
+  });
+
+  for (const m of memberships) {
+    const memberCount = await testDb.membership.count({
+      where: { organizationId: m.organizationId },
+    });
+    if (memberCount === 1) {
+      await testDb.organization.delete({
+        where: { id: m.organizationId },
+      });
+    }
+  }
+
+  // Cascade deletes sessions, accounts, memberships, etc.
+  await testDb.user.delete({ where: { id: user.id } });
+}
+
+/**
+ * Cleans up any verification records for an email (OTP codes).
+ */
+export async function cleanupVerifications(email: string): Promise<void> {
+  await testDb.verification.deleteMany({
+    where: {
+      identifier: { contains: email },
+    },
+  });
+}

--- a/tests/fixtures/test-user.ts
+++ b/tests/fixtures/test-user.ts
@@ -137,12 +137,20 @@ export async function cleanupUser(email: string): Promise<void> {
 }
 
 /**
- * Cleans up any verification records for an email (OTP codes).
+ * Cleans up any verification records for an email (OTP codes and password reset tokens).
  */
 export async function cleanupVerifications(email: string): Promise<void> {
+  const user = await testDb.user.findUnique({
+    where: { email },
+    select: { id: true },
+  });
+
   await testDb.verification.deleteMany({
     where: {
-      identifier: { contains: email },
+      OR: [
+        { identifier: { contains: email } },
+        ...(user ? [{ identifier: `password-reset:${user.id}` }] : []),
+      ],
     },
   });
 }

--- a/tests/global-teardown.ts
+++ b/tests/global-teardown.ts
@@ -1,0 +1,43 @@
+import { testDb } from "./fixtures/db";
+
+/**
+ * Safety-net cleanup that runs after all tests complete.
+ * Removes any orphaned test data in case individual test cleanup failed.
+ */
+export default async function globalTeardown() {
+  try {
+    // Delete all test users (identifiable by @e2e.local email pattern)
+    const testUsers = await testDb.user.findMany({
+      where: { email: { endsWith: "@e2e.local" } },
+      select: { id: true, email: true },
+    });
+
+    for (const user of testUsers) {
+      // Delete orgs where user is the only member
+      const memberships = await testDb.membership.findMany({
+        where: { userId: user.id },
+        select: { organizationId: true },
+      });
+
+      for (const m of memberships) {
+        const memberCount = await testDb.membership.count({
+          where: { organizationId: m.organizationId },
+        });
+        if (memberCount === 1) {
+          await testDb.organization.delete({
+            where: { id: m.organizationId },
+          }).catch(() => {});
+        }
+      }
+
+      await testDb.user.delete({ where: { id: user.id } }).catch(() => {});
+    }
+
+    // Clean up orphaned verification records
+    await testDb.verification.deleteMany({
+      where: { identifier: { contains: "@e2e.local" } },
+    });
+  } finally {
+    await testDb.$disconnect();
+  }
+}

--- a/tests/helpers/otp-input.ts
+++ b/tests/helpers/otp-input.ts
@@ -1,0 +1,14 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Fills a MuiOtpInput component with a 6-digit OTP code.
+ * The MuiOtpInput renders 6 individual <input type="tel"> elements.
+ */
+export async function fillOtpInput(page: Page, otp: string): Promise<void> {
+  const inputs = page.locator('input[inputmode="numeric"]');
+  const count = await inputs.count();
+
+  for (let i = 0; i < Math.min(otp.length, count); i++) {
+    await inputs.nth(i).fill(otp[i]!);
+  }
+}

--- a/tests/onboarding/wizard.spec.ts
+++ b/tests/onboarding/wizard.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from "@playwright/test";
+import {
+  createVerifiedUser,
+  createUserWithOrg,
+  cleanupUser,
+  cleanupVerifications,
+} from "../fixtures/test-user";
+import { signInTestUser } from "../fixtures/auth";
+
+test.describe("Onboarding wizard", () => {
+  const emails: string[] = [];
+
+  test.afterAll(async () => {
+    for (const email of emails) {
+      await cleanupUser(email);
+      await cleanupVerifications(email);
+    }
+  });
+
+  test("Step 0 validation: cannot proceed without required fields", async ({ page }) => {
+    const user = await createVerifiedUser({ onboardingComplete: false });
+    emails.push(user.email);
+
+    await signInTestUser(page, user.email, user.password);
+    await page.goto("/onboarding");
+
+    await expect(page.getByText("Welcome to BuildTrack Pro")).toBeVisible({ timeout: 15000 });
+
+    // Try to continue without filling anything
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Should show validation errors
+    await expect(page.getByText("Company name is required")).toBeVisible();
+    await expect(page.getByText("Company type is required")).toBeVisible();
+
+    // Fill only name, try again
+    await page.getByPlaceholder("Enter your company name").fill("Test Company");
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Company type still required
+    await expect(page.getByText("Company type is required")).toBeVisible();
+  });
+
+  test("forward/back navigation works", async ({ page }) => {
+    const user = await createVerifiedUser({ onboardingComplete: false });
+    emails.push(user.email);
+
+    await signInTestUser(page, user.email, user.password);
+    await page.goto("/onboarding");
+
+    await expect(page.getByText("Tell us about your company")).toBeVisible({ timeout: 15000 });
+
+    // Fill required fields to proceed
+    await page.getByPlaceholder("Enter your company name").fill("Nav Test Co");
+    await page.getByText("Select company type").click();
+    await page.getByRole("option", { name: "General Contractor" }).click();
+
+    // Go to Step 1
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(page.getByText("How can we reach you?")).toBeVisible();
+
+    // Go back to Step 0
+    await page.getByRole("button", { name: "Back" }).click();
+    await expect(page.getByText("Tell us about your company")).toBeVisible();
+
+    // Company name should be preserved
+    await expect(page.getByPlaceholder("Enter your company name")).toHaveValue("Nav Test Co");
+  });
+
+  test("skip buttons work on steps 1 and 2", async ({ page }) => {
+    const user = await createVerifiedUser({ onboardingComplete: false });
+    emails.push(user.email);
+
+    await signInTestUser(page, user.email, user.password);
+    await page.goto("/onboarding");
+
+    await expect(page.getByText("Welcome to BuildTrack Pro")).toBeVisible({ timeout: 15000 });
+
+    // Fill Step 0
+    await page.getByPlaceholder("Enter your company name").fill("Skip Test Co");
+    await page.getByText("Select company type").click();
+    await page.getByRole("option", { name: "Subcontractor" }).click();
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Step 1: Skip
+    await expect(page.getByText("How can we reach you?")).toBeVisible();
+    await page.getByRole("button", { name: "Skip for now" }).click();
+
+    // Step 2: Skip
+    await expect(page.getByText("Add your company logo")).toBeVisible();
+    await page.getByRole("button", { name: "Skip for now" }).click();
+
+    // Should be on Step 3 (Review)
+    await expect(page.getByText("Review and finalize")).toBeVisible();
+  });
+
+  test("complete onboarding creates org and redirects to dashboard", async ({ page }) => {
+    const user = await createVerifiedUser({ onboardingComplete: false });
+    emails.push(user.email);
+    const companyName = `Onboard Co ${Date.now()}`;
+
+    await signInTestUser(page, user.email, user.password);
+    await page.goto("/onboarding");
+
+    await expect(page.getByText("Welcome to BuildTrack Pro")).toBeVisible({ timeout: 15000 });
+
+    // Step 0: Company Identity
+    await page.getByPlaceholder("Enter your company name").fill(companyName);
+    await page.getByText("Select company type").click();
+    await page.getByRole("option", { name: "Developer" }).click();
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Step 1: Skip
+    await page.getByRole("button", { name: "Skip for now" }).click();
+
+    // Step 2: Skip
+    await page.getByRole("button", { name: "Skip for now" }).click();
+
+    // Step 3: Review - submit
+    await expect(page.getByText("Review and finalize")).toBeVisible();
+    await page.getByRole("button", { name: "Launch BuildTrack Pro" }).click();
+
+    // Success state
+    await expect(page.getByText("You're all set!")).toBeVisible({ timeout: 10000 });
+
+    // Wait for redirect away from onboarding (1.5s delay in app + navigation)
+    await page.waitForURL(
+      (url) => !url.pathname.includes("/onboarding"),
+      { timeout: 15000 }
+    );
+  });
+
+  test("user with existing org is redirected away from onboarding", async ({ page }) => {
+    const { user, organization } = await createUserWithOrg();
+    emails.push(user.email);
+
+    await signInTestUser(page, user.email, user.password);
+    await page.goto("/onboarding");
+
+    // Should redirect to org dashboard (server-side check in onboarding page)
+    await page.waitForURL(
+      (url) => !url.pathname.includes("/onboarding"),
+      { timeout: 15000 }
+    );
+  });
+});

--- a/tests/onboarding/wizard.spec.ts
+++ b/tests/onboarding/wizard.spec.ts
@@ -1,146 +1,100 @@
-import { test, expect } from "@playwright/test";
-import {
-  createVerifiedUser,
-  createUserWithOrg,
-  cleanupUser,
-  cleanupVerifications,
-} from "../fixtures/test-user";
-import { signInTestUser } from "../fixtures/auth";
+import { test, expect, signInTestUser } from "../fixtures";
 
 test.describe("Onboarding wizard", () => {
-  const emails: string[] = [];
-
-  test.afterAll(async () => {
-    for (const email of emails) {
-      await cleanupUser(email);
-      await cleanupVerifications(email);
-    }
-  });
-
-  test("Step 0 validation: cannot proceed without required fields", async ({ page }) => {
-    const user = await createVerifiedUser({ onboardingComplete: false });
-    emails.push(user.email);
-
-    await signInTestUser(page, user.email, user.password);
-    await page.goto("/onboarding");
-
-    await expect(page.getByText("Welcome to BuildTrack Pro")).toBeVisible({ timeout: 15000 });
+  test("Step 0 validation: cannot proceed without required fields", async ({
+    verifiedUser,
+    page,
+    onboardingPage,
+  }) => {
+    await signInTestUser(page, verifiedUser.email, verifiedUser.password);
+    await onboardingPage.goto();
+    await expect(onboardingPage.heading).toBeVisible({ timeout: 15000 });
 
     // Try to continue without filling anything
-    await page.getByRole("button", { name: "Continue" }).click();
+    await onboardingPage.continueButton.click();
 
-    // Should show validation errors
     await expect(page.getByText("Company name is required")).toBeVisible();
     await expect(page.getByText("Company type is required")).toBeVisible();
 
     // Fill only name, try again
-    await page.getByPlaceholder("Enter your company name").fill("Test Company");
-    await page.getByRole("button", { name: "Continue" }).click();
+    await onboardingPage.companyNameInput.fill("Test Company");
+    await onboardingPage.continueButton.click();
 
-    // Company type still required
     await expect(page.getByText("Company type is required")).toBeVisible();
   });
 
-  test("forward/back navigation works", async ({ page }) => {
-    const user = await createVerifiedUser({ onboardingComplete: false });
-    emails.push(user.email);
-
-    await signInTestUser(page, user.email, user.password);
-    await page.goto("/onboarding");
-
+  test("forward/back navigation works", async ({
+    verifiedUser,
+    page,
+    onboardingPage,
+  }) => {
+    await signInTestUser(page, verifiedUser.email, verifiedUser.password);
+    await onboardingPage.goto();
     await expect(page.getByText("Tell us about your company")).toBeVisible({ timeout: 15000 });
 
-    // Fill required fields to proceed
-    await page.getByPlaceholder("Enter your company name").fill("Nav Test Co");
-    await page.getByText("Select company type").click();
-    await page.getByRole("option", { name: "General Contractor" }).click();
+    await onboardingPage.fillCompanyIdentity("Nav Test Co", "General Contractor");
 
     // Go to Step 1
-    await page.getByRole("button", { name: "Continue" }).click();
+    await onboardingPage.continueButton.click();
     await expect(page.getByText("How can we reach you?")).toBeVisible();
 
     // Go back to Step 0
-    await page.getByRole("button", { name: "Back" }).click();
+    await onboardingPage.backButton.click();
     await expect(page.getByText("Tell us about your company")).toBeVisible();
 
     // Company name should be preserved
-    await expect(page.getByPlaceholder("Enter your company name")).toHaveValue("Nav Test Co");
+    await expect(onboardingPage.companyNameInput).toHaveValue("Nav Test Co");
   });
 
-  test("skip buttons work on steps 1 and 2", async ({ page }) => {
-    const user = await createVerifiedUser({ onboardingComplete: false });
-    emails.push(user.email);
+  test("skip buttons work on steps 1 and 2", async ({
+    verifiedUser,
+    page,
+    onboardingPage,
+  }) => {
+    await signInTestUser(page, verifiedUser.email, verifiedUser.password);
+    await onboardingPage.goto();
+    await expect(onboardingPage.heading).toBeVisible({ timeout: 15000 });
 
-    await signInTestUser(page, user.email, user.password);
-    await page.goto("/onboarding");
-
-    await expect(page.getByText("Welcome to BuildTrack Pro")).toBeVisible({ timeout: 15000 });
-
-    // Fill Step 0
-    await page.getByPlaceholder("Enter your company name").fill("Skip Test Co");
-    await page.getByText("Select company type").click();
-    await page.getByRole("option", { name: "Subcontractor" }).click();
-    await page.getByRole("button", { name: "Continue" }).click();
+    await onboardingPage.fillCompanyIdentity("Skip Test Co", "Subcontractor");
+    await onboardingPage.continueButton.click();
 
     // Step 1: Skip
     await expect(page.getByText("How can we reach you?")).toBeVisible();
-    await page.getByRole("button", { name: "Skip for now" }).click();
+    await onboardingPage.skipButton.click();
 
     // Step 2: Skip
     await expect(page.getByText("Add your company logo")).toBeVisible();
-    await page.getByRole("button", { name: "Skip for now" }).click();
+    await onboardingPage.skipButton.click();
 
     // Should be on Step 3 (Review)
     await expect(page.getByText("Review and finalize")).toBeVisible();
   });
 
-  test("complete onboarding creates org and redirects to dashboard", async ({ page }) => {
-    const user = await createVerifiedUser({ onboardingComplete: false });
-    emails.push(user.email);
+  test("complete onboarding creates org and redirects to dashboard", async ({
+    verifiedUser,
+    page,
+    onboardingPage,
+  }) => {
     const companyName = `Onboard Co ${Date.now()}`;
 
-    await signInTestUser(page, user.email, user.password);
-    await page.goto("/onboarding");
+    await signInTestUser(page, verifiedUser.email, verifiedUser.password);
+    await onboardingPage.goto();
+    await expect(onboardingPage.heading).toBeVisible({ timeout: 15000 });
 
-    await expect(page.getByText("Welcome to BuildTrack Pro")).toBeVisible({ timeout: 15000 });
+    await onboardingPage.completeOnboarding(companyName, "Developer");
 
-    // Step 0: Company Identity
-    await page.getByPlaceholder("Enter your company name").fill(companyName);
-    await page.getByText("Select company type").click();
-    await page.getByRole("option", { name: "Developer" }).click();
-    await page.getByRole("button", { name: "Continue" }).click();
-
-    // Step 1: Skip
-    await page.getByRole("button", { name: "Skip for now" }).click();
-
-    // Step 2: Skip
-    await page.getByRole("button", { name: "Skip for now" }).click();
-
-    // Step 3: Review - submit
-    await expect(page.getByText("Review and finalize")).toBeVisible();
-    await page.getByRole("button", { name: "Launch BuildTrack Pro" }).click();
-
-    // Success state
-    await expect(page.getByText("You're all set!")).toBeVisible({ timeout: 10000 });
-
-    // Wait for redirect away from onboarding (1.5s delay in app + navigation)
-    await page.waitForURL(
-      (url) => !url.pathname.includes("/onboarding"),
-      { timeout: 15000 }
-    );
+    await expect(onboardingPage.successHeading).toBeVisible({ timeout: 10000 });
+    await onboardingPage.waitForRedirect();
   });
 
-  test("user with existing org is redirected away from onboarding", async ({ page }) => {
-    const { user, organization } = await createUserWithOrg();
-    emails.push(user.email);
+  test("user with existing org is redirected away from onboarding", async ({
+    userWithOrg,
+    page,
+    onboardingPage,
+  }) => {
+    await signInTestUser(page, userWithOrg.user.email, userWithOrg.user.password);
+    await onboardingPage.goto();
 
-    await signInTestUser(page, user.email, user.password);
-    await page.goto("/onboarding");
-
-    // Should redirect to org dashboard (server-side check in onboarding page)
-    await page.waitForURL(
-      (url) => !url.pathname.includes("/onboarding"),
-      { timeout: 15000 }
-    );
+    await onboardingPage.waitForRedirect();
   });
 });

--- a/tests/pages/forgot-password.page.ts
+++ b/tests/pages/forgot-password.page.ts
@@ -1,0 +1,52 @@
+import type { Page, Locator } from "@playwright/test";
+
+export class ForgotPasswordPage {
+  readonly page: Page;
+  readonly emailInput: Locator;
+  readonly sendResetButton: Locator;
+  readonly successHeading: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emailInput = page.getByLabel("Email address");
+    this.sendResetButton = page.getByRole("button", { name: "Send reset link" });
+    this.successHeading = page.getByText("Check your email");
+  }
+
+  async goto() {
+    await this.page.goto("/forgot-password");
+  }
+
+  async requestReset(email: string) {
+    await this.emailInput.fill(email);
+    await this.sendResetButton.click();
+  }
+}
+
+export class ResetPasswordPage {
+  readonly page: Page;
+  readonly newPasswordInput: Locator;
+  readonly confirmPasswordInput: Locator;
+  readonly resetButton: Locator;
+  readonly successHeading: Locator;
+  readonly continueToSignInButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.newPasswordInput = page.getByLabel("New password", { exact: true });
+    this.confirmPasswordInput = page.getByLabel("Confirm new password");
+    this.resetButton = page.getByRole("button", { name: "Reset password" });
+    this.successHeading = page.getByText("Password reset!");
+    this.continueToSignInButton = page.getByRole("button", { name: /continue to sign in/i });
+  }
+
+  async goto(token: string) {
+    await this.page.goto(`/reset-password?token=${token}`);
+  }
+
+  async resetPassword(newPassword: string) {
+    await this.newPasswordInput.fill(newPassword);
+    await this.confirmPasswordInput.fill(newPassword);
+    await this.resetButton.click();
+  }
+}

--- a/tests/pages/onboarding.page.ts
+++ b/tests/pages/onboarding.page.ts
@@ -1,0 +1,54 @@
+import type { Page, Locator } from "@playwright/test";
+
+export class OnboardingPage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly companyNameInput: Locator;
+  readonly companyTypeSelect: Locator;
+  readonly continueButton: Locator;
+  readonly skipButton: Locator;
+  readonly backButton: Locator;
+  readonly launchButton: Locator;
+  readonly successHeading: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByText("Welcome to BuildTrack Pro");
+    this.companyNameInput = page.getByPlaceholder("Enter your company name");
+    this.companyTypeSelect = page.getByText("Select company type");
+    this.continueButton = page.getByRole("button", { name: "Continue" });
+    this.skipButton = page.getByRole("button", { name: "Skip for now" });
+    this.backButton = page.getByRole("button", { name: "Back" });
+    this.launchButton = page.getByRole("button", { name: "Launch BuildTrack Pro" });
+    this.successHeading = page.getByText("You're all set!");
+  }
+
+  async goto() {
+    await this.page.goto("/onboarding");
+  }
+
+  async fillCompanyIdentity(companyName: string, companyType: string) {
+    await this.companyNameInput.fill(companyName);
+    await this.companyTypeSelect.click();
+    await this.page.getByRole("option", { name: companyType }).click();
+  }
+
+  async skipToReview() {
+    await this.skipButton.click(); // Skip Contact
+    await this.skipButton.click(); // Skip Logo
+  }
+
+  async completeOnboarding(companyName: string, companyType = "General Contractor") {
+    await this.fillCompanyIdentity(companyName, companyType);
+    await this.continueButton.click();
+    await this.skipToReview();
+    await this.launchButton.click();
+  }
+
+  async waitForRedirect() {
+    await this.page.waitForURL(
+      (url) => !url.pathname.includes("/onboarding"),
+      { timeout: 15000 }
+    );
+  }
+}

--- a/tests/pages/sign-in.page.ts
+++ b/tests/pages/sign-in.page.ts
@@ -1,0 +1,29 @@
+import type { Page, Locator } from "@playwright/test";
+
+export class SignInPage {
+  readonly page: Page;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly signInButton: Locator;
+  readonly heading: Locator;
+  readonly forgotPasswordLink: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emailInput = page.getByLabel("Email address");
+    this.passwordInput = page.getByLabel("Password");
+    this.signInButton = page.getByRole("button", { name: "Sign in" });
+    this.heading = page.getByText("Welcome back");
+    this.forgotPasswordLink = page.getByRole("link", { name: "Forgot password?" });
+  }
+
+  async goto(params?: string) {
+    await this.page.goto(`/sign-in${params ? `?${params}` : ""}`);
+  }
+
+  async signIn(email: string, password: string) {
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.signInButton.click();
+  }
+}

--- a/tests/pages/sign-up.page.ts
+++ b/tests/pages/sign-up.page.ts
@@ -1,0 +1,53 @@
+import type { Page, Locator } from "@playwright/test";
+import { getOtpForEmail } from "../fixtures/otp";
+import { fillOtpInput } from "../helpers/otp-input";
+
+const BETA_CODE = process.env.BETA_ACCESS_CODE ?? "buildtrack-beta-2026";
+
+export class SignUpPage {
+  readonly page: Page;
+  readonly nameInput: Locator;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly betaCodeInput: Locator;
+  readonly createAccountButton: Locator;
+  readonly verifyEmailButton: Locator;
+  readonly verifyHeading: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.nameInput = page.getByLabel("Full name");
+    this.emailInput = page.getByLabel("Email address");
+    this.passwordInput = page.getByLabel("Password");
+    this.betaCodeInput = page.getByLabel("Beta access code");
+    this.createAccountButton = page.getByRole("button", { name: "Create account" });
+    this.verifyEmailButton = page.getByRole("button", { name: "Verify email" });
+    this.verifyHeading = page.getByText("Verify your email");
+  }
+
+  async goto() {
+    await this.page.goto("/sign-up");
+  }
+
+  async fillForm(name: string, email: string, password: string, betaCode = BETA_CODE) {
+    await this.nameInput.fill(name);
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.betaCodeInput.fill(betaCode);
+  }
+
+  async submit() {
+    await this.createAccountButton.click();
+  }
+
+  async fillAndSubmit(name: string, email: string, password: string, betaCode = BETA_CODE) {
+    await this.fillForm(name, email, password, betaCode);
+    await this.submit();
+  }
+
+  async verifyOtp(email: string) {
+    const otp = await getOtpForEmail(email);
+    await fillOtpInput(this.page, otp);
+    await this.verifyEmailButton.click();
+  }
+}

--- a/tests/pages/verify-email.page.ts
+++ b/tests/pages/verify-email.page.ts
@@ -1,0 +1,37 @@
+import type { Page, Locator } from "@playwright/test";
+import { getOtpForEmail } from "../fixtures/otp";
+import { fillOtpInput } from "../helpers/otp-input";
+
+export class VerifyEmailPage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly sendCodeButton: Locator;
+  readonly verifyButton: Locator;
+  readonly otpInput: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByText("Verify your email");
+    this.sendCodeButton = page.getByRole("button", { name: "Send verification code" });
+    this.verifyButton = page.getByRole("button", { name: "Verify email" });
+    this.otpInput = page.locator('input[inputmode="numeric"]').first();
+  }
+
+  async goto() {
+    await this.page.goto("/verify-email");
+  }
+
+  async sendCodeIfNeeded() {
+    try {
+      await this.sendCodeButton.click({ timeout: 5000 });
+    } catch {
+      // OTP was already sent — inputs should be visible
+    }
+  }
+
+  async verifyOtp(email: string) {
+    const otp = await getOtpForEmail(email);
+    await fillOtpInput(this.page, otp);
+    await this.verifyButton.click();
+  }
+}

--- a/tests/smoke/full-journey.spec.ts
+++ b/tests/smoke/full-journey.spec.ts
@@ -1,14 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures";
 import { uniqueEmail, cleanupUser, cleanupVerifications } from "../fixtures/test-user";
-import { getOtpForEmail } from "../fixtures/otp";
-import { fillOtpInput } from "../helpers/otp-input";
-
-const BETA_CODE = process.env.BETA_ACCESS_CODE ?? "buildtrack-beta-2026";
 
 test.describe("Full journey: sign-up → verify → onboarding → dashboard", () => {
   const testEmail = uniqueEmail();
-  const testPassword = "TestPass123!";
-  const testName = "E2E Smoke Tester";
   const companyName = `Smoke Co ${Date.now()}`;
 
   test.afterAll(async () => {
@@ -16,66 +10,29 @@ test.describe("Full journey: sign-up → verify → onboarding → dashboard", (
     await cleanupVerifications(testEmail);
   });
 
-  test("complete sign-up through onboarding to dashboard", async ({ page }) => {
+  test("complete sign-up through onboarding to dashboard", async ({
+    signUpPage,
+    onboardingPage,
+  }) => {
     // ─── Step 1: Sign Up ───
-    await page.goto("/sign-up");
-    await expect(page.getByText("Create your account")).toBeVisible();
-
-    await page.getByLabel("Full name").fill(testName);
-    await page.getByLabel("Email address").fill(testEmail);
-    await page.getByLabel("Password").fill(testPassword);
-    await page.getByLabel("Beta access code").fill(BETA_CODE);
-
-    await page.getByRole("button", { name: "Create account" }).click();
+    await signUpPage.goto();
+    await expect(signUpPage.page.getByText("Create your account")).toBeVisible();
+    await signUpPage.fillAndSubmit("E2E Smoke Tester", testEmail, "TestPass123!");
 
     // ─── Step 2: OTP Verification ───
-    await expect(page.getByText("Verify your email")).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText(testEmail)).toBeVisible();
-
-    // Read OTP from the database
-    const otp = await getOtpForEmail(testEmail);
-    await fillOtpInput(page, otp);
-
-    await page.getByRole("button", { name: "Verify email" }).click();
+    await expect(signUpPage.verifyHeading).toBeVisible({ timeout: 15000 });
+    await expect(signUpPage.page.getByText(testEmail)).toBeVisible();
+    await signUpPage.verifyOtp(testEmail);
 
     // ─── Step 3: Onboarding Wizard ───
-    await expect(page.getByText("Welcome to BuildTrack Pro")).toBeVisible({ timeout: 15000 });
-
-    // Step 0: Company Identity (required fields)
-    await page.getByPlaceholder("Enter your company name").fill(companyName);
-
-    // Open the company type select and pick an option
-    await page.getByText("Select company type").click();
-    await page.getByRole("option", { name: "General Contractor" }).click();
-
-    // Continue to Step 1 (Contact)
-    await page.getByRole("button", { name: "Continue" }).click();
-    await expect(page.getByText("How can we reach you?")).toBeVisible();
-
-    // Skip Step 1 (Contact)
-    await page.getByRole("button", { name: "Skip for now" }).click();
-
-    // Skip Step 2 (Logo)
-    await expect(page.getByText("Add your company logo")).toBeVisible();
-    await page.getByRole("button", { name: "Skip for now" }).click();
-
-    // Step 3: Review
-    await expect(page.getByText("Review and finalize")).toBeVisible();
-
-    // Submit
-    await page.getByRole("button", { name: "Launch BuildTrack Pro" }).click();
+    await expect(onboardingPage.heading).toBeVisible({ timeout: 15000 });
+    await onboardingPage.completeOnboarding(companyName);
 
     // ─── Step 4: Success & Dashboard ───
-    await expect(page.getByText("You're all set!")).toBeVisible({ timeout: 10000 });
+    await expect(onboardingPage.successHeading).toBeVisible({ timeout: 10000 });
+    await onboardingPage.waitForRedirect();
 
-    // Wait for redirect away from onboarding (1.5s delay in the app + navigation)
-    await page.waitForURL(
-      (url) => !url.pathname.includes("/onboarding"),
-      { timeout: 15000 }
-    );
-
-    // Verify we landed on a real page (not auth pages)
-    const url = page.url();
+    const url = onboardingPage.page.url();
     expect(url).not.toContain("/sign-");
     expect(url).not.toContain("/verify-email");
   });

--- a/tests/smoke/full-journey.spec.ts
+++ b/tests/smoke/full-journey.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+import { uniqueEmail, cleanupUser, cleanupVerifications } from "../fixtures/test-user";
+import { getOtpForEmail } from "../fixtures/otp";
+import { fillOtpInput } from "../helpers/otp-input";
+
+const BETA_CODE = process.env.BETA_ACCESS_CODE ?? "buildtrack-beta-2026";
+
+test.describe("Full journey: sign-up → verify → onboarding → dashboard", () => {
+  const testEmail = uniqueEmail();
+  const testPassword = "TestPass123!";
+  const testName = "E2E Smoke Tester";
+  const companyName = `Smoke Co ${Date.now()}`;
+
+  test.afterAll(async () => {
+    await cleanupUser(testEmail);
+    await cleanupVerifications(testEmail);
+  });
+
+  test("complete sign-up through onboarding to dashboard", async ({ page }) => {
+    // ─── Step 1: Sign Up ───
+    await page.goto("/sign-up");
+    await expect(page.getByText("Create your account")).toBeVisible();
+
+    await page.getByLabel("Full name").fill(testName);
+    await page.getByLabel("Email address").fill(testEmail);
+    await page.getByLabel("Password").fill(testPassword);
+    await page.getByLabel("Beta access code").fill(BETA_CODE);
+
+    await page.getByRole("button", { name: "Create account" }).click();
+
+    // ─── Step 2: OTP Verification ───
+    await expect(page.getByText("Verify your email")).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(testEmail)).toBeVisible();
+
+    // Read OTP from the database
+    const otp = await getOtpForEmail(testEmail);
+    await fillOtpInput(page, otp);
+
+    await page.getByRole("button", { name: "Verify email" }).click();
+
+    // ─── Step 3: Onboarding Wizard ───
+    await expect(page.getByText("Welcome to BuildTrack Pro")).toBeVisible({ timeout: 15000 });
+
+    // Step 0: Company Identity (required fields)
+    await page.getByPlaceholder("Enter your company name").fill(companyName);
+
+    // Open the company type select and pick an option
+    await page.getByText("Select company type").click();
+    await page.getByRole("option", { name: "General Contractor" }).click();
+
+    // Continue to Step 1 (Contact)
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(page.getByText("How can we reach you?")).toBeVisible();
+
+    // Skip Step 1 (Contact)
+    await page.getByRole("button", { name: "Skip for now" }).click();
+
+    // Skip Step 2 (Logo)
+    await expect(page.getByText("Add your company logo")).toBeVisible();
+    await page.getByRole("button", { name: "Skip for now" }).click();
+
+    // Step 3: Review
+    await expect(page.getByText("Review and finalize")).toBeVisible();
+
+    // Submit
+    await page.getByRole("button", { name: "Launch BuildTrack Pro" }).click();
+
+    // ─── Step 4: Success & Dashboard ───
+    await expect(page.getByText("You're all set!")).toBeVisible({ timeout: 10000 });
+
+    // Wait for redirect away from onboarding (1.5s delay in the app + navigation)
+    await page.waitForURL(
+      (url) => !url.pathname.includes("/onboarding"),
+      { timeout: 15000 }
+    );
+
+    // Verify we landed on a real page (not auth pages)
+    const url = page.url();
+    expect(url).not.toContain("/sign-");
+    expect(url).not.toContain("/verify-email");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a full Playwright E2E test suite covering sign-up, sign-in, email verification (OTP), forgot/reset password, and onboarding wizard flows
- Introduces reusable test infrastructure: custom fixtures with auto-cleanup, Page Object Models, OTP/password-reset-token helpers, and a global teardown safety net for `@e2e.local` users
- Adds a new `e2e` job to the GitHub Actions CI pipeline running against a PostgreSQL service container with pgvector
- Updates `claudedocs/testing-guide.md` with the new directory structure, patterns, and coverage map

## Test plan
- [ ] `npx playwright test` passes locally against a running dev server
- [ ] CI `e2e` job passes on this PR
- [ ] Verify global teardown cleans up all `@e2e.local` users and verification rows after suite completion