### PR TITLE
Add custom IBeamLoader for page and auth loading states

### DIFF
--- a/src/__tests__/layout/account-tab-content.test.tsx
+++ b/src/__tests__/layout/account-tab-content.test.tsx
@@ -90,6 +90,6 @@ describe("AccountTabContent", () => {
     renderWithTheme(<AccountTabContent onCloseModal={mockOnCloseModal} />);
 
     expect(screen.queryByText("Your Teams")).not.toBeInTheDocument();
-    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.getByRole("status", { name: /loading/i })).toBeInTheDocument();
   });
 });

--- a/src/app/(app)/[orgSlug]/loading.tsx
+++ b/src/app/(app)/[orgSlug]/loading.tsx
@@ -1,10 +1,10 @@
 import { Box } from '@mui/material';
-import CircularProgress from '@mui/material/CircularProgress';
+import { IBeamLoader } from '@/components/ui/IBeamLoader';
 
 export default function OrgHomeLoading() {
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-      <CircularProgress size={32} />
+      <IBeamLoader size={32} />
     </Box>
   );
 }

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/document-explorer/page.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/document-explorer/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Box, Typography, CircularProgress, Tooltip, Menu, MenuItem, useTheme } from '@mui/material';
+import { Box, Typography, Tooltip, Menu, MenuItem, useTheme } from '@mui/material';
+import { IBeamLoader } from '@/components/ui/IBeamLoader';
 import Pagination from '@/components/documents/Pagination';
 import { FileText, ChevronDown, Sparkles, Search, AlignJustify, Table2, LayoutGrid } from 'lucide-react';
 import { keepPreviousData } from '@tanstack/react-query';
@@ -278,7 +279,7 @@ export default function DocumentExplorerPage() {
         if (!activeSearchText) {
           return (
             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1, py: 8 }}>
-              <CircularProgress size={32} />
+              <IBeamLoader size={32} />
             </Box>
           );
         }

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/loading.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/loading.tsx
@@ -1,10 +1,10 @@
 import { Box } from '@mui/material';
-import CircularProgress from '@mui/material/CircularProgress';
+import { IBeamLoader } from '@/components/ui/IBeamLoader';
 
 export default function ProjectLoading() {
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-      <CircularProgress size={32} />
+      <IBeamLoader size={32} />
     </Box>
   );
 }

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -16,9 +16,9 @@ import {
   InputAdornment,
   IconButton,
   Stack,
-  CircularProgress,
 } from '@mui/material';
 import { Button } from '@/components/ui/button';
+import { IBeamLoader } from '@/components/ui/IBeamLoader';
 
 function FloatingPaths({ position }: { position: number }) {
   const paths = Array.from({ length: 36 }, (_, i) => ({
@@ -617,7 +617,7 @@ function SignInLoading() {
         justifyContent: 'center',
       }}
     >
-      <CircularProgress />
+      <IBeamLoader size={40} />
     </Box>
   );
 }

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -14,9 +14,9 @@ import {
   Alert,
   Stack,
   Paper,
-  CircularProgress,
 } from '@mui/material';
 import { Button } from '@/components/ui/button';
+import { IBeamLoader } from '@/components/ui/IBeamLoader';
 
 export default function VerifyEmailPage() {
   const router = useRouter();
@@ -97,7 +97,7 @@ export default function VerifyEmailPage() {
           justifyContent: 'center',
         }}
       >
-        <CircularProgress />
+        <IBeamLoader size={40} />
       </Box>
     );
   }

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -15,9 +15,9 @@ import {
   Paper,
   Stack,
   Alert,
-  CircularProgress,
 } from "@mui/material";
 import { Button } from '@/components/ui/button';
+import { IBeamLoader } from '@/components/ui/IBeamLoader';
 import CheckIcon from "@mui/icons-material/Check";
 
 const WRONG_EMAIL_MSG = "This invitation was sent to a different email address";
@@ -97,7 +97,9 @@ export default function InvitePage() {
         }}
       >
         <BlueprintBackground />
-        <CircularProgress sx={{ position: "relative", zIndex: 1 }} />
+        <Box sx={{ position: "relative", zIndex: 1 }}>
+          <IBeamLoader size={40} />
+        </Box>
       </Box>
     );
   }

--- a/src/components/layout/AccountTabContent.tsx
+++ b/src/components/layout/AccountTabContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Box, Typography, CircularProgress } from '@mui/material';
+import { Box, Typography } from '@mui/material';
+import { IBeamLoader } from '@/components/ui/IBeamLoader';
 import { Plus, Crown, Buildings } from '@phosphor-icons/react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -26,7 +27,7 @@ export default function AccountTabContent({ onCloseModal }: AccountTabContentPro
   if (isLoading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
-        <CircularProgress size={28} />
+        <IBeamLoader size={28} />
       </Box>
     );
   }

--- a/src/components/layout/ProfileTabContent.tsx
+++ b/src/components/layout/ProfileTabContent.tsx
@@ -3,7 +3,8 @@
 import { useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Box, TextField, Typography, CircularProgress } from '@mui/material';
+import { Box, TextField, Typography } from '@mui/material';
+import { IBeamLoader } from '@/components/ui/IBeamLoader';
 import { Button } from '@/components/ui/button';
 import { api } from '@/trpc/react';
 import { useSnackbar } from '@/hooks/useSnackbar';
@@ -44,7 +45,7 @@ export default function ProfileTabContent() {
   if (isLoading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
-        <CircularProgress size={28} />
+        <IBeamLoader size={28} />
       </Box>
     );
   }

