### PR TITLE
Persist Gantt edits to localStorage so drafts survive refresh (#97)

### DIFF
--- a/.claude/commands/gantt.md
+++ b/.claude/commands/gantt.md
@@ -45,7 +45,7 @@ Before editing, understand the existing file layout:
 
 ```
 src/components/bryntum/
-├── BryntumGanttWrapper.tsx    ← Main wrapper: state, sync, conflict handling, auto-save debounce
+├── BryntumGanttWrapper.tsx    ← Main wrapper: state, sync, conflict handling, draft hook
 ├── types.ts                   ← Shared types: PopoverPlacement, SelectedTask, GanttConfig, etc.
 ├── constants.ts               ← UI constants: POPOVER_WIDTH, POPOVER_GAP, etc.
 ├── config/
@@ -53,21 +53,29 @@ src/components/bryntum/
 ├── components/
 │   ├── GanttToolbar.tsx       ← Toolbar: add task, zoom, shift, preset controls
 │   ├── TaskDetailsPopover.tsx ← Task detail popover (leaf tasks only)
+│   ├── VersionControlBar.tsx  ← "N changes" badge + Create Snapshot button
+│   ├── SaveVersionDialog.tsx  ← Create Snapshot dialog (triggers server sync)
+│   ├── VersionHistoryDrawer.tsx ← List/restore/delete saved snapshots
 │   └── ConflictDialog.tsx     ← Version conflict resolution dialog
 ├── hooks/
 │   ├── useGanttControls.ts    ← Gantt control methods (add, zoom, shift, preset)
+│   ├── useGanttDraft.ts       ← Per-device draft persistence to localStorage (ticket #97)
 │   ├── useTaskPopover.ts      ← Task selection and popover placement state
 │   └── useBryntumThemeAssets.ts ← Dynamic theme CSS and Font Awesome loading
 └── utils/
     ├── ganttValidation.ts     ← Parent task duration validation
+    ├── injectTaskVersions.ts  ← Inject `version` field into outgoing sync pack
+    ├── reconcileSyncPack.ts   ← Reconcile CrudManager added/removed bags with shadow refs
     └── calculatePopoverPlacement.ts ← Popover positioning logic
 ```
 
 **Related files outside bryntum/:**
 - `src/server/api/routers/gantt.ts` — tRPC router for load/sync
+- `src/server/api/helpers/ganttSync.ts` — `syncTasks`/`syncDependencies`/etc. (orphan-parentId defense lives here)
 - `src/app/api/gantt/load/route.ts` — Load transport endpoint
-- `src/app/api/gantt/sync/route.ts` — Sync transport endpoint
+- `src/app/api/gantt/sync/route.ts` — Sync transport endpoint (always returns HTTP 200, even on error — see pitfall below)
 - `src/lib/utils/gantt.ts` — Shared Gantt data helpers
+- `src/store/ganttChangesStore.ts` — Zustand store for "N changes" counter; `serialize()`/`hydrate()` used by draft hook
 
 ### Step 3: Apply Changes Following Existing Patterns
 - New types → `types.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@
 @claudedocs/trpc-guide.md
 @claudedocs/vercel.md
 @claudedocs/csi-codes.md
+@claudedocs/gantt-drafts.md
 
 ## Documentation Update Rules
 When making changes that affect these docs, update them in the same task:
@@ -21,6 +22,7 @@ When making changes that affect these docs, update them in the same task:
 - tRPC routers, procedures, or data-fetching pattern changes → update `claudedocs/trpc-guide.md`
 - Vercel env vars, deployments, or project config changes → update `claudedocs/vercel.md`
 - CSI code list changes, data sources, or selector behavior → update `claudedocs/csi-codes.md`
+- Gantt draft persistence (useGanttDraft, ganttChangesStore snapshot/hydrate, edit-mode auto-unlock, storage shape bumps) → update `claudedocs/gantt-drafts.md`
 
 ## Vercel
 - See `claudedocs/vercel.md` for full Vercel configuration reference

--- a/claudedocs/gantt-drafts.md
+++ b/claudedocs/gantt-drafts.md
@@ -1,0 +1,133 @@
+# Gantt Draft Persistence
+
+Per-device local-storage persistence for unsaved Gantt edits. Drafts survive page refresh and SPA navigation (ticket #97). Server sync stays manual ("Create Snapshot" button).
+
+## User-Visible Behavior
+
+- User adds/edits/deletes tasks → changes accumulate in localStorage as they happen
+- User navigates away (other route, tab close, refresh) → changes persist
+- User returns → draft restores automatically; the "N changes since last snapshot" counter comes back at the same value they left it
+- User clicks **Create Snapshot** → explicit server sync + draft is cleared on success
+- Edit mode auto-unlocks when there's a draft to restore (user clearly wants to keep editing)
+- Drafts are per-device, per-project — switching projects clears the counter and loads a different draft if one exists
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/components/bryntum/hooks/useGanttDraft.ts` | Orchestrator: save/restore/clear lifecycle, the `hasGanttDraft` helper for edit-mode autounlock |
+| `src/store/ganttChangesStore.ts` | Zustand store for the "N changes" counter; exposes `serialize()` and `hydrate()` so the hook can round-trip counter state |
+| `src/components/bryntum/BryntumGanttWrapper.tsx` | Calls `useGanttDraft({ getGanttInstance, projectId, isLoading })`; initializes `isEditMode` to `true` when `hasGanttDraft(projectId)` |
+
+## Storage Shape
+
+Key: `gantt-draft-v4-{projectId}` (bump the `v4` suffix whenever the payload shape changes — older keys are ignored and cleaned up on next restore)
+
+Value: JSON-stringified `DraftBundle`:
+
+```ts
+interface DraftBundle {
+  projectJson: string;             // Bryntum's own `project.json` serialization
+  counter: GanttChangesSnapshot;   // { added, modified, removed } entries as [id,name] pairs
+  savedAt: number;                 // ms epoch — for debugging/sorting
+}
+```
+
+## Save Flow
+
+1. User edits task → Bryntum fires `taskStore.change` or `dependencyStore.change`
+2. Hook's save handler runs (no debounce)
+3. If `taskStore.count === 0` → skip (Bryntum's internal bulk operations fire `change` events during transient empty states; ignoring these prevents wiping a valid draft with nothing)
+4. Otherwise: serialize `{ projectJson: project.json, counter: store.serialize(), savedAt: now }` to localStorage
+
+## Restore Flow
+
+Runs exactly once per component mount, after `isLoading` flips to `false`:
+
+1. `useGanttChangesStore.reset()` — clear counter from any prior project
+2. Parse stored bundle; if malformed or has no tasks → delete and skip
+3. `setTimeout(500ms)` — wait for the wrapper's post-load effects (commitAsync, `enableStm`) to settle; applying the draft synchronously while that async chain is in flight caused records to be silently dropped
+4. After the delay:
+   - `project.json = bundle.projectJson` — Bryntum rebuilds stores from the snapshot
+   - `useGanttChangesStore.hydrate(bundle.counter)` — counter shows exactly what the user saw before refresh
+   - `project.commitAsync()` — trigger the scheduling engine so the chart paints the restored records
+
+## Clear Flow
+
+The hook subscribes to `project.on('sync', ...)`. When the user explicitly creates a Snapshot (which internally triggers a server sync), the draft is deleted from localStorage. No other code path clears it — transient empty states from Bryntum don't cause deletion, only explicit save does.
+
+## Design Decisions (Non-Obvious)
+
+| Decision | Reason |
+|---|---|
+| Use `project.json` (Bryntum-native) instead of manually tracking adds/updates/removes | Bryntum wrote both the serializer and deserializer. Trying to reimplement it led to hundreds of lines of phantom-id reconciliation, parentId rewiring, and replay logic that kept producing corner-case bugs. `project.json` handles all of it correctly. |
+| 500ms delay before restore | The wrapper has its own `commitAsync → enableStm` chain that fires on `isLoading: false`. Applying `project.json` synchronously mid-chain caused Bryntum to silently drop records during reconciliation. 500ms lets the wrapper settle on server state first; then we apply the draft on top. Heuristic, not proven — a slow device could exceed it. If we see regressions, replace with an explicit completion signal from the wrapper. |
+| Snapshot counter alongside project state | After `project.json = saved`, Bryntum considers the loaded state as the new baseline — nothing is "modified". So we can't infer the counter from the store after restore. Persisting the in-memory counter snapshot (which is accurate *during* editing) and rehydrating is the only way to get an accurate count across refresh. |
+| `taskCount === 0` guard on save | Bryntum fires `change` events during internal reconciliation when the store is momentarily empty. Writing that state would wipe the user's draft. "Don't persist empty" is a safer default than a debounce timer. |
+| Edit mode auto-unlocks when draft exists | If there's unsaved work waiting to restore, the user clearly intends to keep editing. Making them click a lock toggle after refresh creates an extra step and hides the restored tasks (read-only mode hides triple-dot menus and disables right-click actions). |
+| No debounce on save | Debouncing caused data loss when the user deleted a task and immediately refreshed — the debounced save hadn't fired yet. The `count === 0` guard is enough to filter transient Bryntum states without needing a timer. |
+| Reset counter on project switch | `ganttChangesStore` is a Zustand singleton, so switching projects would otherwise carry over counts from the previous project. The restore effect calls `reset()` before deciding what to hydrate. |
+| Return HTTP 200 with `success:false` on sync errors (unrelated but related) | Bryntum's `onCrudRequestFailure` path has a bug (`Cannot set properties of undefined (setting 'isBeingMaterialized')`). Routing errors through `onCrudFailure` via 200 + success:false avoids the crash. See `src/app/api/gantt/sync/route.ts`. |
+
+## Known Tradeoffs
+
+- **Draft wins over server state on restore.** If user A has a draft on device X and user B edits the same project server-side, A's draft restore overwrites B's changes locally. This is single-device draft scope. Multi-user conflict resolution is handled at Save time via the `version` field + `ScheduleVersion` snapshot system.
+- **500ms delay is a heuristic, not a guarantee.** On an extremely slow device the wrapper's post-load effects might not finish in 500ms and the race could reappear. We haven't observed this in practice.
+- **No explicit "Discard Draft" UI yet.** A draft is cleared only when the user syncs. Manually clearing localStorage (or calling `Create Snapshot` with no changes) is the only way to drop a draft without syncing. Acceptable for MVP.
+- **If user legitimately deletes all tasks**, the `count === 0` guard means we *don't* persist that empty state — on next refresh they'd see their last non-empty draft. Intentional tradeoff: protect against Bryntum's transient empties at the cost of a rare undo flow.
+
+## Rules for Future Changes
+
+- **Never call `project.json = saved` without waiting** for the wrapper's post-load effects (the 500ms setTimeout). Doing so synchronously at `isLoading: false` time will race with `commitAsync`/`enableStm` and Bryntum will silently drop your records.
+- **Never dispatch `gantt-reload` from the draft restore path.** The wrapper listens for that event and calls `project.load()`, which fetches from the server and overwrites the draft you just applied.
+- **Bump the storage key prefix** (`gantt-draft-vN-`) whenever the bundle shape changes. Old keys will fail to parse, get deleted on next restore, and the user starts clean in the new format — no migration code needed.
+- **Keep the `count === 0` guard.** Removing it re-introduces the "empty draft wipes the project" bug that took hours to diagnose.
+- **Don't add features like multi-device sync or draft merging to this file.** Drafts are explicitly per-device, per-session. Cross-device work belongs in the existing Version + sync system.
+
+## Rollback
+
+To disable drafts temporarily: remove the `useGanttDraft(...)` call from `BryntumGanttWrapper.tsx` and the `hasGanttDraft(projectId)` call from the `isEditMode` initializer. Everything else (ganttChangesStore, the wrapper's own sync logic) continues to work — drafts just stop persisting. The next real sync clears any lingering localStorage entries.
+
+## Debugging
+
+The hook only logs via `console.warn` on genuine errors (parse failures, `commitAsync` rejections, `localStorage.setItem` throws). There are no diagnostic `console.log` calls in production code — they were stripped after the system stabilized.
+
+### Reproducing or diagnosing regressions
+
+If a regression appears and you need verbose tracing, add targeted logs at these decision points (they were originally numbered roughly in this order and the list is worth preserving):
+
+1. **Restore gate**: `isLoading`, `projectId`, `restoredRef.current`, whether a draft was found in localStorage, whether `bundleHasTasks` passed.
+2. **Restore timing**: before and after the 500ms `setTimeout`, so you can see if something intervened during the wait.
+3. **Pre/post-assignment counts**: `project.taskStore?.count` before and after `project.json = bundle.projectJson` to see whether the assignment actually loaded records.
+4. **Counter hydrate**: the `{added, modified, removed}` arrays pulled from the bundle, to confirm they match the badge number shown in the UI.
+5. **commitAsync timing**: a poll of `taskStore.count` every ~200ms for a few seconds after commit. If the count drops from N to 0 within that window, the 500ms delay isn't long enough or a new effect is interfering (this was the original race we hit).
+6. **Save guard**: whether the save was skipped due to `!projectJson` or `taskCount === 0`, and the source event (`taskStore.change` vs `dependencyStore.change`).
+
+### Common scenarios
+
+**"Counter shows wrong number after refresh."**
+The badge reads directly from `ganttChangesStore`, which `hydrate()` sets from the bundle. Either the snapshot at save time was already wrong, or something is calling `handleTaskChange` post-hydrate. Put a `console.log` right before the `hydrate()` call to confirm what went in, and compare to the actual badge after restore.
+
+**"Tasks don't show up after refresh."**
+Check `project.taskStore.count` immediately after `project.json = bundle.projectJson` — if it's non-zero, the data loaded. If the count later drops to zero, the 500ms delay lost its race with the wrapper's `commitAsync → enableStm` chain. Increase the delay temporarily (1000ms+) to confirm; the proper fix would be an explicit completion signal instead of a timer.
+
+**"Counter shows N but should be 0 after switching projects."**
+The restore effect calls `useGanttChangesStore.getState().reset()` before deciding what to hydrate. If the reset isn't running, the component didn't remount on project change (investigate route-group keying).
+
+**"Draft keeps getting wiped."**
+The `taskCount === 0` guard blocks Bryntum's transient empty states. If a draft is being overwritten anyway, Bryntum is reporting non-zero `project.json` but zero `taskStore.count` — a Bryntum inconsistency that would need separate investigation.
+
+### Inspecting / clearing localStorage manually
+
+```js
+// View current draft for a project (paste in console, replace projectId):
+JSON.parse(localStorage.getItem('gantt-draft-v4-{projectId}'))
+
+// Clear all Gantt drafts:
+Object.keys(localStorage)
+  .filter(k => k.startsWith('gantt-draft-'))
+  .forEach(k => localStorage.removeItem(k));
+
+// Clear just the current project's draft (paste projectId):
+localStorage.removeItem('gantt-draft-v4-{projectId}');
+```

--- a/src/app/api/gantt/sync/route.ts
+++ b/src/app/api/gantt/sync/route.ts
@@ -47,11 +47,6 @@ export async function POST(request: Request) {
       'tasks: +' + (taskChanges?.added?.length ?? 0),
       '~' + (taskChanges?.updated?.length ?? 0),
       '-' + (taskChanges?.removed?.length ?? 0));
-    if (taskChanges?.updated) {
-      for (const t of taskChanges.updated) {
-        console.log('[Gantt:sync] Updated task in payload:', t.id, '— version:', t.version, 'typeof version:', typeof t.version);
-      }
-    }
 
     // Create tRPC context and caller
     const ctx = await createTRPCContext({
@@ -71,10 +66,12 @@ export async function POST(request: Request) {
 
     return NextResponse.json(result);
   } catch (error) {
+    // Always return HTTP 200 with `{ success: false }`. Non-200 responses push
+    // Bryntum's CrudManager into `onCrudRequestFailure`, which crashes while
+    // iterating in-flight records ("Cannot set properties of undefined (setting
+    // 'isBeingMaterialized')"). 200 + success:false routes through `onCrudFailure`,
+    // which is safe, and the response is still surfaced via the `syncFail` listener.
     if (error instanceof TRPCError) {
-      // Version conflicts return HTTP 200 with conflict flag so Bryntum's CrudManager
-      // doesn't show its built-in error popup (which intercepts non-200 responses).
-      // We detect the conflict in the client-side 'sync' handler instead.
       if (error.code === 'CONFLICT') {
         console.log('[Gantt:sync] CONFLICT:', error.message);
         return NextResponse.json({
@@ -88,22 +85,17 @@ export async function POST(request: Request) {
           timeRanges: { rows: [] },
         });
       }
-      const statusMap: Record<string, number> = {
-        NOT_FOUND: 404,
-        FORBIDDEN: 403,
-        UNAUTHORIZED: 401,
-        BAD_REQUEST: 400,
-      };
-      const status = statusMap[error.code] ?? 500;
-      return NextResponse.json(
-        { success: false, message: error.message },
-        { status }
-      );
+      console.error('[Gantt:sync] tRPC error:', error.code, error.message);
+      return NextResponse.json({
+        success: false,
+        message: error.message,
+        code: error.code,
+      });
     }
     console.error("[Gantt:sync:route] Unexpected error:", error);
-    return NextResponse.json(
-      { success: false, message: "Internal server error" },
-      { status: 500 }
-    );
+    return NextResponse.json({
+      success: false,
+      message: error instanceof Error ? error.message : "Internal server error",
+    });
   }
 }

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -16,6 +16,9 @@ import TaskInfoDialog from './components/TaskInfoDialog';
 import { useBryntumThemeAssets } from './hooks/useBryntumThemeAssets';
 import { useTaskPopover } from './hooks/useTaskPopover';
 import { useGanttControls } from './hooks/useGanttControls';
+import { useGanttDraft, hasGanttDraft } from './hooks/useGanttDraft';
+import { injectTaskVersions } from './utils/injectTaskVersions';
+import { reconcileSyncPack } from './utils/reconcileSyncPack';
 import type { BryntumTaskRecord, BryntumGanttInstance } from './types';
 import GanttLoadingSpinner from './components/GanttLoadingSpinner';
 
@@ -77,18 +80,36 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
   const [taskInfoRecord, setTaskInfoRecord] = useState<BryntumTaskRecord | null>(null);
 
   // Lock mode: chart is locked by default; admin-level users can unlock to edit.
+  // If a localStorage draft is present we start unlocked — the user has unsaved
+  // work and clearly wants to keep editing rather than click a toggle first.
   const { currentOrg } = useOrgFromUrl();
   const canEditChart = canManageProjects(currentOrg?.role ?? '');
-  const [isEditMode, setIsEditMode] = useState(false);
+  const [isEditMode, setIsEditMode] = useState(() => hasGanttDraft(projectId));
   const editingUnlocked = canEditChart && isEditMode;
 
   const isReloadingRef = useRef(false);
   const skipVersionRef = useRef(false);
 
+  // Bryntum's CrudManager "added"/"removed" bags can drop records when the
+  // scheduling engine commits state between cycles (see force-sync comment below).
+  // We shadow-track IDs from the reliable taskStore events so `onBeforeSync` can
+  // reconcile the outgoing pack. `lastSync*` captures what was sent so we only
+  // clear those IDs on a successful sync (new changes during the request stay).
+  const pendingAddedIdsRef = useRef<Set<string>>(new Set());
+  const pendingRemovedIdsRef = useRef<Set<string>>(new Set());
+  const lastSyncAddedIdsRef = useRef<Set<string>>(new Set());
+  const lastSyncRemovedIdsRef = useRef<Set<string>>(new Set());
+
   const { selectedTask, popoverPlacement, handleTaskClick, closeTaskPopover, isTaskPopoverOpen } =
     useTaskPopover();
 
   useBryntumThemeAssets();
+
+  useGanttDraft({
+    getGanttInstance,
+    projectId,
+    isLoading,
+  });
 
   // Sync Bryntum's built-in readOnly flag with our edit-mode state.
   // This disables cell editing, task drag, task resize, and dependency creation.
@@ -145,42 +166,43 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
 
     const onSync = () => {
       skipVersionRef.current = false;
+      // Clear only the IDs that were actually sent in this sync cycle; any IDs
+      // added to pending* after `onBeforeSync` fired belong to the next sync.
+      for (const id of lastSyncAddedIdsRef.current) pendingAddedIdsRef.current.delete(id);
+      for (const id of lastSyncRemovedIdsRef.current) pendingRemovedIdsRef.current.delete(id);
+      lastSyncAddedIdsRef.current.clear();
+      lastSyncRemovedIdsRef.current.clear();
       void utils.gantt.tasks.invalidate();
-      // Sync complete — store events already tracked the changes
     };
 
     const onSyncFail = () => {
       skipVersionRef.current = false;
+      // Keep pending IDs intact for retry; just drop the in-flight snapshot.
+      lastSyncAddedIdsRef.current.clear();
+      lastSyncRemovedIdsRef.current.clear();
     };
 
-    // Inject version into sync payload for optimistic locking.
-    // Bryntum only sends changed fields; version is never edited by users so we must
-    // manually inject it for each updated record. Engine-cascaded records (successor
-    // recalculations) are intentionally NOT injected — they skip the version check.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const onBeforeSync = ({ pack }: { pack: any }) => {
+    // Engine-cascaded records (successor recalculations) are intentionally NOT
+    // injected — they skip the version check.
+    const onBeforeSync = ({ pack }: { pack: unknown }) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const taskStore = gantt.project.taskStore;
+      reconcileSyncPack(
+        pack,
+        taskStore as Parameters<typeof reconcileSyncPack>[1],
+        pendingAddedIdsRef.current,
+        pendingRemovedIdsRef.current,
+      );
+
+      // Snapshot IDs actually being sent so `onSync` can clear only these on success,
+      // without dropping new changes that arrive mid-request.
+      lastSyncAddedIdsRef.current = new Set(pendingAddedIdsRef.current);
+      lastSyncRemovedIdsRef.current = new Set(pendingRemovedIdsRef.current);
+
       // When user clicks "Proceed" after a conflict, skip version injection
       // so the server does a last-write-wins save (no version check).
-      if (skipVersionRef.current) {
-        return;
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const taskChanges = pack?.tasks as { updated?: Array<Record<string, unknown>> } | undefined;
-      if (taskChanges?.updated) {
-        for (const task of taskChanges.updated) {
-          if (task.id && typeof task.id === 'string') {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            const record = gantt.project.taskStore.getById(task.id) as { get?: (field: string) => unknown; data?: Record<string, unknown> } | null;
-            if (record?.get) {
-              const version = record.get('version');
-              if (typeof version === 'number') {
-                task.version = version;
-              }
-            }
-          }
-        }
-      }
+      if (skipVersionRef.current) return;
+      injectTaskVersions(pack, taskStore as Parameters<typeof injectTaskVersions>[1]);
     };
 
     // Track changes via direct store events (add/remove/update).
@@ -195,6 +217,7 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         .filter((r) => !r.isRoot && r.id)
         .map((r) => ({ id: String(r.id), name: r.name ?? 'New Task' }));
       if (tasks.length > 0) {
+        for (const t of tasks) pendingAddedIdsRef.current.add(t.id);
         window.dispatchEvent(new CustomEvent('gantt-task-change', {
           detail: { type: 'add', tasks },
         }));
@@ -208,6 +231,15 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         .filter((r) => !r.isRoot && r.id)
         .map((r) => ({ id: String(r.id), name: r.name ?? 'Task' }));
       if (tasks.length > 0) {
+        for (const t of tasks) {
+          // If added then removed before sync, the two cancel out. Otherwise track
+          // the removal so we can reconcile the pack if Bryntum drops it.
+          if (pendingAddedIdsRef.current.has(t.id)) {
+            pendingAddedIdsRef.current.delete(t.id);
+          } else {
+            pendingRemovedIdsRef.current.add(t.id);
+          }
+        }
         window.dispatchEvent(new CustomEvent('gantt-task-change', {
           detail: { type: 'remove', tasks },
         }));

--- a/src/components/bryntum/components/SaveVersionDialog.tsx
+++ b/src/components/bryntum/components/SaveVersionDialog.tsx
@@ -34,12 +34,12 @@ export default function SaveVersionDialog({ open, onOpenChange, projectId }: Sav
     onSuccess: (data) => {
       void utils.schedule.listVersions.invalidate({ projectId });
       window.dispatchEvent(new CustomEvent('gantt-version-saved', { detail: { name: data.name, id: data.id } }));
-      showSnackbar('Version saved', 'success');
+      showSnackbar('Snapshot created', 'success');
       reset();
       onOpenChange(false);
     },
     onError: (error) => {
-      showSnackbar(error.message || 'Failed to save version', 'error');
+      showSnackbar(error.message || 'Failed to create snapshot', 'error');
     },
   });
 
@@ -80,7 +80,7 @@ export default function SaveVersionDialog({ open, onOpenChange, projectId }: Sav
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
       <form onSubmit={handleSubmit(handleSave)}>
-        <DialogTitle sx={{ fontSize: 16, fontWeight: 600, pb: 0.5 }}>Save Version</DialogTitle>
+        <DialogTitle sx={{ fontSize: 16, fontWeight: 600, pb: 0.5 }}>Create Snapshot</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
           {/* Date & time pill */}
           <Box
@@ -119,7 +119,7 @@ export default function SaveVersionDialog({ open, onOpenChange, projectId }: Sav
             render={({ field }) => (
               <TextField
                 {...field}
-                label="Version name (optional)"
+                label="Snapshot name (optional)"
                 placeholder="e.g. Baseline v1 — March 31"
                 fullWidth
                 autoFocus
@@ -136,7 +136,7 @@ export default function SaveVersionDialog({ open, onOpenChange, projectId }: Sav
               <TextField
                 {...field}
                 label="Description (optional)"
-                placeholder="What changed in this version?"
+                placeholder="What changed in this snapshot?"
                 fullWidth
                 multiline
                 minRows={2}
@@ -153,7 +153,7 @@ export default function SaveVersionDialog({ open, onOpenChange, projectId }: Sav
             Cancel
           </Button>
           <Button variant="contained" size="small" type="submit" loading={isSyncing || saveMutation.isPending}>
-            Save
+            Create Snapshot
           </Button>
         </DialogActions>
       </form>

--- a/src/components/bryntum/components/VersionControlBar.tsx
+++ b/src/components/bryntum/components/VersionControlBar.tsx
@@ -169,7 +169,7 @@ export default function VersionControlBar() {
 
             {/* Save button */}
             <Tooltip
-              title={hasChanges ? 'Save a new version' : 'No unsaved changes'}
+              title={hasChanges ? 'Create a named snapshot you can restore later' : 'No changes since your last snapshot'}
               arrow
               placement="bottom"
             >
@@ -203,7 +203,7 @@ export default function VersionControlBar() {
                 }}
               >
                 <FloppyDisk size={12} weight={hasChanges ? 'fill' : 'regular'} />
-                Save
+                Snapshot
               </Box>
             </Tooltip>
           </Box>
@@ -245,7 +245,7 @@ export default function VersionControlBar() {
         >
           <GitDiff size={14} weight="bold" color="var(--status-amber)" />
           <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, letterSpacing: '-0.01em' }}>
-            {changeCount} Unsaved Change{changeCount !== 1 ? 's' : ''}
+            {changeCount} Change{changeCount !== 1 ? 's' : ''} Since Last Snapshot
           </Typography>
         </Box>
 

--- a/src/components/bryntum/hooks/useGanttDraft.ts
+++ b/src/components/bryntum/hooks/useGanttDraft.ts
@@ -1,0 +1,208 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useGanttChangesStore, type GanttChangesSnapshot } from '@/store/ganttChangesStore';
+
+interface GanttStoreRecord {
+  id?: string | number;
+  name?: string;
+  isRoot?: boolean;
+  [key: string]: unknown;
+}
+
+interface GanttStore {
+  on: (event: string, handler: () => void) => void;
+  un: (event: string, handler: () => void) => void;
+  count?: number;
+  records?: GanttStoreRecord[];
+}
+
+interface GanttProject {
+  json?: string;
+  taskStore?: GanttStore;
+  dependencyStore?: GanttStore;
+  commitAsync?: () => Promise<unknown>;
+  on?: (event: string, handler: () => void) => void;
+  un?: (event: string, handler: () => void) => void;
+}
+
+interface GanttInstance {
+  project?: GanttProject;
+}
+
+interface UseGanttDraftOptions {
+  getGanttInstance: () => GanttInstance | null;
+  projectId?: string;
+  isLoading: boolean;
+}
+
+const STORAGE_PREFIX = 'gantt-draft-v4-';
+
+function storageKey(projectId: string) {
+  return `${STORAGE_PREFIX}${projectId}`;
+}
+
+// Bundled format: the Bryntum project state (for Gantt to restore the store)
+// plus the live counter snapshot (for the "N changes since last snapshot" badge
+// to come back exactly as the user left it).
+interface DraftBundle {
+  projectJson: string;
+  counter: GanttChangesSnapshot;
+  savedAt: number;
+}
+
+function parseBundle(saved: string): DraftBundle | null {
+  try {
+    const parsed = JSON.parse(saved) as Partial<DraftBundle>;
+    if (typeof parsed.projectJson !== 'string' || !parsed.counter) return null;
+    return parsed as DraftBundle;
+  } catch {
+    return null;
+  }
+}
+
+function bundleHasTasks(bundle: DraftBundle): boolean {
+  try {
+    const project = JSON.parse(bundle.projectJson) as { tasks?: unknown[] };
+    return Array.isArray(project.tasks) && project.tasks.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+// Synchronous check for a saved draft with actual task data. Safe to call
+// during initial render — no effects, no Bryntum dependencies. Used by the
+// wrapper to auto-unlock edit mode when the user has unsaved work waiting
+// to be restored.
+export function hasGanttDraft(projectId: string | undefined): boolean {
+  if (typeof window === 'undefined' || !projectId) return false;
+  try {
+    const saved = window.localStorage.getItem(storageKey(projectId));
+    if (!saved) return false;
+    const bundle = parseBundle(saved);
+    return bundle != null && bundleHasTasks(bundle);
+  } catch {
+    return false;
+  }
+}
+
+// Per-device draft persistence for Gantt edits. Uses Bryntum's built-in
+// `project.json` getter/setter to snapshot and restore the full project
+// state — tasks, dependencies, assignments, resources. Drafts survive page
+// refresh / navigation; cleared on explicit sync.
+export function useGanttDraft({ getGanttInstance, projectId, isLoading }: UseGanttDraftOptions) {
+  const restoredRef = useRef(false);
+
+  // Restore draft once after Bryntum finishes loading server data.
+  useEffect(() => {
+    if (isLoading || !projectId || restoredRef.current) return;
+    const project = getGanttInstance()?.project;
+    if (!project) return;
+
+    restoredRef.current = true;
+
+    // The "N changes since last snapshot" counter is a singleton Zustand store.
+    // On project switch (component remount with a new projectId), it still
+    // holds counts from the previous project. Reset before we decide what to
+    // repopulate it with.
+    useGanttChangesStore.getState().reset();
+
+    const saved = localStorage.getItem(storageKey(projectId));
+    if (!saved) return;
+
+    const bundle = parseBundle(saved);
+    if (!bundle || !bundleHasTasks(bundle)) {
+      try {
+        localStorage.removeItem(storageKey(projectId));
+      } catch {
+        // ignore
+      }
+      return;
+    }
+
+    // Defer restore past the wrapper's post-load effects (commitAsync +
+    // enableStm). At isLoading:false, the wrapper schedules a commitAsync; its
+    // .then(() => enableStm()) runs async. If we restore mid-flight, something
+    // in that chain clears our records. 500ms is a heuristic that's worked
+    // reliably — if we regress, an explicit completion signal from the wrapper
+    // would be better.
+    const timer = setTimeout(() => {
+      try {
+        (project as { json: string }).json = bundle.projectJson;
+
+        // Hydrate the counter from the persisted snapshot — the exact state
+        // the user saw before refresh, including adds/modifies/removes that
+        // we couldn't infer from the store alone.
+        useGanttChangesStore.getState().hydrate(bundle.counter);
+
+        // Trigger a commitAsync so the chart paints the restored records.
+        void project.commitAsync?.().catch((err: unknown) => {
+          console.warn('[useGanttDraft] restore: commitAsync error', err);
+        });
+      } catch (err) {
+        console.warn('[useGanttDraft] restore failed', err);
+      }
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [isLoading, projectId, getGanttInstance]);
+
+  // Save the full project state on every store change. No debounce — the
+  // `taskCount === 0` guard below filters Bryntum's transient empty states,
+  // and debouncing would risk losing the user's last action if they refresh
+  // immediately after editing (e.g., delete task then Cmd+R).
+  useEffect(() => {
+    if (isLoading || !projectId) return;
+    const project = getGanttInstance()?.project;
+    if (!project) return;
+
+    const save = () => {
+      try {
+        const projectJson = (project as { json?: string }).json;
+        const taskCount = project.taskStore?.count ?? 0;
+        // Skip empty project.json (Bryntum returns nothing before init is done)
+        // and zero-task states (Bryntum's internal reconciliation fires `change`
+        // events mid-operation with the store momentarily empty — persisting
+        // that would wipe a valid draft).
+        if (!projectJson || taskCount === 0) return;
+
+        const bundle: DraftBundle = {
+          projectJson,
+          counter: useGanttChangesStore.getState().serialize(),
+          savedAt: Date.now(),
+        };
+        localStorage.setItem(storageKey(projectId), JSON.stringify(bundle));
+      } catch (err) {
+        console.warn('[useGanttDraft] save: error writing', err);
+      }
+    };
+
+    project.taskStore?.on('change', save);
+    project.dependencyStore?.on('change', save);
+
+    return () => {
+      project.taskStore?.un('change', save);
+      project.dependencyStore?.un('change', save);
+    };
+  }, [isLoading, projectId, getGanttInstance]);
+
+  // Clear draft when the user explicitly syncs (Create Snapshot succeeds).
+  useEffect(() => {
+    if (!projectId) return;
+    const project = getGanttInstance()?.project;
+    if (!project?.on || !project.un) return;
+
+    const clear = () => {
+      try {
+        localStorage.removeItem(storageKey(projectId));
+      } catch {
+        // ignore
+      }
+    };
+
+    project.on('sync', clear);
+    return () => {
+      project.un?.('sync', clear);
+    };
+  }, [projectId, getGanttInstance]);
+}

--- a/src/components/bryntum/utils/injectTaskVersions.ts
+++ b/src/components/bryntum/utils/injectTaskVersions.ts
@@ -1,0 +1,19 @@
+interface VersionedTaskStore {
+  getById?: (id: string) => { get?: (field: string) => unknown } | null;
+}
+
+// Bryntum only writes user-edited fields in the sync pack. `version` is never
+// edited by users, so the server's optimistic-lock check would fail without
+// manual injection here.
+export function injectTaskVersions(pack: unknown, taskStore: VersionedTaskStore | undefined): void {
+  const taskChanges = (pack as { tasks?: { updated?: Array<Record<string, unknown>> } } | null | undefined)?.tasks;
+  if (!taskChanges?.updated || !taskStore?.getById) return;
+  for (const task of taskChanges.updated) {
+    if (typeof task.id !== 'string') continue;
+    const record = taskStore.getById(task.id);
+    const version = record?.get?.('version');
+    if (typeof version === 'number') {
+      task.version = version;
+    }
+  }
+}

--- a/src/components/bryntum/utils/reconcileSyncPack.ts
+++ b/src/components/bryntum/utils/reconcileSyncPack.ts
@@ -1,0 +1,52 @@
+interface ReconcileTaskStore {
+  getById?: (id: string) => { data?: Record<string, unknown> } | null;
+}
+
+interface SyncPack {
+  tasks?: {
+    added?: Array<Record<string, unknown>>;
+    removed?: Array<{ id: string | number }>;
+  };
+}
+
+// Bryntum's scheduling engine commits dirty state during deferred calculations,
+// which can drop records from the CrudManager's added/removed bags before sync
+// fires. Callers populate pendingAdded/Removed from `taskStore.on('add'/'remove')`
+// which fire reliably at user-action time — this injects any records Bryntum lost
+// so the outgoing pack matches what the user did.
+export function reconcileSyncPack(
+  pack: unknown,
+  taskStore: ReconcileTaskStore | undefined,
+  pendingAddedIds: Set<string>,
+  pendingRemovedIds: Set<string>
+): void {
+  if (!pack || typeof pack !== 'object') return;
+  const typed = pack as SyncPack;
+
+  if (pendingAddedIds.size > 0 && taskStore?.getById) {
+    const bagAddedIds = new Set((typed.tasks?.added ?? []).map((t) => String(t.id)));
+    const missing = Array.from(pendingAddedIds).filter((id) => !bagAddedIds.has(id));
+    if (missing.length > 0) {
+      typed.tasks = typed.tasks ?? {};
+      typed.tasks.added = typed.tasks.added ?? [];
+      for (const id of missing) {
+        const record = taskStore.getById(id);
+        if (record?.data) {
+          typed.tasks.added.push({ ...record.data });
+        }
+      }
+    }
+  }
+
+  if (pendingRemovedIds.size > 0) {
+    const bagRemovedIds = new Set((typed.tasks?.removed ?? []).map((t) => String(t.id)));
+    const missing = Array.from(pendingRemovedIds).filter((id) => !bagRemovedIds.has(id));
+    if (missing.length > 0) {
+      typed.tasks = typed.tasks ?? {};
+      typed.tasks.removed = typed.tasks.removed ?? [];
+      for (const id of missing) {
+        typed.tasks.removed.push({ id });
+      }
+    }
+  }
+}

--- a/src/server/api/helpers/ganttSync.ts
+++ b/src/server/api/helpers/ganttSync.ts
@@ -90,8 +90,28 @@ export async function syncTasks(
       return phantomIdMap.get(parentId) ?? parentId;
     };
 
+    // Pre-fetch all existing task IDs in this project so we can verify parent references
+    // before INSERT — otherwise a stale parentId (task deleted in a prior sync, or a
+    // phantom reference that never resolved) triggers FK violation and rolls back
+    // the whole transaction. Better to null the parent and log than fail the batch.
+    const existingTaskIds = new Set(
+      (await db.ganttTask.findMany({ where: { projectId }, select: { id: true } }))
+        .map((t) => t.id),
+    );
+    // Pre-assigned IDs in this batch also count as "existing" because they insert first.
+    for (const { id } of tasksWithIds) existingTaskIds.add(id);
+
     for (const { task, id } of sorted) {
-      const parentId = resolveParentId(task.parentId);
+      let parentId = resolveParentId(task.parentId);
+      if (parentId && !existingTaskIds.has(parentId)) {
+        console.warn('[Gantt:syncTasks] Orphan parentId — setting to null:', {
+          taskId: id,
+          phantomId: task.$PhantomId,
+          unresolvedParentId: task.parentId,
+          resolvedAs: parentId,
+        });
+        parentId = null;
+      }
 
       await db.ganttTask.create({
         data: {
@@ -156,9 +176,28 @@ export async function syncTasks(
       // Resolve parent phantom ID if needed (any phantom format, not just "$"-prefixed)
       if (task.parentId !== undefined) {
         const rawParentId = task.parentId;
-        updateData.parentId = rawParentId
+        const resolved = rawParentId
           ? (phantomIdMap.get(rawParentId) ?? rawParentId)
           : null;
+        if (resolved) {
+          // Verify parent actually exists to avoid FK violation rolling back the batch
+          const parentExists = await db.ganttTask.findUnique({
+            where: { id: resolved },
+            select: { id: true },
+          });
+          if (!parentExists) {
+            console.warn('[Gantt:syncTasks] Orphan parentId on update — setting to null:', {
+              taskId: task.id,
+              unresolvedParentId: rawParentId,
+              resolvedAs: resolved,
+            });
+            updateData.parentId = null;
+          } else {
+            updateData.parentId = resolved;
+          }
+        } else {
+          updateData.parentId = null;
+        }
       }
 
       // Optimistic version check: only if client sent a version (direct user edits).

--- a/src/store/ganttChangesStore.ts
+++ b/src/store/ganttChangesStore.ts
@@ -14,6 +14,12 @@ interface InternalState {
   removed: Map<string, string>;  // id → name
 }
 
+export interface GanttChangesSnapshot {
+  added: Array<[string, string]>;
+  modified: Array<[string, string]>;
+  removed: Array<[string, string]>;
+}
+
 interface GanttChangesStore {
   hasChanges: boolean;
   changeCount: number;
@@ -26,6 +32,10 @@ interface GanttChangesStore {
   setActiveVersionId: (id: string | null) => void;
   handleTaskChange: (type: 'add' | 'remove' | 'update', tasks: TaskEntry[]) => void;
   reset: () => void;
+  /** Snapshot the raw internal maps so the draft layer can persist them verbatim. */
+  serialize: () => GanttChangesSnapshot;
+  /** Restore the raw internal maps from a snapshot. Used by draft restore. */
+  hydrate: (snapshot: GanttChangesSnapshot) => void;
 }
 
 function computePublicState(internal: InternalState) {
@@ -88,6 +98,21 @@ export const useGanttChangesStore = create<GanttChangesStore>((set) => {
 
     reset: () => {
       internal = { added: new Map(), modified: new Map(), removed: new Map() };
+      set(computePublicState(internal));
+    },
+
+    serialize: () => ({
+      added: Array.from(internal.added.entries()),
+      modified: Array.from(internal.modified.entries()),
+      removed: Array.from(internal.removed.entries()),
+    }),
+
+    hydrate: (snapshot) => {
+      internal = {
+        added: new Map(snapshot.added),
+        modified: new Map(snapshot.modified),
+        removed: new Map(snapshot.removed),
+      };
       set(computePublicState(internal));
     },
   };


### PR DESCRIPTION
## Summary
- Adds per-device draft persistence for Bryntum Gantt via `useGanttDraft` — unsaved edits are snapshotted to localStorage on every store change and restored 500ms after server load settles, with the "N changes since last snapshot" counter rehydrated in lockstep via new `serialize`/`hydrate` on `ganttChangesStore`.
- Hardens the sync pipeline: `/api/gantt/sync` now always returns HTTP 200 so Bryntum's CrudManager routes errors through `onCrudFailure` instead of the crashy `onCrudRequestFailure` path, and a new `reconcileSyncPack` util reinjects added/removed records that Bryntum's bags drop mid-cycle using shadow-tracked IDs from the wrapper.
- `syncTasks` now verifies parent existence before INSERT/UPDATE and nulls orphan `parentId`s instead of letting FK violations roll back the whole transaction.
- UI rename Version → Snapshot in `SaveVersionDialog`/`VersionControlBar`, new `claudedocs/gantt-drafts.md` documenting the full draft lifecycle and non-obvious design tradeoffs.

## Test plan
- [ ] Edit a task, refresh the page — the edit and "N changes" badge both come back
- [ ] Edit a task, navigate away and back — draft restores and edit mode is auto-unlocked
- [ ] Click Create Snapshot with changes — draft clears on success, counter resets
- [ ] Trigger a sync conflict — UI still routes through conflict dialog (no CrudManager crash)
- [ ] Switch projects — counter resets, other project's draft loads if present

🤖 Generated with [Claude Code](https://claude.com/claude-code)