### PR TITLE
Use org logos and identicons across switcher and avatar slots

### DIFF
--- a/src/app/api/organization/logo/route.ts
+++ b/src/app/api/organization/logo/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { put } from "@vercel/blob";
 import { auth } from "@/lib/auth";
+import { env } from "@/env";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
@@ -37,7 +38,12 @@ export async function POST(req: NextRequest) {
     const blob = await put(
       `organizations/logos/${session.user.id}/${file.name}`,
       file,
-      { access: "public", addRandomSuffix: true }
+      {
+        access: "public",
+        addRandomSuffix: true,
+        contentType: file.type,
+        token: env.BLOB_AVATARS_READ_WRITE_TOKEN,
+      }
     );
 
     return NextResponse.json({ logoUrl: blob.url });

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import { Building2, ArrowRight } from "lucide-react";
+import { ArrowRight } from "lucide-react";
+import OrgAvatar from "@/components/ui/OrgAvatar";
 import { motion } from "framer-motion";
 import { api } from "@/trpc/react";
 import { useSession, signOut } from "@/lib/auth-client";
@@ -220,20 +221,13 @@ export default function InvitePage() {
           gap: 2,
         }}
       >
-        <Box
-          sx={{
-            width: 48,
-            height: 48,
-            bgcolor: "text.primary",
-            borderRadius: '12px',
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            flexShrink: 0,
-          }}
-        >
-          <Building2 style={{ color: "white", width: 22, height: 22 }} />
-        </Box>
+        <OrgAvatar
+          name={invitation.organization.name}
+          seed={invitation.organization.slug ?? invitation.organization.id}
+          logoUrl={invitation.organization.logoUrl}
+          size={48}
+          borderRadius="12px"
+        />
         <Box>
           <Typography sx={{ fontWeight: 500, mb: 0.25 }}>
             {invitation.organization.name}

--- a/src/components/layout/AccountTabContent.tsx
+++ b/src/components/layout/AccountTabContent.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { api } from '@/trpc/react';
 import { formatRole } from '@/lib/utils/formatting';
+import OrgAvatar from '@/components/ui/OrgAvatar';
 
 interface AccountTabContentProps {
   onCloseModal: () => void;
@@ -59,24 +60,13 @@ export default function AccountTabContent({ onCloseModal }: AccountTabContentPro
               bgcolor: 'action.hover',
             }}
           >
