### PR TITLE
Add end date column to Gantt chart

### DIFF
--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -128,6 +128,13 @@ export function createGanttConfig(
         resizable: true,
       },
       {
+        type: 'enddate',
+        field: 'endDate',
+        text: 'End',
+        width: 120,
+        resizable: true,
+      },
+      {
         type: 'duration',
         text: 'Duration',
         width: 100,


### PR DESCRIPTION
Adds an End Date column to the Gantt chart between the Start and Duration columns. Uses Bryntum's built-in `enddate` column type, matching the existing Start column configuration.

Closes #88