### PR TITLE
Add hover sheen microinteraction to Gantt task bars

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -310,6 +310,7 @@ body {
   box-shadow: var(--gantt-task-shadow) !important;
   border-width: 1px !important;
   border-style: solid !important;
+  overflow: hidden !important;
   transition: box-shadow 0.15s ease, transform 0.1s ease !important;
 }
 
@@ -327,13 +328,47 @@ body {
   pointer-events: none !important;
 }
 
+/* Decorative sheen — a subtle light sweep across the bar on hover.
+   Delayed 120ms so fast cursor flyovers don't trigger it. Parent/summary
+   bars opt out below to keep their quieter treatment. */
+.bryntum-gantt-container .b-gantt-task::after {
+  content: '' !important;
+  position: absolute !important;
+  inset: 0 !important;
+  border-radius: inherit !important;
+  background: linear-gradient(
+    110deg,
+    transparent 0%,
+    transparent 35%,
+    rgba(255, 255, 255, 0.28) 50%,
+    transparent 65%,
+    transparent 100%
+  ) !important;
+  transform: translateX(-100%);
+  pointer-events: none !important;
+}
+
+.bryntum-gantt-container .b-gantt-task:hover::after {
+  animation: gantt-task-sheen 1.1s ease-out 120ms 1;
+}
+
+.bryntum-gantt-container .b-gantt-task.gantt-parent-bar:hover::after,
+.bryntum-gantt-container .b-gantt-task.b-gantt-task-parent:hover::after {
+  animation: none !important;
+}
+
+@keyframes gantt-task-sheen {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
 /* Task bar hover — slight lift, plus an inset right-edge cue so users know
    the end of the bar is grabbable as soon as they hover (before reaching the
    14px handle zone). The crisp white pill from .b-over-end-handle (further
    below) covers this hint once the cursor enters the handle. */
 .bryntum-gantt-container .b-gantt-task:hover {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1), inset -3px 0 0 rgba(255, 255, 255, 0.4) !important;
-  transform: translateY(-0.5px) !important;
+  transform: translateY(-1px) !important;
 }
 
 /* Parent/summary bars aren't user-resizable (Bryntum derives their duration


### PR DESCRIPTION
## Summary
- Adds a decorative white gradient sheen that sweeps across child task bars on hover (120ms delay, 1.1s duration), implemented as a `::after` pseudo-element on `.b-gantt-task` with `overflow: hidden` on the parent so the sweep clips to the rounded corners.
- Bumps the existing hover lift from `-0.5px` to `-1px` for a slightly more present feel.
- Parent/summary bars opt out of the sweep to preserve their quieter treatment — they only get the lift.

## Test plan
- [ ] Hover a child task bar — expect a subtle white sweep left-to-right across the bar after ~120ms, and a 1px lift
- [ ] Hover a parent/summary bar — expect the lift only, no sweep
- [ ] Flick the cursor quickly across a row of bars — the 120ms delay should prevent a cascade of sheens
- [ ] Confirm resize handles still work at the bar edges (they live on `.b-gantt-task-wrap`, a parent element, so they shouldn't be affected by the new `overflow: hidden`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)