-            <Box
-              sx={{
-                width: 36,
-                height: 36,
-                borderRadius: '10px',
-                background: (theme) =>
-                  `linear-gradient(135deg, ${theme.palette.accent.dark}, ${theme.palette.accent.gradientEnd})`,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                flexShrink: 0,
-                fontSize: '0.8125rem',
-                fontWeight: 600,
-                color: 'common.white',
-              }}
-            >
-              {org.name.charAt(0).toUpperCase()}
-            </Box>
+            <OrgAvatar
+              name={org.name}
+              seed={org.slug ?? org.id}
+              logoUrl={org.logoUrl}
+              size={36}
+              borderRadius="10px"
+            />
             <Box sx={{ minWidth: 0, flex: 1 }}>
               <Typography
                 sx={{

--- a/src/components/layout/OrgSwitcher.tsx
+++ b/src/components/layout/OrgSwitcher.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CaretDown, Check } from '@phosphor-icons/react';
+import { CaretDown } from '@phosphor-icons/react';
 import { motion } from 'framer-motion';
 import { useState, useEffect } from 'react';
 import { useRouter, useParams, usePathname } from 'next/navigation';
@@ -13,28 +13,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useLoading } from '@/components/providers/LoadingProvider';
-
-function OrgAvatar({ name, size = 34 }: { name: string; size?: number }) {
-  return (
-    <Box
-      sx={{
-        width: size,
-        height: size,
-        borderRadius: '8px',
-        background: (theme) => `linear-gradient(180deg, ${theme.palette.accent.dark} 0%, ${theme.palette.accent.gradientEnd} 100%)`,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexShrink: 0,
-        color: 'common.white',
-        fontSize: '0.6875rem',
-        fontWeight: 600,
-      }}
-    >
-      {name.charAt(0).toUpperCase()}
-    </Box>
-  );
-}
+import OrgAvatar from '@/components/ui/OrgAvatar';
 
 export default function OrgSwitcher({ collapsed = false }: { collapsed?: boolean }) {
   const [orgMenuOpen, setOrgMenuOpen] = useState(false);
@@ -50,6 +29,7 @@ export default function OrgSwitcher({ collapsed = false }: { collapsed?: boolean
   );
 
   const currentOrg = organizations.find((org) => org.slug === currentOrgSlug);
+  const otherOrgs = organizations.filter((org) => org.slug !== currentOrgSlug);
 
   useEffect(() => {
     hideLoading();
@@ -67,16 +47,27 @@ export default function OrgSwitcher({ collapsed = false }: { collapsed?: boolean
     return isLoading ? (
       <Skeleton variant="rectangular" width={34} height={34} sx={{ borderRadius: '8px', flexShrink: 0 }} />
     ) : (
-      <OrgAvatar name={currentOrg?.name ?? 'O'} />
+      <OrgAvatar
+        name={currentOrg?.name ?? 'Organization'}
+        seed={currentOrg?.slug ?? currentOrg?.id ?? 'org'}
+        logoUrl={currentOrg?.logoUrl}
+      />
     );
   }
+
+  const hasSwitcher = otherOrgs.length > 0;
 
   const triggerContent = (
     <>
       {isLoading ? (
         <Skeleton variant="rectangular" width={34} height={34} sx={{ borderRadius: '8px', flexShrink: 0 }} />
       ) : (
-        <OrgAvatar name={currentOrg?.name ?? 'O'} />
+        <OrgAvatar
+          name={currentOrg?.name ?? 'Organization'}
+          seed={currentOrg?.slug ?? currentOrg?.id ?? 'org'}
+          logoUrl={currentOrg?.logoUrl}
+          className="org-avatar"
+        />
       )}
       <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', minWidth: 0, flex: 1, gap: '2px' }}>
         {isLoading ? (
@@ -100,24 +91,37 @@ export default function OrgSwitcher({ collapsed = false }: { collapsed?: boolean
             >
               {currentOrg?.name ?? 'No Organization'}
             </Typography>
-            <Typography sx={{ fontSize: '0.625rem', fontWeight: 500, color: 'text.secondary', lineHeight: 1 }}>
-              Pro Plan
-            </Typography>
+            {currentOrg?.role && (
+              <Typography
+                sx={{
+                  fontSize: '0.625rem',
+                  fontWeight: 500,
+                  color: 'text.secondary',
+                  lineHeight: 1,
+                  textTransform: 'capitalize',
+                }}
+              >
+                {currentOrg.role}
+              </Typography>
+            )}
           </>
         )}
       </Box>
-      <motion.div
-        animate={{ rotate: orgMenuOpen ? 180 : 0 }}
-        transition={{ duration: 0.15 }}
-        style={{ flexShrink: 0 }}
-      >
-        <CaretDown size={14} weight="bold" />
-      </motion.div>
+      {hasSwitcher && (
+        <motion.div
+          animate={{ rotate: orgMenuOpen ? 180 : 0 }}
+          transition={{ duration: 0.15 }}
+          className="caret-icon"
+          style={{ flexShrink: 0 }}
+        >
+          <CaretDown size={14} weight="bold" />
+        </motion.div>
+      )}
     </>
   );
 
-  // Single org — show as non-interactive row (same layout, no dropdown)
-  if (organizations.length <= 1 && !isLoading) {
+  // No other orgs to switch to — non-interactive row (no caret)
+  if (!hasSwitcher && !isLoading) {
     return (
       <Box
         sx={{
@@ -135,7 +139,7 @@ export default function OrgSwitcher({ collapsed = false }: { collapsed?: boolean
     );
   }
 
-  // Multiple orgs — dropdown switcher
+  // Has other orgs — dropdown switcher
   return (
     <DropdownMenu open={orgMenuOpen} onOpenChange={setOrgMenuOpen}>
       <DropdownMenuTrigger asChild>
@@ -154,8 +158,17 @@ export default function OrgSwitcher({ collapsed = false }: { collapsed?: boolean
             cursor: 'pointer',
             color: 'text.disabled',
             transition: 'background-color 0.15s',
+            '& .caret-icon': {
+              transition: 'transform 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+            },
             '&:hover': {
               bgcolor: 'action.hover',
+              '& .org-avatar': {
+                transform: 'scale(1.04)',
+              },
+              '& .caret-icon': {
+                transform: 'translateY(1px)',
+              },
             },
             '&:disabled': {
               cursor: 'not-allowed',
@@ -166,50 +179,62 @@ export default function OrgSwitcher({ collapsed = false }: { collapsed?: boolean
           {triggerContent}
         </Box>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" sideOffset={8}>
+      <DropdownMenuContent
+        align="start"
+        sideOffset={8}
+        slotProps={{ paper: { sx: { minWidth: 240 } } }}
+      >
         <Box sx={{ px: 1, py: 0.75, mb: 0.5 }}>
           <Typography sx={{ fontSize: '0.625rem', textTransform: 'uppercase', letterSpacing: '0.1em', color: 'text.disabled', fontWeight: 500 }}>
-            Switch Organization
+            Switch to…
           </Typography>
         </Box>
-        {organizations.map((org) => {
-          const isActive = org.slug === currentOrgSlug;
-          return (
-            <DropdownMenuItem key={org.id} onClick={() => handleSwitch(org.slug)}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, width: '100%' }}>
-                <Box
-                  sx={{
-                    width: 32,
-                    height: 32,
-                    borderRadius: '12px',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    fontSize: '0.75rem',
-                    fontWeight: 600,
-                    flexShrink: 0,
-                    background: isActive
-                      ? (theme) => `linear-gradient(180deg, ${theme.palette.accent.dark} 0%, ${theme.palette.accent.gradientEnd} 100%)`
-                      : undefined,
-                    bgcolor: isActive ? undefined : 'action.hover',
-                    color: isActive ? 'white' : 'text.secondary',
-                  }}
-                >
-                  {org.name.charAt(0).toUpperCase()}
-                </Box>
-                <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 }}>
-                  <Typography sx={{ fontSize: '0.875rem', overflow: 'hidden', textOverflow: 'ellipsis', fontWeight: isActive ? 500 : 400 }}>
+        {otherOrgs.map((org, index) => (
+          <DropdownMenuItem key={org.id} onClick={() => handleSwitch(org.slug)}>
+            <motion.div
+              initial={{ opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.18, delay: index * 0.03, ease: [0.4, 0, 0.2, 1] }}
+              whileTap={{ scale: 0.97 }}
+              style={{ width: '100%' }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1.5,
+                  width: '100%',
+                  '& .item-avatar, & .item-text': {
+                    transition: 'transform 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+                  },
+                  '&:hover .item-avatar': {
+                    transform: 'scale(1.06)',
+                  },
+                  '&:hover .item-text': {
+                    transform: 'translateX(2px)',
+                  },
+                }}
+              >
+                <OrgAvatar
+                  className="item-avatar"
+                  name={org.name}
+                  seed={org.slug ?? org.id}
+                  logoUrl={org.logoUrl}
+                  size={32}
+                  borderRadius="12px"
+                />
+                <Box className="item-text" sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 }}>
+                  <Typography sx={{ fontSize: '0.875rem', overflow: 'hidden', textOverflow: 'ellipsis', fontWeight: 400 }}>
                     {org.name}
                   </Typography>
                   <Typography sx={{ fontSize: '0.6875rem', color: 'text.disabled', textTransform: 'capitalize' }}>
                     {org.role}
                   </Typography>
                 </Box>
-                {isActive && <Check size={16} weight="bold" style={{ flexShrink: 0 }} />}
               </Box>
-            </DropdownMenuItem>
-          );
-        })}
+            </motion.div>
+          </DropdownMenuItem>
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/ui/OrgAvatar.tsx
+++ b/src/components/ui/OrgAvatar.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Box } from '@mui/material';
+
+interface OrgAvatarProps {
+  name: string;
+  seed: string;
+  logoUrl?: string | null;
+  size?: number;
+  borderRadius?: number | string;
+  className?: string;
+}
+
+function dicebearUrl(seed: string) {
+  return `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(seed)}`;
+}
+
+export default function OrgAvatar({
+  name,
+  seed,
+  logoUrl,
+  size = 34,
+  borderRadius = '8px',
+  className,
+}: OrgAvatarProps) {
+  const [imgError, setImgError] = useState(false);
+  const src = logoUrl && !imgError ? logoUrl : dicebearUrl(seed);
+
+  useEffect(() => {
+    setImgError(false);
+  }, [logoUrl]);
+
+  return (
+    <Box
+      className={className}
+      component="img"
+      src={src}
+      alt={name}
+      onError={() => {
+        if (logoUrl && !imgError) setImgError(true);
+      }}
+      sx={{
+        width: size,
+        height: size,
+        borderRadius,
+        objectFit: 'cover',
+        flexShrink: 0,
+        bgcolor: 'action.hover',
+        transition: 'transform 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+      }}
+    />
+  );
+}

--- a/src/server/api/routers/invitation.ts
+++ b/src/server/api/routers/invitation.ts
@@ -197,6 +197,8 @@ export const invitationRouter = createTRPCRouter({
             select: {
               id: true,
               name: true,
+              slug: true,
+              logoUrl: true,
             },
           },
           project: {

--- a/src/server/api/routers/organization.ts
+++ b/src/server/api/routers/organization.ts
@@ -74,7 +74,7 @@ export const organizationRouter = createTRPCRouter({
     const memberships = await ctx.db.membership.findMany({
       where: { userId: ctx.session.user.id },
       include: {
-        organization: { select: { id: true, name: true, slug: true } },
+        organization: { select: { id: true, name: true, slug: true, logoUrl: true } },
       },
       orderBy: { createdAt: "asc" },
     });


### PR DESCRIPTION
## Summary
- New shared `OrgAvatar` UI primitive that renders the org logo when present and falls back to a DiceBear identicon; used by the sidebar switcher, account modal, and invite page.
- Org switcher now filters the current org out of the dropdown list, hides the caret when there is nothing to switch to, and replaces the hardcoded "Pro Plan" label with the membership role; dropdown items gain subtle hover/tap animations.
- tRPC `organization.list` and `invitation.getByToken` now select `logoUrl` (and `slug` for the invite flow) so the avatar can resolve.
- `/api/organization/logo` now targets the public avatars blob store (`BLOB_AVATARS_READ_WRITE_TOKEN`) and sets `contentType`, fixing a latent bug where returned URLs defaulted to the private store and 403'd in the browser.

## Test plan
- [ ] Sidebar switcher: single-org user sees row without caret; multi-org user sees only other orgs in the dropdown.
- [ ] Account modal and `/invite/[token]` page display org logo if set, identicon otherwise.
- [ ] Upload an org logo via settings and confirm the returned URL loads in the browser without a 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)