### PR TITLE
Split project Manage tab into Team and Settings routes

### DIFF
--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/settings/page.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/settings/page.tsx
@@ -4,13 +4,13 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
-  Trash, Warning, PlusCircle, MapPin, Swatches, CaretDown,
+  Trash, Warning, MapPin, Swatches, CaretDown,
   Image as ImageIcon, UploadSimple, X, FloppyDisk,
 } from '@phosphor-icons/react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import {
   Autocomplete as MuiAutocomplete,
-  Box, Typography, Tabs, Tab, Paper, Popover, TextField,
+  Box, Typography, Paper, Popover, TextField,
   CircularProgress, IconButton, Tooltip,
 } from '@mui/material';
 import { useTheme, alpha, type Theme } from '@mui/material/styles';
@@ -19,17 +19,13 @@ import { useRouter, useParams } from 'next/navigation';
 import { useDropzone } from 'react-dropzone';
 import usePlacesAutocomplete, { getGeocode } from 'use-places-autocomplete';
 import { api } from '@/trpc/react';
-import { canInviteMembers, canDeleteProjects, canManageProjects } from '@/lib/permissions';
+import { canDeleteProjects, canManageProjects } from '@/lib/permissions';
 import { updateProjectSchema, type UpdateProjectInput } from '@/lib/validations/project';
 import { PROJECT_ICON_OPTIONS, getProjectIcon } from '@/lib/constants/projectIconComponents';
 import ProjectAvatar from '@/components/ui/ProjectAvatar';
-import InviteDialog from '@/components/team/InviteDialog';
-import MembersList from '@/components/team/MembersList';
-import PendingInvitesList from '@/components/team/PendingInvitesList';
 import DeleteProjectDialog from '@/components/projects/DeleteProjectDialog';
 import { Button } from '@/components/ui/button';
 import { useProjectContext } from '@/components/providers/ProjectProvider';
-import { useOrgContext } from '@/components/providers/OrgProvider';
 import { useSnackbar } from '@/hooks/useSnackbar';
 import { env } from '@/env';
 
