### PR TITLE
Add weekday row and shade weekends in Gantt time axis

### DIFF
--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -157,6 +157,7 @@ export function createGanttConfig(
       taskEdit: false,
       columnLines: true,
       stripe: true,
+      nonWorkingTime: true,
       tree: { toggleTreeNode: false },
       cellTooltip: {
         tooltipRenderer: ({ record, column }) => formatTooltipText(record, column.field),
@@ -183,6 +184,7 @@ export function createGanttConfig(
         base: 'weekAndDayLetter',
         headers: [
           { unit: 'month', dateFormat: 'MMMM YYYY' },
+          { unit: 'day', dateFormat: 'd1' },
           { unit: 'day', dateFormat: 'DD' },
         ],
       },

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -210,6 +210,7 @@ export type GanttConfig = {
     taskEdit?: boolean;
     columnLines?: boolean | { renderer?: (...args: unknown[]) => void };
     stripe?: boolean;
+    nonWorkingTime?: boolean;
     cellTooltip: {
       tooltipRenderer: (args: TooltipRendererArgs) => string;
     };

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -183,10 +183,29 @@ export const ganttRouter = createTRPCRouter({
         projectData.startDate = project.startDate.toISOString();
       }
 
+      // Provide a default calendar that marks Sat/Sun as non-working so the
+      // Gantt `nonWorkingTime` feature shades weekend columns. Projects that
+      // have their own calendars override this via the `calendars` JSON column.
+      const defaultCalendars = {
+        rows: [
+          {
+            id: project.calendarId,
+            name: "General",
+            intervals: [
+              {
+                recurrentStartDate: "on Sat at 0:00",
+                recurrentEndDate: "on Mon at 0:00",
+                isWorking: false,
+              },
+            ],
+          },
+        ],
+      };
+
       return {
         success: true,
         project: projectData,
-        calendars: project.calendars ?? null,
+        calendars: project.calendars ?? defaultCalendars,
         tasks: { rows: taskTree },
         dependencies: { rows: ganttDependencies },
         resources: { rows: ganttResources },


### PR DESCRIPTION
## Summary
- Added a third header row to the Gantt `weekAndDayLetterCompact` preset showing single-letter weekday (M/T/W/T/F/S/S) between the month and day-number rows.
- Enabled Bryntum's `nonWorkingTime` feature so Sat/Sun columns render as shaded non-working time.
- The `gantt.load` procedure now returns a default calendar with weekends marked non-working when the project has no custom `calendars` JSON, which is the source of the non-working intervals the feature reads.

## Test plan
- [ ] Open the Gantt page on an existing project and verify the time axis shows month → weekday letter → day number, with Sat/Sun columns visibly grayed out.
- [ ] Confirm existing task bars still render at their stored start/end dates (no retroactive rescheduling on load).
- [ ] Drag a task across a weekend and confirm the scheduling engine now treats Sat/Sun as non-working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)