### PR TITLE
Show month and day number in Gantt Week view header

### DIFF
--- a/src/components/bryntum/components/GanttToolbar.tsx
+++ b/src/components/bryntum/components/GanttToolbar.tsx
@@ -18,7 +18,7 @@ import {
 // ─── Constants ────────────────────────────────────────────────────────────────
 const VIEW_PRESETS = [
   { label: 'Day',   value: 'hourAndDay' },
-  { label: 'Week',  value: 'weekAndDayLetter' },
+  { label: 'Week',  value: 'weekAndDayLetterCompact' },
   { label: 'Month', value: 'weekAndMonth' },
   { label: 'Year',  value: 'monthAndYear' },
 ] as const;
@@ -102,7 +102,7 @@ export default function GanttToolbar({
   canUndo = false,
   canRedo = false,
 }: GanttToolbarProps) {
-  const [activePreset, setActivePreset] = useState('weekAndDayLetter');
+  const [activePreset, setActivePreset] = useState('weekAndDayLetterCompact');
   const theme = useTheme();
 
   const handlePresetClick = (preset: string) => {

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -47,6 +47,13 @@ export function createGanttConfig(
     animateTreeNodeToggle: false, // Disable animations for faster rendering
     detectCSSCompatibilityIssues: false,
 
+    // Virtualize the time axis so the user can switch to fine-grained presets
+    // (e.g. hourAndDay) over a multi-year startDate/endDate span without
+    // Bryntum throwing "Configured date range will result in a too long time axis".
+    // Only `bufferCoef × viewport` worth of ticks are rendered at once; the
+    // range slides as the user scrolls.
+    infiniteScroll: true,
+
     project: {
       autoLoad: true,
       autoSync: false,
@@ -170,7 +177,17 @@ export function createGanttConfig(
       },
     },
     emptyText: 'No tasks yet — click "+ Add Task" above or double-click here to get started',
-    viewPreset: 'weekAndDayLetter',
+    presets: [
+      {
+        id: 'weekAndDayLetterCompact',
+        base: 'weekAndDayLetter',
+        headers: [
+          { unit: 'month', dateFormat: 'MMMM YYYY' },
+          { unit: 'day', dateFormat: 'DD' },
+        ],
+      },
+    ],
+    viewPreset: 'weekAndDayLetterCompact',
     startDate: new Date(new Date().getFullYear(), new Date().getMonth() - 3, 1),
     endDate: new Date(new Date().getFullYear(), new Date().getMonth() + 24, 1),
     barMargin: 10,

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -229,6 +229,11 @@ export type GanttConfig = {
   };
   emptyText?: string;
   viewPreset: string;
+  presets?: Array<{
+    id: string;
+    base?: string;
+    headers?: Array<{ unit: string; dateFormat: string }>;
+  }>;
   startDate?: Date;
   endDate?: Date;
   barMargin: number;


### PR DESCRIPTION
## Summary
- Replaces the built-in `weekAndDayLetter` top row (e.g. `SUN 29 MAR 2026`) with a custom preset that shows the month name + year on top and the day number below, matching the reference layout in issue #98.
- Registers the preset via `presets: [{ id: 'weekAndDayLetterCompact', base: 'weekAndDayLetter', headers: [...] }]` so the toolbar's Week button can still switch to it by id.
- Enables `infiniteScroll` so the multi-year `startDate`/`endDate` range doesn't overflow Bryntum's time axis under finer-grained presets.

Closes #98

## Test plan
- [ ] Open any project's Gantt page and click the **Week** toolbar button — top header reads `September 2020` style, bottom row shows `15, 16, 17…`.
- [ ] Verify Day / Month / Year presets still behave as before.
- [ ] Reload the page with Week selected — the Week button remains highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)