@@ -122,7 +118,7 @@ function PlainLocationField({
 }
 
 // ---------------------------------------------------------------------------
-// Settings Form (extracted for clarity)
+// Settings Form
 // ---------------------------------------------------------------------------
 
 function ProjectSettingsForm({
@@ -158,7 +154,6 @@ function ProjectSettingsForm({
   const SelectedIconComponent = getProjectIcon(selectedIcon);
   const selectedIconLabel = PROJECT_ICON_OPTIONS.find(o => o.id === selectedIcon)?.label ?? 'Building';
 
-  // Track whether image changed relative to original
   const imageChanged = imageUrl !== (projectImageUrl ?? undefined);
 
   const cleanupUploadedImage = useCallback((url?: string) => {
@@ -173,7 +168,6 @@ function ProjectSettingsForm({
     }
   }, [organizationId]);
 
-  // Cleanup orphaned upload on unmount
   useEffect(() => {
     return () => {
       if (uploadedUrlRef.current) {
@@ -197,9 +191,8 @@ function ProjectSettingsForm({
       void utils.project.list.invalidate();
       void utils.project.getActive.invalidate();
       void utils.project.getBySlug.invalidate();
-      // If slug changed, navigate to the new URL
       if (updated.slug !== params.projectSlug) {
-        router.replace(`/${params.orgSlug}/projects/${updated.slug}/manage`);
+        router.replace(`/${params.orgSlug}/projects/${updated.slug}/settings`);
       }
     },
     onError: (err) => {
@@ -211,7 +204,6 @@ function ProjectSettingsForm({
     updateMutation.mutate({ ...data, projectId });
   };
 
-  // Photo upload
   const handlePhotoDrop = useCallback(async (acceptedFiles: File[]) => {
     const file = acceptedFiles[0];
     if (!file || !organizationId) return;
@@ -535,44 +527,23 @@ function ProjectSettingsForm({
 }
 
 // ---------------------------------------------------------------------------
-// Main Manage Page
+// Settings Page
 // ---------------------------------------------------------------------------
 
-type ManageTab = 'members' | 'pending' | 'settings';
-
-export default function ManagePage() {
+export default function ProjectSettingsPage() {
   const theme = useTheme();
-  const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<ManageTab>('members');
 
   const { projectId, projectName, organizationId } = useProjectContext();
-  const { orgId } = useOrgContext();
 
-  const { data: members = [], isLoading: membersLoading } = api.projectMember.list.useQuery(
+  const { data: members = [] } = api.projectMember.list.useQuery(
     { projectId },
     { enabled: !!projectId }
   );
-
-  const { data: invitations = [], isLoading: invitationsLoading } =
-    api.invitation.list.useQuery({ projectId }, { enabled: !!projectId });
-
   const { data: currentUser } = api.user.me.useQuery();
-
-  const currentMembership = members.find(
-    (m) => m.user.id === currentUser?.id
-  );
-  const canManage = currentMembership ? canInviteMembers(currentMembership.role) : false;
+  const currentMembership = members.find((m) => m.user.id === currentUser?.id);
   const canDelete = currentMembership ? canDeleteProjects(currentMembership.role) : false;
   const canEdit = currentMembership ? canManageProjects(currentMembership.role) : false;
-
-  const pendingCount = invitations.filter((inv) => inv.status === 'pending').length;
-
-  useEffect(() => {
-    if (pendingCount === 0 && activeTab === 'pending') {
-      setActiveTab('members');
-    }
-  }, [pendingCount, activeTab]);
 
   return (
     <Box
@@ -586,7 +557,7 @@ export default function ManagePage() {
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
         <Box>
           <Typography variant="h5" sx={{ fontWeight: 600, color: 'text.primary' }}>
-            Manage
+            Project Settings
           </Typography>
           <Typography variant="body2" sx={{ color: 'text.disabled', mt: 0.5 }}>
             {projectName}
@@ -594,23 +565,6 @@ export default function ManagePage() {
         </Box>
       </Box>
 
-      {/* Tabs */}
-      <Box sx={{ mb: 3 }}>
-        <Tabs
-          value={activeTab}
-          onChange={(_, newValue) => setActiveTab(newValue)}
-          sx={{
-            borderBottom: 1, borderColor: 'divider',
-            '& .MuiTab-root': { textTransform: 'none', fontWeight: 500, fontSize: '0.875rem' },
-          }}
-        >
-          <Tab label={`Members (${members.length})`} value="members" />
-          {pendingCount > 0 && <Tab label={`Pending (${pendingCount})`} value="pending" />}
-          <Tab label="Settings" value="settings" />
-        </Tabs>
-      </Box>
-
-      {/* Tab Content */}
       <Paper
         elevation={0}
         sx={{
@@ -621,120 +575,61 @@ export default function ManagePage() {
           transition: 'border-color 0.2s ease',
         }}
       >
-        <AnimatePresence mode="wait">
-          {activeTab === 'members' && (
-            <Box component={motion.div} key="members"
-              initial={{ opacity: 0 }} animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }} transition={{ duration: 0.15 }}
-              sx={{ p: 2 }}>
-              {canManage && (
-                <Box onClick={() => setInviteDialogOpen(true)}
-                  sx={{
-                    display: 'flex', alignItems: 'center', gap: 1.5,
-                    p: 1.75, mb: 1.5, borderRadius: '12px', cursor: 'pointer',
-                    transition: 'background-color 0.2s',
-                    '&:hover': { bgcolor: 'action.hover' },
-                  }}>
-                  <Box sx={{
-                    width: 38, height: 38, borderRadius: '50%',
-                    bgcolor: alpha(theme.palette.primary.main, 0.08),
-                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  }}>
-                    <PlusCircle size={20} weight="light" color={theme.palette.primary.main} />
-                  </Box>
-                  <Typography sx={{ fontWeight: 600, fontSize: '0.875rem', color: 'text.primary' }}>
-                    Invite Member
-                  </Typography>
-                </Box>
-              )}
-              <MembersList members={members} isLoading={membersLoading} />
-            </Box>
-          )}
+        {/* Project Details — edit form */}
+        {canEdit ? (
+          <ProjectSettingsForm projectId={projectId} organizationId={organizationId} />
+        ) : (
+          <Box sx={{ px: 3, py: 2.5 }}>
+            <Typography sx={{ color: 'text.disabled', fontSize: '0.875rem' }}>
+              Only project owners, admins, and project managers can edit project settings.
+            </Typography>
+          </Box>
+        )}
 
-          {activeTab === 'pending' && (
-            <Box component={motion.div} key="pending"
-              initial={{ opacity: 0 }} animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }} transition={{ duration: 0.15 }}
-              sx={{ p: 2 }}>
-              {pendingCount > 0 ? (
-                <PendingInvitesList invitations={invitations} isLoading={invitationsLoading}
-                  projectId={projectId} canManage={canManage} />
-              ) : (
-                <Typography sx={{ textAlign: 'center', color: 'text.disabled', py: 4 }}>
-                  No pending invitations
+        {/* Danger Zone — delete */}
+        {canDelete && (
+          <>
+            <Box sx={{
+              px: 3, py: 1.5,
+              bgcolor: alpha(theme.palette.error.main, 0.04),
+              borderTop: '1px solid',
+              borderBottom: '1px solid',
+              borderColor: alpha(theme.palette.error.main, 0.15),
+              display: 'flex', alignItems: 'center', gap: 1,
+            }}>
+              <Warning size={14} color={theme.palette.error.main} />
+              <Typography sx={{
+                fontSize: '0.75rem', fontWeight: 600, color: 'error.main',
+                textTransform: 'uppercase', letterSpacing: '0.05em',
+              }}>
+                Danger Zone
+              </Typography>
+            </Box>
+            <Box sx={{
+              px: 3, py: 2.5, display: 'flex', alignItems: 'center',
+              justifyContent: 'space-between', gap: 2,
+            }}>
+              <Box>
+                <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary', mb: 0.25 }}>
+                  Delete this project
                 </Typography>
-              )}
+                <Typography sx={{ fontSize: '0.8125rem', color: 'text.secondary', lineHeight: 1.5 }}>
+                  Permanently delete this project and all its data. This cannot be undone.
+                </Typography>
+              </Box>
+              <Button variant="outlined" color="error"
+                onClick={() => setDeleteDialogOpen(true)}
+                startIcon={<Trash size={14} />}
+                sx={{
+                  flexShrink: 0, borderRadius: '8px', fontWeight: 600,
+                  fontSize: '0.8125rem', textTransform: 'none',
+                }}>
+                Delete
+              </Button>
             </Box>
-          )}
-
-          {activeTab === 'settings' && (
-            <Box component={motion.div} key="settings"
-              initial={{ opacity: 0 }} animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }} transition={{ duration: 0.15 }}>
-              {/* Project Details — edit form */}
-              {canEdit ? (
-                <ProjectSettingsForm projectId={projectId} organizationId={organizationId} />
-              ) : (
-                <Box sx={{ px: 3, py: 2.5 }}>
-                  <Typography sx={{ color: 'text.disabled', fontSize: '0.875rem' }}>
-                    Only project owners, admins, and project managers can edit project settings.
-                  </Typography>
-                </Box>
-              )}
-
-              {/* Danger Zone — delete */}
-              {canDelete && (
-                <>
-                  <Box sx={{
-                    px: 3, py: 1.5,
-                    bgcolor: alpha(theme.palette.error.main, 0.04),
-                    borderTop: '1px solid',
-                    borderBottom: '1px solid',
-                    borderColor: alpha(theme.palette.error.main, 0.15),
-                    display: 'flex', alignItems: 'center', gap: 1,
-                  }}>
-                    <Warning size={14} color={theme.palette.error.main} />
-                    <Typography sx={{
-                      fontSize: '0.75rem', fontWeight: 600, color: 'error.main',
-                      textTransform: 'uppercase', letterSpacing: '0.05em',
-                    }}>
-                      Danger Zone
-                    </Typography>
-                  </Box>
-                  <Box sx={{
-                    px: 3, py: 2.5, display: 'flex', alignItems: 'center',
-                    justifyContent: 'space-between', gap: 2,
-                  }}>
-                    <Box>
-                      <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary', mb: 0.25 }}>
-                        Delete this project
-                      </Typography>
-                      <Typography sx={{ fontSize: '0.8125rem', color: 'text.secondary', lineHeight: 1.5 }}>
-                        Permanently delete this project and all its data. This cannot be undone.
-                      </Typography>
-                    </Box>
-                    <Button variant="outlined" color="error"
-                      onClick={() => setDeleteDialogOpen(true)}
-                      startIcon={<Trash size={14} />}
-                      sx={{
-                        flexShrink: 0, borderRadius: '8px', fontWeight: 600,
-                        fontSize: '0.8125rem', textTransform: 'none',
-                      }}>
-                      Delete
-                    </Button>
-                  </Box>
-                </>
-              )}
-            </Box>
-          )}
-        </AnimatePresence>
+          </>
+        )}
       </Paper>
-
-      {/* Invite Dialog */}
-      {canManage && (
-        <InviteDialog open={inviteDialogOpen} onOpenChange={setInviteDialogOpen}
-          organizationId={organizationId} projectId={projectId} />
-      )}
 
       {/* Delete Project Dialog */}
       <DeleteProjectDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/team/page.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/team/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { PlusCircle } from '@phosphor-icons/react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Box, Typography, Tabs, Tab, Paper } from '@mui/material';
+import { useTheme, alpha } from '@mui/material/styles';
+import { api } from '@/trpc/react';
+import { canInviteMembers } from '@/lib/permissions';
+import InviteDialog from '@/components/team/InviteDialog';
+import MembersList from '@/components/team/MembersList';
+import PendingInvitesList from '@/components/team/PendingInvitesList';
+import { useProjectContext } from '@/components/providers/ProjectProvider';
+
+type TeamTab = 'members' | 'pending';
+
+export default function TeamPage() {
+  const theme = useTheme();
+  const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<TeamTab>('members');
+
+  const { projectId, projectName, organizationId } = useProjectContext();
+
+  const { data: members = [], isLoading: membersLoading } = api.projectMember.list.useQuery(
+    { projectId },
+    { enabled: !!projectId }
+  );
+
+  const { data: invitations = [], isLoading: invitationsLoading } =
+    api.invitation.list.useQuery({ projectId }, { enabled: !!projectId });
+
+  const { data: currentUser } = api.user.me.useQuery();
+
+  const currentMembership = members.find((m) => m.user.id === currentUser?.id);
+  const canManage = currentMembership ? canInviteMembers(currentMembership.role) : false;
+
+  const pendingCount = invitations.filter((inv) => inv.status === 'pending').length;
+
+  useEffect(() => {
+    if (pendingCount === 0 && activeTab === 'pending') {
+      setActiveTab('members');
+    }
+  }, [pendingCount, activeTab]);
+
+  return (
+    <Box
+      component={motion.div}
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+      sx={{ p: 3, maxWidth: 800, mx: 'auto' }}
+    >
+      {/* Header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
+        <Box>
+          <Typography variant="h5" sx={{ fontWeight: 600, color: 'text.primary' }}>
+            Team
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'text.disabled', mt: 0.5 }}>
+            {projectName}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Tabs */}
+      <Box sx={{ mb: 3 }}>
+        <Tabs
+          value={activeTab}
+          onChange={(_, newValue) => setActiveTab(newValue)}
+          sx={{
+            borderBottom: 1, borderColor: 'divider',
+            '& .MuiTab-root': { textTransform: 'none', fontWeight: 500, fontSize: '0.875rem' },
+          }}
+        >
+          <Tab label={`Members (${members.length})`} value="members" />
+          {pendingCount > 0 && <Tab label={`Pending (${pendingCount})`} value="pending" />}
+        </Tabs>
+      </Box>
+
+      {/* Tab Content */}
+      <Paper
+        elevation={0}
+        sx={{
+          border: 1,
+          borderColor: 'divider',
+          borderRadius: '12px',
+          overflow: 'hidden',
+          transition: 'border-color 0.2s ease',
+        }}
+      >
+        <AnimatePresence mode="wait">
+          {activeTab === 'members' && (
+            <Box component={motion.div} key="members"
+              initial={{ opacity: 0 }} animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }} transition={{ duration: 0.15 }}
+              sx={{ p: 2 }}>
+              {canManage && (
+                <Box onClick={() => setInviteDialogOpen(true)}
+                  sx={{
+                    display: 'flex', alignItems: 'center', gap: 1.5,
+                    p: 1.75, mb: 1.5, borderRadius: '12px', cursor: 'pointer',
+                    transition: 'background-color 0.2s',
+                    '&:hover': { bgcolor: 'action.hover' },
+                  }}>
+                  <Box sx={{
+                    width: 38, height: 38, borderRadius: '50%',
+                    bgcolor: alpha(theme.palette.primary.main, 0.08),
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  }}>
+                    <PlusCircle size={20} weight="light" color={theme.palette.primary.main} />
+                  </Box>
+                  <Typography sx={{ fontWeight: 600, fontSize: '0.875rem', color: 'text.primary' }}>
+                    Invite Member
+                  </Typography>
+                </Box>
+              )}
+              <MembersList members={members} isLoading={membersLoading} />
+            </Box>
+          )}
+
+          {activeTab === 'pending' && (
+            <Box component={motion.div} key="pending"
+              initial={{ opacity: 0 }} animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }} transition={{ duration: 0.15 }}
+              sx={{ p: 2 }}>
+              {pendingCount > 0 ? (
+                <PendingInvitesList invitations={invitations} isLoading={invitationsLoading}
+                  projectId={projectId} canManage={canManage} />
+              ) : (
+                <Typography sx={{ textAlign: 'center', color: 'text.disabled', py: 4 }}>
+                  No pending invitations
+                </Typography>
+              )}
+            </Box>
+          )}
+        </AnimatePresence>
+      </Paper>
+
+      {/* Invite Dialog */}
+      {canManage && (
+        <InviteDialog open={inviteDialogOpen} onOpenChange={setInviteDialogOpen}
+          organizationId={organizationId} projectId={projectId} />
+      )}
+    </Box>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -25,7 +25,7 @@ const PAGE_TITLES: Record<string, string> = {
   files: 'File Tree',
   'document-explorer': 'Document Explorer',
   team: 'Team',
-  manage: 'Manage',
+  settings: 'Project Settings',
 };
 
 interface HeaderProps {

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -5,16 +5,19 @@ import Link from 'next/link';
 import { usePathname, useParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { User, Settings, CreditCard, LifeBuoy, LogOut, ChevronRight } from 'lucide-react';
-import { ChartBar, FolderSimple, FileMagnifyingGlass, GearSix, X, type Icon } from '@phosphor-icons/react';
+import { ChartBar, FolderSimple, FileMagnifyingGlass, GearSix, UsersThree, X, type Icon } from '@phosphor-icons/react';
 import { Drawer, Box, IconButton, Typography } from '@mui/material';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { projectNavItems, getProjectNavHref } from './navItems';
+import { projectNavItems, getProjectNavHref, SIDEBAR_SECTIONS } from './navItems';
 import OrgSwitcher from './OrgSwitcher';
 
+import { api } from '@/trpc/react';
+import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
+import { useProjectSwitcher } from '@/hooks/useProjectSwitcher';
 import { authClient, signOut } from '@/lib/auth-client';
 import { getInitials } from '@/lib/utils/formatting';
 import LoadingSpinner from '@/components/ui/loading-spinner';
@@ -26,6 +29,7 @@ const iconMap: Record<string, Icon> = {
   FolderSimple,
   FileMagnifyingGlass,
   GearSix,
+  UsersThree,
 };
 
 interface MobileDrawerProps {
@@ -49,6 +53,15 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
   const { data: session } = authClient.useSession();
   const user = session?.user;
   const { showLoading, hideLoading } = useLoading();
+
+  const { activeOrganizationId } = useOrgFromUrl();
+  const { currentProject } = useProjectSwitcher(activeOrganizationId, orgSlug ?? '');
+  const projectId = currentProject?.id ?? '';
+  const { data: projectMembers = [] } = api.projectMember.list.useQuery(
+    { projectId },
+    { enabled: !!projectId, retry: false },
+  );
+  const memberCount = projectMembers.length;
 
   const [profileOpen, setProfileOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
@@ -133,110 +146,135 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
           overflow: 'hidden',
         }}
       >
-        {/* Section Label */}
-        <Typography
-          sx={{
-            fontSize: '0.5625rem',
-            fontWeight: 600,
-            color: 'text.disabled',
-            letterSpacing: '0.12em',
-            textTransform: 'uppercase',
-            px: 1,
-            pb: 1,
-            userSelect: 'none',
-          }}
-        >
-          Navigation
-        </Typography>
+        {/* Grouped Nav Sections */}
+        {SIDEBAR_SECTIONS.map((section, sectionIdx) => {
+          const items = projectNavItems.filter((i) => i.section === section.id);
+          if (items.length === 0) return null;
 
-        {/* Nav Items */}
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1px' }}>
-          {projectNavItems.map((item) => {
-            const NavIcon = iconMap[item.icon] ?? ChartBar;
-            const href = getProjectNavHref(item.segment, orgSlug, projectSlug);
-            const isActive = !!(projectSlug && pathname.includes(`/projects/${projectSlug}/${item.segment}`));
-            const isDisabled = !projectSlug;
-
-            const content = (
-              <Box
+          return (
+            <Box key={section.id} sx={{ mb: sectionIdx < SIDEBAR_SECTIONS.length - 1 ? 2 : 0 }}>
+              <Typography
                 sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1.25,
-                  px: 1.25,
-                  py: 0.875,
-                  borderRadius: '8px',
-                  position: 'relative',
-                  transition: 'all 0.15s ease',
-                  bgcolor: isActive ? 'sidebar.activeItemBg' : 'transparent',
-                  color: isActive ? 'text.primary' : 'text.secondary',
-                  opacity: isDisabled ? 0.35 : 1,
-                  cursor: isDisabled ? 'default' : 'pointer',
-                  overflow: 'hidden',
-                  '&:hover': isDisabled ? {} : {
-                    bgcolor: isActive ? 'sidebar.activeItemBg' : 'sidebar.hoverBg',
-                    color: 'text.primary',
-                  },
+                  fontSize: '0.5625rem',
+                  fontWeight: 600,
+                  color: 'text.disabled',
+                  letterSpacing: '0.12em',
+                  textTransform: 'uppercase',
+                  px: 1,
+                  pb: 1,
+                  userSelect: 'none',
                 }}
               >
-                {/* Active Indicator — thin left accent */}
-                {isActive && (
-                  <Box
-                    sx={{
-                      position: 'absolute',
-                      left: 0,
-                      top: '50%',
-                      transform: 'translateY(-50%)',
-                      width: '2.5px',
-                      height: 16,
-                      borderRadius: '0 2px 2px 0',
-                      bgcolor: 'sidebar.indicator',
-                    }}
-                    aria-hidden="true"
-                  />
-                )}
+                {section.label}
+              </Typography>
 
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 20, height: 20, flexShrink: 0 }}>
-                  <NavIcon size={17} weight={isActive ? 'fill' : 'regular'} />
-                </Box>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1px' }}>
+                {items.map((item) => {
+                  const NavIcon = iconMap[item.icon] ?? ChartBar;
+                  const href = getProjectNavHref(item.segment, orgSlug, projectSlug);
+                  const isActive = !!(projectSlug && pathname.includes(`/projects/${projectSlug}/${item.segment}`));
+                  const isDisabled = !projectSlug;
+                  const badgeCount = item.id === 'team' && !isDisabled ? memberCount : null;
 
-                <Typography
-                  sx={{
-                    fontSize: '0.8125rem',
-                    fontWeight: isActive ? 550 : 400,
-                    letterSpacing: isActive ? '-0.005em' : '0',
-                    lineHeight: 1,
-                    flex: 1,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  {item.label}
-                </Typography>
+                  const content = (
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1.25,
+                        px: 1.25,
+                        py: 0.875,
+                        borderRadius: '8px',
+                        position: 'relative',
+                        transition: 'all 0.15s ease',
+                        bgcolor: isActive ? 'sidebar.activeItemBg' : 'transparent',
+                        color: isActive ? 'text.primary' : 'text.secondary',
+                        opacity: isDisabled ? 0.35 : 1,
+                        cursor: isDisabled ? 'default' : 'pointer',
+                        overflow: 'hidden',
+                        '&:hover': isDisabled ? {} : {
+                          bgcolor: isActive ? 'sidebar.activeItemBg' : 'sidebar.hoverBg',
+                          color: 'text.primary',
+                        },
+                      }}
+                    >
+                      {/* Active Indicator — thin left accent */}
+                      {isActive && (
+                        <Box
+                          sx={{
+                            position: 'absolute',
+                            left: 0,
+                            top: '50%',
+                            transform: 'translateY(-50%)',
+                            width: '2.5px',
+                            height: 16,
+                            borderRadius: '0 2px 2px 0',
+                            bgcolor: 'sidebar.indicator',
+                          }}
+                          aria-hidden="true"
+                        />
+                      )}
 
-                {/* Subtle arrow for active item */}
-                {isActive && (
-                  <ChevronRight style={{ width: 13, height: 13, opacity: 0.4, flexShrink: 0 }} />
-                )}
+                      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 20, height: 20, flexShrink: 0 }}>
+                        <NavIcon size={17} weight={isActive ? 'fill' : 'regular'} />
+                      </Box>
+
+                      <Typography
+                        sx={{
+                          fontSize: '0.8125rem',
+                          fontWeight: isActive ? 550 : 400,
+                          letterSpacing: isActive ? '-0.005em' : '0',
+                          lineHeight: 1,
+                          flex: 1,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {item.label}
+                      </Typography>
+
+                      {badgeCount !== null && badgeCount > 0 && !isActive && (
+                        <Typography
+                          sx={{
+                            fontSize: '0.6875rem',
+                            fontWeight: 500,
+                            color: 'text.disabled',
+                            lineHeight: 1,
+                            flexShrink: 0,
+                            minWidth: 16,
+                            textAlign: 'right',
+                          }}
+                        >
+                          {badgeCount}
+                        </Typography>
+                      )}
+
+                      {/* Subtle arrow for active item */}
+                      {isActive && (
+                        <ChevronRight style={{ width: 13, height: 13, opacity: 0.4, flexShrink: 0 }} />
+                      )}
+                    </Box>
+                  );
+
+                  if (isDisabled) {
+                    return <Box key={item.id}>{content}</Box>;
+                  }
+
+                  return (
+                    <Link
+                      key={item.id}
+                      href={href}
+                      style={{ textDecoration: 'none', color: 'inherit' }}
+                    >
+                      {content}
+                    </Link>
+                  );
+                })}
               </Box>
-            );
-
-            if (isDisabled) {
-              return <Box key={item.id}>{content}</Box>;
-            }
-
-            return (
-              <Link
-                key={item.id}
-                href={href}
-                style={{ textDecoration: 'none', color: 'inherit' }}
-              >
-                {content}
-              </Link>
-            );
-          })}
-        </Box>
+            </Box>
+          );
+        })}
       </Box>
 
       {/* User Profile */}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,16 +4,19 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname, useParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
-import { User, ChartBar, FolderSimple, FileMagnifyingGlass, GearSix, CaretRight, CaretLineLeft, CaretLineRight, CreditCard, Lifebuoy, SignOut, type Icon } from '@phosphor-icons/react';
+import { User, ChartBar, FolderSimple, FileMagnifyingGlass, GearSix, UsersThree, CaretRight, CaretLineLeft, CaretLineRight, CreditCard, Lifebuoy, SignOut, type Icon } from '@phosphor-icons/react';
 import { Box, Typography, Tooltip } from '@mui/material';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { projectNavItems, getProjectNavHref } from './navItems';
+import { projectNavItems, getProjectNavHref, SIDEBAR_SECTIONS } from './navItems';
 import OrgSwitcher from './OrgSwitcher';
 
+import { api } from '@/trpc/react';
+import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
+import { useProjectSwitcher } from '@/hooks/useProjectSwitcher';
 import { authClient, signOut } from '@/lib/auth-client';
 import { getInitials } from '@/lib/utils/formatting';
 import LoadingSpinner from '@/components/ui/loading-spinner';
@@ -28,6 +31,7 @@ const iconMap: Record<string, Icon> = {
   FolderSimple,
   FileMagnifyingGlass,
   GearSix,
+  UsersThree,
 };
 
 const profileMenuItems = [
@@ -51,6 +55,15 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
   const { data: session } = authClient.useSession();
   const user = session?.user;
   const { showLoading, hideLoading } = useLoading();
+
+  const { activeOrganizationId } = useOrgFromUrl();
+  const { currentProject } = useProjectSwitcher(activeOrganizationId, orgSlug ?? '');
+  const projectId = currentProject?.id ?? '';
+  const { data: projectMembers = [] } = api.projectMember.list.useQuery(
+    { projectId },
+    { enabled: !!projectId, retry: false },
+  );
+  const memberCount = projectMembers.length;
 
   const [profileOpen, setProfileOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
@@ -141,125 +154,150 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
           transition: 'padding 0.2s ease',
         }}
       >
-        {/* Section Label */}
-        {!collapsed && (
-          <Typography
-            sx={{
-              fontSize: '0.5625rem',
-              fontWeight: 600,
-              color: 'text.disabled',
-              letterSpacing: '0.12em',
-              textTransform: 'uppercase',
-              px: 1,
-              pb: 1,
-              userSelect: 'none',
-            }}
-          >
-            Navigation
-          </Typography>
-        )}
+        {/* Grouped Nav Sections */}
+        {SIDEBAR_SECTIONS.map((section, sectionIdx) => {
+          const items = projectNavItems.filter((i) => i.section === section.id);
+          if (items.length === 0) return null;
 
-        {/* Nav Items */}
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1px' }}>
-          {projectNavItems.map((item) => {
-            const NavIcon = iconMap[item.icon] ?? ChartBar;
-            const href = getProjectNavHref(item.segment, orgSlug, projectSlug);
-            const isActive = !!(projectSlug && pathname.includes(`/projects/${projectSlug}/${item.segment}`));
-            const isDisabled = !projectSlug;
+          return (
+            <Box key={section.id} sx={{ mb: sectionIdx < SIDEBAR_SECTIONS.length - 1 ? 2 : 0 }}>
+              {!collapsed && (
+                <Typography
+                  sx={{
+                    fontSize: '0.5625rem',
+                    fontWeight: 600,
+                    color: 'text.disabled',
+                    letterSpacing: '0.12em',
+                    textTransform: 'uppercase',
+                    px: 1,
+                    pb: 1,
+                    userSelect: 'none',
+                  }}
+                >
+                  {section.label}
+                </Typography>
+              )}
 
-            const content = (
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: collapsed ? 'center' : 'flex-start',
-                  gap: collapsed ? 0 : 1.25,
-                  px: collapsed ? 0 : 1.25,
-                  py: 0.875,
-                  borderRadius: '8px',
-                  position: 'relative',
-                  transition: 'all 0.15s ease',
-                  bgcolor: isActive ? 'sidebar.activeItemBg' : 'transparent',
-                  color: isActive ? 'text.primary' : 'text.secondary',
-                  opacity: isDisabled ? 0.35 : 1,
-                  cursor: isDisabled ? 'default' : 'pointer',
-                  overflow: 'hidden',
-                  '&:hover': isDisabled ? {} : {
-                    bgcolor: isActive ? 'sidebar.activeItemBg' : 'sidebar.hoverBg',
-                    color: 'text.primary',
-                  },
-                }}
-              >
-                {/* Active Indicator — thin left accent */}
-                {isActive && (
-                  <Box
-                    sx={{
-                      position: 'absolute',
-                      left: 0,
-                      top: '50%',
-                      transform: 'translateY(-50%)',
-                      width: '2.5px',
-                      height: 16,
-                      borderRadius: '0 2px 2px 0',
-                      bgcolor: 'sidebar.indicator',
-                    }}
-                    aria-hidden="true"
-                  />
-                )}
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1px' }}>
+                {items.map((item) => {
+                  const NavIcon = iconMap[item.icon] ?? ChartBar;
+                  const href = getProjectNavHref(item.segment, orgSlug, projectSlug);
+                  const isActive = !!(projectSlug && pathname.includes(`/projects/${projectSlug}/${item.segment}`));
+                  const isDisabled = !projectSlug;
+                  const badgeCount = item.id === 'team' && !isDisabled ? memberCount : null;
 
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 20, height: 20, flexShrink: 0 }}>
-                  <NavIcon size={17} weight={isActive ? 'fill' : 'regular'} />
-                </Box>
+                  const content = (
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: collapsed ? 'center' : 'flex-start',
+                        gap: collapsed ? 0 : 1.25,
+                        px: collapsed ? 0 : 1.25,
+                        py: 0.875,
+                        borderRadius: '8px',
+                        position: 'relative',
+                        transition: 'all 0.15s ease',
+                        bgcolor: isActive ? 'sidebar.activeItemBg' : 'transparent',
+                        color: isActive ? 'text.primary' : 'text.secondary',
+                        opacity: isDisabled ? 0.35 : 1,
+                        cursor: isDisabled ? 'default' : 'pointer',
+                        overflow: 'hidden',
+                        '&:hover': isDisabled ? {} : {
+                          bgcolor: isActive ? 'sidebar.activeItemBg' : 'sidebar.hoverBg',
+                          color: 'text.primary',
+                        },
+                      }}
+                    >
+                      {/* Active Indicator — thin left accent */}
+                      {isActive && (
+                        <Box
+                          sx={{
+                            position: 'absolute',
+                            left: 0,
+                            top: '50%',
+                            transform: 'translateY(-50%)',
+                            width: '2.5px',
+                            height: 16,
+                            borderRadius: '0 2px 2px 0',
+                            bgcolor: 'sidebar.indicator',
+                          }}
+                          aria-hidden="true"
+                        />
+                      )}
 
-                {!collapsed && (
-                  <Typography
-                    sx={{
-                      fontSize: '0.8125rem',
-                      fontWeight: isActive ? 550 : 400,
-                      letterSpacing: isActive ? '-0.005em' : '0',
-                      lineHeight: 1,
-                      flex: 1,
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {item.label}
-                  </Typography>
-                )}
+                      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 20, height: 20, flexShrink: 0 }}>
+                        <NavIcon size={17} weight={isActive ? 'fill' : 'regular'} />
+                      </Box>
 
-                {/* Subtle arrow for active item */}
-                {isActive && !collapsed && (
-                  <CaretRight style={{ width: 13, height: 13, opacity: 0.4, flexShrink: 0 }} />
-                )}
+                      {!collapsed && (
+                        <Typography
+                          sx={{
+                            fontSize: '0.8125rem',
+                            fontWeight: isActive ? 550 : 400,
+                            letterSpacing: isActive ? '-0.005em' : '0',
+                            lineHeight: 1,
+                            flex: 1,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {item.label}
+                        </Typography>
+                      )}
+
+                      {!collapsed && badgeCount !== null && badgeCount > 0 && !isActive && (
+                        <Typography
+                          sx={{
+                            fontSize: '0.6875rem',
+                            fontWeight: 500,
+                            color: 'text.disabled',
+                            lineHeight: 1,
+                            flexShrink: 0,
+                            minWidth: 16,
+                            textAlign: 'right',
+                          }}
+                        >
+                          {badgeCount}
+                        </Typography>
+                      )}
+
+                      {/* Subtle arrow for active item */}
+                      {isActive && !collapsed && (
+                        <CaretRight style={{ width: 13, height: 13, opacity: 0.4, flexShrink: 0 }} />
+                      )}
+                    </Box>
+                  );
+
+                  const wrappedContent = collapsed ? (
+                    <Tooltip title={item.label} placement="right" key={item.id}>
+                      {isDisabled ? (
+                        <Box>{content}</Box>
+                      ) : (
+                        <Link href={href} style={{ textDecoration: 'none', color: 'inherit' }}>
+                          {content}
+                        </Link>
+                      )}
+                    </Tooltip>
+                  ) : isDisabled ? (
+                    <Box key={item.id}>{content}</Box>
+                  ) : (
+                    <Link
+                      key={item.id}
+                      href={href}
+                      style={{ textDecoration: 'none', color: 'inherit' }}
+                    >
+                      {content}
+                    </Link>
+                  );
+
+                  return wrappedContent;
+                })}
               </Box>
-            );
-
-            const wrappedContent = collapsed ? (
-              <Tooltip title={item.label} placement="right" key={item.id}>
-                {isDisabled ? (
-                  <Box>{content}</Box>
-                ) : (
-                  <Link href={href} style={{ textDecoration: 'none', color: 'inherit' }}>
-                    {content}
-                  </Link>
-                )}
-              </Tooltip>
-            ) : isDisabled ? (
-              <Box key={item.id}>{content}</Box>
-            ) : (
-              <Link
-                key={item.id}
-                href={href}
-                style={{ textDecoration: 'none', color: 'inherit' }}
-              >
-                {content}
-              </Link>
-            );
-
-            return wrappedContent;
-          })}
-        </Box>
+            </Box>
+          );
+        })}
 
         {/* Spacer */}
         <Box sx={{ flex: 1 }} />

--- a/src/components/layout/navItems.ts
+++ b/src/components/layout/navItems.ts
@@ -1,19 +1,33 @@
+export type NavSection = 'navigation' | 'workspace';
+
 export interface NavItem {
   id: string;
   label: string;
   icon: string;
   segment: string;
+  section: NavSection;
 }
+
+export interface NavSectionDef {
+  id: NavSection;
+  label: string;
+}
+
+export const SIDEBAR_SECTIONS: NavSectionDef[] = [
+  { id: 'navigation', label: 'Navigation' },
+  { id: 'workspace', label: 'Workspace' },
+];
 
 // Organization-level navigation (no longer used)
 export const orgNavItems: NavItem[] = [];
 
 // Project-level navigation (requires a selected project)
 export const projectNavItems: NavItem[] = [
-  { id: 'gantt', label: 'Gantt', icon: 'ChartBar', segment: 'gantt' },
-  { id: 'files', label: 'File Tree', icon: 'FolderSimple', segment: 'files' },
-  { id: 'document-explorer', label: 'Document Explorer', icon: 'FileMagnifyingGlass', segment: 'document-explorer' },
-  { id: 'manage', label: 'Manage', icon: 'GearSix', segment: 'manage' },
+  { id: 'gantt', label: 'Gantt', icon: 'ChartBar', segment: 'gantt', section: 'navigation' },
+  { id: 'files', label: 'File Tree', icon: 'FolderSimple', segment: 'files', section: 'navigation' },
+  { id: 'document-explorer', label: 'Document Explorer', icon: 'FileMagnifyingGlass', segment: 'document-explorer', section: 'navigation' },
+  { id: 'team', label: 'Team', icon: 'UsersThree', segment: 'team', section: 'workspace' },
+  { id: 'project-settings', label: 'Project Settings', icon: 'GearSix', segment: 'settings', section: 'workspace' },
 ];
 
 // Helper to build org-level URLs
@@ -32,4 +46,3 @@ export function getProjectNavHref(
   }
   return `/${orgSlug}/projects/${projectSlug}/${segment}`;
 }
-


### PR DESCRIPTION
## Summary
- Replaces the single `/manage` page with two dedicated routes: `/team` (members + pending invites) and `/settings` (project details + danger zone).
- Sidebar and mobile drawer now group nav items into `Navigation` and `Workspace` sections, with a live member-count badge on the Team item.
- `PAGE_TITLES` and the slug-rename redirect are updated to point at `/settings`.

## Test plan
- [ ] Visit `/[org]/projects/[project]/team` — members list renders, Pending tab only appears when there are pending invites, Invite Member button shows only for roles with `canInviteMembers`.
- [ ] Visit `/[org]/projects/[project]/settings` — project details form is editable for project_manager+, Danger Zone shows for admin/owner, slug rename redirects to the new `/settings` URL.
- [ ] Sidebar + mobile drawer show Team with a member count badge (hidden when count is 0) and Project Settings under the Workspace section.
- [ ] Old `/manage` route no longer resolves; no broken links elsewhere in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)