### PR TITLE
Fix digest workflow: set GH_REPO so gh CLI works without checkout

### DIFF
--- a/.github/workflows/preview-digest.yml
+++ b/.github/workflows/preview-digest.yml
@@ -16,6 +16,7 @@ jobs:
       pull-requests: read
     env:
       GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       RECIPIENTS: '["lawrence.nicastro1@gmail.com","chaseton9@gmail.com"]'


### PR DESCRIPTION
## Summary
- First live run of the digest workflow failed with `fatal: not a git repository` because `gh pr list` needs repo context and we don't run `actions/checkout`.
- Fix: set `GH_REPO: \${{ github.repository }}` in the job env. One-line change.
- No runtime code touched.

## Test plan
- [ ] Dispatch: \`gh workflow run preview-digest.yml --ref preview\`
- [ ] Run completes without the git error and either sends the digest or exits with "Nothing merged yesterday"

🤖 Generated with [Claude Code](https://claude.com/claude-code)