### PR TITLE
Make Gantt container feel lighter and more canvas-like

### DIFF
--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -24,9 +24,8 @@ const WRAPPER_STYLE: CSSProperties = {
   flexDirection: 'column',
   height: '100%',
   borderRadius: '12px',
-  border: '1px solid var(--border-color)',
   backgroundColor: 'var(--bg-card)',
-  boxShadow: 'var(--gantt-container-ring), var(--gantt-container-shadow)',
+  overflow: 'clip',
 };
 
 const GANTT_CONTENT_STYLE: CSSProperties = {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -90,12 +90,7 @@
   --gantt-task-backdrop: rgba(255, 255, 255, 0.4);
   --gantt-splitter-color: rgba(0, 0, 0, 0.06);
   --gantt-splitter-hover: rgba(43, 45, 66, 0.12);
-  --gantt-container-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.04),
-    0 4px 12px rgba(0, 0, 0, 0.06),
-    0 12px 28px rgba(0, 0, 0, 0.05);
-  --gantt-container-ring: 0 0 0 1px rgba(0, 0, 0, 0.06);
-  --gantt-toolbar-bg: #fafbfc;
+  --gantt-toolbar-bg: #ffffff;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Drop the border, inset ring, and three-layer drop shadow from the Gantt wrapper so the chart reads as a flat sheet on the page canvas instead of a floating card.
- Merge the toolbar background into the chart surface (white on white, separated only by the existing hairline) so the toolbar and chart no longer read as two stacked panels.
- Clean up the now-orphan `--gantt-container-shadow` and `--gantt-container-ring` CSS vars.

## Test plan
- [ ] Open a project's Gantt tab and confirm the card no longer has a visible border or drop shadow.
- [ ] Verify the rounded corners still clip cleanly at the chart edges (`overflow: clip` on the wrapper).
- [ ] Confirm the toolbar and chart read as one surface with only the hairline separator between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)