--- a/src/components/ui/IBeamLoader.tsx
+++ b/src/components/ui/IBeamLoader.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useId } from 'react';
+
+type Props = {
+  size?: number;
+  color?: string;
+  speed?: number;
+  className?: string;
+};
+
+export function IBeamLoader({
+  size = 64,
+  color = 'currentColor',
+  speed = 1,
+  className,
+}: Props) {
+  const dur = 2.4 / speed;
+  const uid = useId().replace(/:/g, '');
+  const cls = {
+    g: `ibeam-g-${uid}`,
+    r: `ibeam-r-${uid}`,
+    colLeft: `ibeam-col-left-${uid}`,
+    beamTop: `ibeam-beam-top-${uid}`,
+    colRight: `ibeam-col-right-${uid}`,
+    mid: `ibeam-mid-${uid}`,
+    reset: `ibeam-reset-${uid}`,
+  };
+
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className={className}
+      style={{ width: size, height: size, display: 'inline-block' }}
+    >
+      <svg viewBox="0 0 24 24" width={size} height={size}>
+        <style>{`
+          @keyframes ${cls.colLeft}  { 0%,8%   { transform: scaleY(0); } 22%,100% { transform: scaleY(1); } }
+          @keyframes ${cls.beamTop}  { 0%,22%  { transform: scaleX(0); } 38%,100% { transform: scaleX(1); } }
+          @keyframes ${cls.colRight} { 0%,38%  { transform: scaleY(0); } 52%,100% { transform: scaleY(1); } }
+          @keyframes ${cls.mid}      { 0%,52%  { transform: scaleY(0); } 68%,92%  { transform: scaleY(1); } 100% { transform: scaleY(1); opacity: 0; } }
+          @keyframes ${cls.reset}    { 0%,92%  { opacity: 1; } 100% { opacity: 0; } }
+          .${cls.g} { animation: ${cls.reset} ${dur}s infinite; }
+          .${cls.r} { animation-duration: ${dur}s; animation-iteration-count: infinite; animation-timing-function: cubic-bezier(0.4,0,0.2,1); }
+        `}</style>
+        <g className={cls.g}>
+          <rect
+            className={cls.r}
+            x="3"
+            y="3"
+            width="3"
+            height="18"
+            rx="0.5"
+            fill={color}
+            style={{ transformOrigin: '4.5px 21px', animationName: cls.colLeft }}
+          />
+          <rect
+            className={cls.r}
+            x="3"
+            y="3"
+            width="18"
+            height="3"
+            rx="0.5"
+            fill={color}
+            style={{ transformOrigin: '3px 4.5px', animationName: cls.beamTop }}
+          />
+          <rect
+            className={cls.r}
+            x="18"
+            y="3"
+            width="3"
+            height="10"
+            rx="0.5"
+            fill={color}
+            style={{ transformOrigin: '19.5px 3px', animationName: cls.colRight }}
+          />
+          <rect
+            className={cls.r}
+            x="10"
+            y="9"
+            width="2.5"
+            height="12"
+            rx="0.5"
+            fill={color}
+            style={{ transformOrigin: '11.25px 21px', animationName: cls.mid }}
+          />
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/src/components/ui/UploadOverlay.tsx
+++ b/src/components/ui/UploadOverlay.tsx
@@ -52,7 +52,7 @@ export default function UploadOverlay({
           zIndex: 1,
         }}
       >
-        <CircularProgress size={size} sx={{ color: isDark ? 'white' : 'text.secondary' }} />
+        <CircularProgress size={size} sx={{ color: isDark ? 'common.white' : 'text.secondary' }} />
         {text && (
           <Typography
             sx={{

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,9 +3,9 @@
 import { forwardRef } from 'react';
 import {
   Button as MuiButton,
-  CircularProgress,
   type ButtonProps as MuiButtonProps,
 } from '@mui/material';
+import { IBeamLoader } from './IBeamLoader';
 
 const spinnerSizeMap = {
   small: 14,
@@ -35,9 +35,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ref,
   ) => {
     const spinnerSize = spinnerSizeMap[size];
-    const spinner = (
-      <CircularProgress size={spinnerSize} sx={{ color: 'inherit' }} />
-    );
+    const spinner = <IBeamLoader size={spinnerSize} color="currentColor" />;
 
     return (
       <MuiButton

--- a/src/components/ui/loading-spinner.tsx
+++ b/src/components/ui/loading-spinner.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { CircularProgress, Backdrop, Box, Typography } from '@mui/material';
+import { Backdrop, Box, Typography } from '@mui/material';
+import { IBeamLoader } from './IBeamLoader';
 
 interface LoadingSpinnerProps {
   size?: 'sm' | 'md' | 'lg' | 'xl';
@@ -22,8 +23,8 @@ export default function LoadingSpinner({
   text
 }: LoadingSpinnerProps) {
   const spinner = (
-    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1.5 }}>
-      <CircularProgress size={sizeMap[size]} sx={fullScreen ? { color: 'common.white' } : undefined} />
+    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1.5, color: fullScreen ? 'common.white' : 'text.secondary' }}>
+      <IBeamLoader size={sizeMap[size]} />
       {text && (
         <motion.div
           initial={{ opacity: 0 }}


### PR DESCRIPTION
## Summary
- Introduce `IBeamLoader`, a branded animated I-beam SVG loader that inherits color via `currentColor` so it adapts to MUI theme tokens.
- Replace `CircularProgress` on page-level loaders, auth pages (sign-in, verify-email, invite), tab loaders (Account, Profile), and the `Button` loading state.
- Keep `CircularProgress` for dropzones and `UploadOverlay` where MUI's native spinner matches the interactive upload UX.

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test -- account-tab-content` passes
- [ ] Verify loader appears on `/sign-in`, `/verify-email`, `/invite/[token]`, org/project loading routes, and button loading states
- [ ] Verify dropzones (FileDropzone, image-dropzone, StepLogo, ProjectFormBody, manage page) still show CircularProgress during uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)