### PR TITLE
Lock Gantt chart by default with admin-only edit mode toggle

### DIFF
--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -6,6 +6,8 @@ import { Menu } from '@bryntum/gantt';
 import '@bryntum/gantt/gantt.css';
 import { Box } from '@mui/material';
 import { api } from '@/trpc/react';
+import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
+import { canManageProjects } from '@/lib/permissions';
 import { createGanttConfig } from './config/ganttConfig';
 import GanttToolbar from './components/GanttToolbar';
 import { TaskDetailsPopover } from './components/TaskDetailsPopover';
@@ -74,6 +76,12 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
   const [conflictOpen, setConflictOpen] = useState(false);
   const [taskInfoRecord, setTaskInfoRecord] = useState<BryntumTaskRecord | null>(null);
 
+  // Lock mode: chart is locked by default; admin-level users can unlock to edit.
+  const { currentOrg } = useOrgFromUrl();
+  const canEditChart = canManageProjects(currentOrg?.role ?? '');
+  const [isEditMode, setIsEditMode] = useState(false);
+  const editingUnlocked = canEditChart && isEditMode;
+
   const isReloadingRef = useRef(false);
   const skipVersionRef = useRef(false);
 
@@ -81,6 +89,15 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     useTaskPopover();
 
   useBryntumThemeAssets();
+
+  // Sync Bryntum's built-in readOnly flag with our edit-mode state.
+  // This disables cell editing, task drag, task resize, and dependency creation.
+  useEffect(() => {
+    if (isLoading) return;
+    const gantt = getGanttInstance();
+    if (!gantt) return;
+    gantt.readOnly = !editingUnlocked;
+  }, [isLoading, getGanttInstance, editingUnlocked]);
 
   // After data loads, finalize the project so the scheduling engine is ready.
   // delayCalculation defers the initial engine run — commitAsync triggers it.
@@ -469,9 +486,11 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     return () => { detach?.(); };
   }, [isLoading, getGanttInstance, handleTaskClick]);
 
-  // Open task info dialog on double-click of a task bar (replaces Bryntum's built-in task editor)
+  // Open task info dialog on double-click of a task bar (replaces Bryntum's built-in task editor).
+  // Only attach the listener when editing is unlocked — the dialog is an edit surface.
   useEffect(() => {
     if (isLoading) return;
+    if (!editingUnlocked) return;
     const gantt = getGanttInstance();
     if (!gantt) return;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
@@ -480,7 +499,7 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
       setTaskInfoRecord(taskRecord as BryntumTaskRecord);
     }) as (() => void) | undefined;
     return () => { detach?.(); };
-  }, [isLoading, getGanttInstance, closeTaskPopover]);
+  }, [isLoading, getGanttInstance, closeTaskPopover, editingUnlocked]);
 
   // Row action menu — detect clicks on the ⋮ button injected by the name column
   // renderer, then show a programmatic Bryntum Menu at the button position.
@@ -513,6 +532,10 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
       if (!btn || column.type !== 'name') return;
 
       event.stopPropagation();
+
+      // Row action menu contains write actions (add subtask, indent, delete, …) —
+      // don't open it when the chart is locked.
+      if (!editingUnlocked) return;
 
       // Destroy any previously open menu
       if (activeMenuRef.current) {
@@ -590,7 +613,16 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         activeMenuRef.current = null;
       }
     };
-  }, [isLoading, getGanttInstance, closeTaskPopover]);
+  }, [isLoading, getGanttInstance, closeTaskPopover, editingUnlocked]);
+
+  // Close any open row-action menu the moment the chart is locked.
+  useEffect(() => {
+    if (editingUnlocked) return;
+    if (activeMenuRef.current) {
+      activeMenuRef.current.destroy();
+      activeMenuRef.current = null;
+    }
+  }, [editingUnlocked]);
 
   return (
     <div style={WRAPPER_STYLE}>
@@ -606,6 +638,9 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         onRedo={handleRedo}
         canUndo={canUndo}
         canRedo={canRedo}
+        canEditChart={canEditChart}
+        isEditMode={editingUnlocked}
+        onToggleEditMode={() => setIsEditMode((prev) => !prev)}
       />
 
       {/* Bryntum must always render in a visible container so its internal layout
@@ -649,6 +684,10 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         }
         .gantt-row-actions-btn:hover {
           background: rgba(0, 0, 0, 0.04);
+        }
+        /* Hide mutation affordances while the chart is locked. */
+        .bryntum-gantt-container[data-locked="true"] .gantt-row-actions-btn {
+          display: none;
         }
         /* Scroll-to-task button — left of the ⋮ button, uses FA crosshairs icon */
         .gantt-row-scroll-btn {
@@ -703,7 +742,11 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         }
       `}</style>
 
-      <div style={GANTT_CONTENT_STYLE} className="bryntum-gantt-container">
+      <div
+        style={GANTT_CONTENT_STYLE}
+        className="bryntum-gantt-container"
+        data-locked={editingUnlocked ? 'false' : 'true'}
+      >
         <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
           <BryntumGantt ref={ganttRef} {...ganttConfig} />
         </div>

--- a/src/components/bryntum/components/GanttToolbar.tsx
+++ b/src/components/bryntum/components/GanttToolbar.tsx
@@ -12,6 +12,8 @@ import {
   DownloadSimple,
   Columns,
   DotsThreeVertical,
+  Lock,
+  LockOpen,
   Plus,
 } from '@phosphor-icons/react';
 
@@ -83,6 +85,11 @@ type GanttToolbarProps = {
   onRedo?: () => void;
   canUndo?: boolean;
   canRedo?: boolean;
+  /** Whether the current user has permission to unlock the chart for editing. */
+  canEditChart?: boolean;
+  /** Whether the chart is currently unlocked for editing. */
+  isEditMode?: boolean;
+  onToggleEditMode?: () => void;
 };
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -101,7 +108,11 @@ export default function GanttToolbar({
   onRedo,
   canUndo = false,
   canRedo = false,
+  canEditChart = false,
+  isEditMode = false,
+  onToggleEditMode,
 }: GanttToolbarProps) {
+  const editingActive = canEditChart && isEditMode;
   const [activePreset, setActivePreset] = useState('weekAndDayLetter');
   const theme = useTheme();
 
@@ -211,26 +222,28 @@ export default function GanttToolbar({
         </Box>
       </Box>
 
-      {/* ── Undo / Redo ───────────────────────────────────────────────── */}
-      <Box sx={cardContainerSx}>
-        <Box
-          component="button"
-          sx={{ ...cardItemSx, opacity: canUndo ? 1 : 0.35, cursor: canUndo ? 'pointer' : 'default' }}
-          onClick={canUndo ? onUndo : undefined}
-          title="Undo (Ctrl+Z)"
-        >
-          <ArrowUUpLeft size={13} weight="bold" />
+      {/* ── Undo / Redo (only active in edit mode) ───────────────────── */}
+      {editingActive && (
+        <Box sx={{ ...cardContainerSx, animation: 'gantt-tool-pop-in 0.22s cubic-bezier(0.2, 0.9, 0.3, 1.2) both' }}>
+          <Box
+            component="button"
+            sx={{ ...cardItemSx, opacity: canUndo ? 1 : 0.35, cursor: canUndo ? 'pointer' : 'default' }}
+            onClick={canUndo ? onUndo : undefined}
+            title="Undo (Ctrl+Z)"
+          >
+            <ArrowUUpLeft size={13} weight="bold" />
+          </Box>
+          <Box sx={cardDividerSx} />
+          <Box
+            component="button"
+            sx={{ ...cardItemSx, opacity: canRedo ? 1 : 0.35, cursor: canRedo ? 'pointer' : 'default' }}
+            onClick={canRedo ? onRedo : undefined}
+            title="Redo (Ctrl+Y)"
+          >
+            <ArrowUUpRight size={13} weight="bold" />
+          </Box>
         </Box>
-        <Box sx={cardDividerSx} />
-        <Box
-          component="button"
-          sx={{ ...cardItemSx, opacity: canRedo ? 1 : 0.35, cursor: canRedo ? 'pointer' : 'default' }}
-          onClick={canRedo ? onRedo : undefined}
-          title="Redo (Ctrl+Y)"
-        >
-          <ArrowUUpRight size={13} weight="bold" />
-        </Box>
-      </Box>
+      )}
 
       {/* ── Spacer ─────────────────────────────────────────────────────── */}
       <Box sx={{ flex: 1 }} />
@@ -264,8 +277,65 @@ export default function GanttToolbar({
         </Box>
       )}
 
-      {/* ── Add Task ───────────────────────────────────────────────────── */}
-      {onAddTask && (
+      {/* ── Edit / Lock toggle (admin-level users only) ────────────────── */}
+      {canEditChart && (
+        <Box
+          component="button"
+          onClick={onToggleEditMode}
+          title={editingActive ? 'Lock chart (exit edit mode)' : 'Edit chart'}
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.75,
+            height: 34,
+            px: '14px',
+            borderRadius: '10px',
+            fontSize: '12px',
+            fontWeight: 600,
+            fontFamily: 'var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif',
+            letterSpacing: '-0.01em',
+            cursor: 'pointer',
+            transition:
+              'background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.12s ease',
+            '&:active': { transform: 'scale(0.96)' },
+            ...(editingActive
+              ? {
+                  bgcolor: 'var(--accent-primary, #2563eb)',
+                  color: '#fff',
+                  border: '1px solid var(--accent-primary, #2563eb)',
+                  boxShadow: '0 0 0 4px rgba(37, 99, 235, 0.14)',
+                  '&:hover': { filter: 'brightness(0.9)' },
+                }
+              : {
+                  bgcolor: 'var(--bg-card)',
+                  color: 'var(--text-primary)',
+                  border: '1px solid var(--border-color)',
+                  boxShadow: '0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)',
+                  '&:hover': { bgcolor: 'action.hover' },
+                }),
+          }}
+        >
+          <Box
+            key={editingActive ? 'unlocked' : 'locked'}
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              animation: 'gantt-icon-swap 0.32s cubic-bezier(0.2, 0.9, 0.3, 1.2) both',
+            }}
+          >
+            {editingActive ? (
+              <LockOpen size={13} weight="bold" />
+            ) : (
+              <Lock size={13} weight="bold" />
+            )}
+          </Box>
+          {editingActive ? 'Editing' : 'Edit'}
+        </Box>
+      )}
+
+      {/* ── Add Task (only active in edit mode) ────────────────────────── */}
+      {onAddTask && editingActive && (
         <Button
           variant="contained"
           size="small"
@@ -282,6 +352,7 @@ export default function GanttToolbar({
             borderRadius: '8px',
             backgroundColor: 'var(--accent-primary, #2563eb)',
             color: '#fff',
+            animation: 'gantt-tool-pop-in 0.26s cubic-bezier(0.2, 0.9, 0.3, 1.2) both',
             '&:hover': {
               backgroundColor: 'var(--accent-primary, #2563eb)',
               filter: 'brightness(0.9)',
@@ -291,6 +362,29 @@ export default function GanttToolbar({
           Add Task
         </Button>
       )}
+
+      {/* Keyframes for the toolbar micro-animations — scoped via a global <style>. */}
+      <Box
+        component="style"
+        sx={{ display: 'none' }}
+        dangerouslySetInnerHTML={{
+          __html: `
+            @keyframes gantt-tool-pop-in {
+              0%   { opacity: 0; transform: scale(0.9) translateY(2px); }
+              100% { opacity: 1; transform: scale(1) translateY(0); }
+            }
+            @keyframes gantt-icon-swap {
+              0%   { opacity: 0; transform: rotate(-35deg) scale(0.7); }
+              60%  { opacity: 1; transform: rotate(6deg) scale(1.08); }
+              100% { opacity: 1; transform: rotate(0) scale(1); }
+            }
+            @media (prefers-reduced-motion: reduce) {
+              @keyframes gantt-tool-pop-in { from, to { opacity: 1; transform: none; } }
+              @keyframes gantt-icon-swap   { from, to { opacity: 1; transform: none; } }
+            }
+          `,
+        }}
+      />
     </Stack>
   );
 }


### PR DESCRIPTION
Closes #91.

## Summary
- Gantt chart now opens in a read-only state for all users; admins (`canManageProjects`) get an Edit/Lock toggle in the toolbar.
- When locked, Bryntum's `readOnly` flag is set (disables cell edits, drag, resize, dependency creation) and React-level handlers for double-click edit, row-action menu, undo/redo, and Add Task are hidden/suppressed.
- Toolbar includes small pop-in animations for the revealed controls and an icon swap on the lock/unlock button, with `prefers-reduced-motion` fallback.

## Test plan
- [ ] Sign in as an org owner/admin/project_manager → Gantt loads locked; clicking Edit reveals undo/redo + Add Task, enables double-click editor and row-action menu.
- [ ] Sign in as member/viewer → no Edit button visible; chart remains read-only; Bryntum drag/resize/cell-edit disabled.
- [ ] Toggle Lock mid-session → open row-action menu closes immediately; double-click on a task bar no longer opens the info dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)