### PR TITLE
Let owners edit organization details from the account tab

### DIFF
--- a/src/components/layout/AccountTabContent.tsx
+++ b/src/components/layout/AccountTabContent.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import { Box, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { motion, AnimatePresence, type Variants } from 'framer-motion';
 import { IBeamLoader } from '@/components/ui/IBeamLoader';
 import { Plus, Crown, CaretRight, ArrowLeft } from '@phosphor-icons/react';
 import { useRouter } from 'next/navigation';
@@ -14,6 +16,33 @@ import OrgDetailsForm from '@/components/organization/OrgDetailsForm';
 interface AccountTabContentProps {
   onCloseModal: () => void;
 }
+
+const EASE = [0.4, 0, 0.2, 1] as const;
+
+const listViewVariants: Variants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { duration: 0.18, ease: 'easeOut', when: 'beforeChildren' },
+  },
+  exit: { opacity: 0, x: -6, transition: { duration: 0.12 } },
+};
+
+const drillViewVariants: Variants = {
+  hidden: { opacity: 0, x: 8 },
+  visible: { opacity: 1, x: 0, transition: { duration: 0.22, ease: EASE } },
+  exit: { opacity: 0, x: 4, transition: { duration: 0.12 } },
+};
+
+const listStaggerVariants: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.04 } },
+};
+
+const rowVariants: Variants = {
+  hidden: { opacity: 0, y: 6 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.22, ease: EASE } },
+};
 
 export default function AccountTabContent({ onCloseModal }: AccountTabContentProps) {
   const router = useRouter();
@@ -37,143 +66,230 @@ export default function AccountTabContent({ onCloseModal }: AccountTabContentPro
     );
   }
 
-  if (editingOrgId) {
-    const editingOrg = organizations.find((o) => o.id === editingOrgId);
-    const canEdit = editingOrg ? canManageOrganization(editingOrg.role) : false;
-
-    return (
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <Box
-          component="button"
-          onClick={() => setEditingOrgId(null)}
-          sx={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 0.75,
-            alignSelf: 'flex-start',
-            px: 0.5,
-            py: 0.25,
-            bgcolor: 'transparent',
-            border: 'none',
-            cursor: 'pointer',
-            color: 'text.secondary',
-            fontSize: '0.75rem',
-            fontWeight: 500,
-            borderRadius: '6px',
-            transition: 'color 0.15s',
-            '&:hover': { color: 'text.primary' },
-          }}
-        >
-          <ArrowLeft size={13} weight="bold" />
-          Back to teams
-        </Box>
-        <OrgDetailsForm organizationId={editingOrgId} canEdit={canEdit} />
-      </Box>
-    );
-  }
+  const editingOrg = editingOrgId
+    ? organizations.find((o) => o.id === editingOrgId)
+    : null;
+  const drillCanEdit = editingOrg ? canManageOrganization(editingOrg.role) : false;
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-      {/* Section header */}
-      <Box>
-        <Typography sx={{ fontSize: '0.9375rem', fontWeight: 600, lineHeight: 1.3 }}>
-          Your Teams
-        </Typography>
-        <Typography sx={{ fontSize: '0.8125rem', color: 'text.secondary', lineHeight: 1.4, mt: 0.5 }}>
-          Teams you belong to across all organizations.
-        </Typography>
-      </Box>
+    <AnimatePresence mode="wait">
+      {editingOrgId ? (
+        <motion.div
+          key="drill"
+          variants={drillViewVariants}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+        >
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box
+              component="button"
+              onClick={() => setEditingOrgId(null)}
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.75,
+                alignSelf: 'flex-start',
+                px: 0.5,
+                py: 0.25,
+                bgcolor: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                color: 'text.secondary',
+                fontSize: '0.75rem',
+                fontWeight: 500,
+                borderRadius: '6px',
+                transition: 'color 0.15s, transform 0.15s',
+                '& .back-arrow': {
+                  transition: 'transform 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+                },
+                '&:hover': {
+                  color: 'text.primary',
+                  '& .back-arrow': { transform: 'translateX(-2px)' },
+                },
+                '&:active': { transform: 'scale(0.985)' },
+                '&:focus-visible': {
+                  outline: '2px solid',
+                  outlineColor: 'primary.main',
+                  outlineOffset: 2,
+                },
+              }}
+            >
+              <Box component="span" className="back-arrow" sx={{ display: 'inline-flex' }}>
+                <ArrowLeft size={13} weight="bold" />
+              </Box>
+              Back to teams
+            </Box>
+            <OrgDetailsForm organizationId={editingOrgId} canEdit={drillCanEdit} />
+          </Box>
+        </motion.div>
+      ) : (
+        <motion.div
+          key="list"
+          variants={listViewVariants}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+        >
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+            {/* Section header */}
+            <Box>
+              <Typography sx={{ fontSize: '0.9375rem', fontWeight: 600, lineHeight: 1.3 }}>
+                Your Teams
+              </Typography>
+              <Typography sx={{ fontSize: '0.8125rem', color: 'text.secondary', lineHeight: 1.4, mt: 0.5 }}>
+                Teams you belong to across all organizations.
+              </Typography>
+            </Box>
 
-      {/* Org list */}
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-        {organizations.map((org) => {
-          const canEdit = canManageOrganization(org.role);
+            {/* Org list */}
+            <Box
+              component={motion.div}
+              variants={listStaggerVariants}
+              sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
+            >
+              {organizations.map((org) => {
+                const canEdit = canManageOrganization(org.role);
+                const isOwner = org.role === 'owner';
 
-          const rowContent = (
-            <>
-              <OrgAvatar
-                name={org.name}
-                seed={org.slug ?? org.id}
-                logoUrl={org.logoUrl}
-                size={36}
-                borderRadius="10px"
-              />
-              <Box sx={{ minWidth: 0, flex: 1, textAlign: 'left' }}>
-                <Typography
-                  sx={{
-                    fontSize: '0.875rem',
-                    fontWeight: 500,
-                    lineHeight: 1.2,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  {org.name}
-                </Typography>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
-                  {org.role === 'owner' && (
-                    <Crown size={10} weight="fill" style={{ color: 'inherit' }} />
-                  )}
-                  <Typography
-                    sx={{
-                      fontSize: '0.6875rem',
-                      color: 'text.disabled',
+                const rolePill = (
+                  <Box
+                    sx={(theme) => ({
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 0.375,
+                      mt: 0.5,
+                      px: 0.875,
+                      py: 0.25,
+                      borderRadius: '999px',
+                      bgcolor: isOwner
+                        ? alpha(theme.palette.warning.main, 0.18)
+                        : alpha(theme.palette.text.primary, 0.08),
+                      color: isOwner ? theme.palette.warning.dark : theme.palette.text.secondary,
+                      fontSize: '0.625rem',
+                      fontWeight: 600,
                       lineHeight: 1,
+                      letterSpacing: '0.01em',
+                    })}
+                  >
+                    {isOwner && <Crown size={9} weight="fill" />}
+                    {formatRole(org.role)}
+                  </Box>
+                );
+
+                const rowContent = (
+                  <>
+                    <OrgAvatar
+                      className="row-avatar"
+                      name={org.name}
+                      seed={org.slug ?? org.id}
+                      logoUrl={org.logoUrl}
+                      size={36}
+                      borderRadius="10px"
+                    />
+                    <Box sx={{ minWidth: 0, flex: 1, textAlign: 'left' }}>
+                      <Typography
+                        sx={{
+                          fontSize: '0.875rem',
+                          fontWeight: 500,
+                          lineHeight: 1.2,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {org.name}
+                      </Typography>
+                      {rolePill}
+                    </Box>
+                    {canEdit && (
+                      <CaretRight
+                        className="row-chevron"
+                        size={14}
+                        weight="bold"
+                        style={{ color: 'var(--mui-palette-text-disabled)', flexShrink: 0 }}
+                      />
+                    )}
+                  </>
+                );
+
+                if (canEdit) {
+                  return (
+                    <Box
+                      key={org.id}
+                      component={motion.div}
+                      variants={rowVariants}
+                      sx={{ width: '100%' }}
+                    >
+                      <Box
+                        component="button"
+                        onClick={() => setEditingOrgId(org.id)}
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 1.5,
+                          px: 1.5,
+                          py: 1.25,
+                          width: '100%',
+                          border: 'none',
+                          borderRadius: '8px',
+                          bgcolor: 'action.hover',
+                          cursor: 'pointer',
+                          transition: 'background-color 0.15s, transform 0.15s',
+                          '& .row-chevron': {
+                            opacity: 0.4,
+                            transition: 'transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s ease',
+                          },
+                          '& .row-avatar': {
+                            transition: 'transform 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+                          },
+                          '&:hover': {
+                            bgcolor: 'action.selected',
+                            '& .row-avatar': { transform: 'scale(1.04)' },
+                            '& .row-chevron': {
+                              transform: 'translateX(3px)',
+                              opacity: 1,
+                            },
+                          },
+                          '&:active': { transform: 'scale(0.985)' },
+                          '&:focus-visible': {
+                            outline: '2px solid',
+                            outlineColor: 'primary.main',
+                            outlineOffset: 2,
+                          },
+                        }}
+                      >
+                        {rowContent}
+                      </Box>
+                    </Box>
+                  );
+                }
+
+                return (
+                  <Box
+                    key={org.id}
+                    component={motion.div}
+                    variants={rowVariants}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1.5,
+                      px: 1.5,
+                      py: 1.25,
+                      borderRadius: '8px',
+                      bgcolor: 'action.hover',
                     }}
                   >
-                    {formatRole(org.role)}
-                  </Typography>
-                </Box>
-              </Box>
-              {canEdit && (
-                <CaretRight
-                  className="row-chevron"
-                  size={14}
-                  weight="bold"
-                  style={{ color: 'var(--mui-palette-text-disabled)', flexShrink: 0 }}
-                />
-              )}
-            </>
-          );
+                    {rowContent}
+                  </Box>
+                );
+              })}
+            </Box>
 
-          if (canEdit) {
-            return (
-              <Box
-                key={org.id}
-                component="button"
-                onClick={() => setEditingOrgId(org.id)}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1.5,
-                  px: 1.5,
-                  py: 1.25,
-                  width: '100%',
-                  border: 'none',
-                  borderRadius: '8px',
-                  bgcolor: 'action.hover',
-                  cursor: 'pointer',
-                  transition: 'background-color 0.15s',
-                  '& .row-chevron': {
-                    transition: 'transform 0.15s',
-                  },
-                  '&:hover': {
-                    bgcolor: 'action.selected',
-                    '& .row-chevron': {
-                      transform: 'translateX(2px)',
-                    },
-                  },
-                }}
-              >
-                {rowContent}
-              </Box>
-            );
-          }
-
-          return (
+            {/* Create new team */}
             <Box
-              key={org.id}
+              component="button"
+              onClick={handleCreateTeam}
               sx={{
                 display: 'flex',
                 alignItems: 'center',
@@ -181,74 +297,63 @@ export default function AccountTabContent({ onCloseModal }: AccountTabContentPro
                 px: 1.5,
                 py: 1.25,
                 borderRadius: '8px',
-                bgcolor: 'action.hover',
+                border: '1px dashed',
+                borderColor: 'divider',
+                bgcolor: 'transparent',
+                cursor: 'pointer',
+                transition: 'all 0.15s',
+                '&:hover': {
+                  bgcolor: 'action.hover',
+                  borderColor: 'text.disabled',
+                },
+                '&:active': { transform: 'scale(0.985)' },
+                '&:focus-visible': {
+                  outline: '2px solid',
+                  outlineColor: 'primary.main',
+                  outlineOffset: 2,
+                },
               }}
             >
-              {rowContent}
+              <Box
+                sx={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: '10px',
+                  bgcolor: 'action.hover',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                }}
+              >
+                <Plus size={16} weight="bold" />
+              </Box>
+              <Box sx={{ textAlign: 'left' }}>
+                <Typography
+                  sx={{
+                    fontSize: '0.875rem',
+                    fontWeight: 500,
+                    lineHeight: 1.2,
+                    color: 'text.primary',
+                  }}
+                >
+                  Create New Team
+                </Typography>
+                <Typography
+                  sx={{
+                    fontSize: '0.6875rem',
+                    color: 'text.disabled',
+                    lineHeight: 1,
+                    mt: 0.25,
+                  }}
+                >
+                  Set up a new construction company
+                </Typography>
+              </Box>
             </Box>
-          );
-        })}
-      </Box>
-
-      {/* Create new team */}
-      <Box
-        component="button"
-        onClick={handleCreateTeam}
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1.5,
-          px: 1.5,
-          py: 1.25,
-          borderRadius: '8px',
-          border: '1px dashed',
-          borderColor: 'divider',
-          bgcolor: 'transparent',
-          cursor: 'pointer',
-          transition: 'all 0.15s',
-          '&:hover': {
-            bgcolor: 'action.hover',
-            borderColor: 'text.disabled',
-          },
-        }}
-      >
-        <Box
-          sx={{
-            width: 36,
-            height: 36,
-            borderRadius: '10px',
-            bgcolor: 'action.hover',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            flexShrink: 0,
-          }}
-        >
-          <Plus size={16} weight="bold" />
-        </Box>
-        <Box sx={{ textAlign: 'left' }}>
-          <Typography
-            sx={{
-              fontSize: '0.875rem',
-              fontWeight: 500,
-              lineHeight: 1.2,
-              color: 'text.primary',
-            }}
-          >
-            Create New Team
-          </Typography>
-          <Typography
-            sx={{
-              fontSize: '0.6875rem',
-              color: 'text.disabled',
-              lineHeight: 1,
-              mt: 0.25,
-            }}
-          >
-            Set up a new construction company
-          </Typography>
-        </Box>
-      </Box>
-    </Box>
+          </Box>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/src/components/layout/AccountTabContent.tsx
+++ b/src/components/layout/AccountTabContent.tsx
@@ -1,13 +1,15 @@
 'use client';
 
+import { useState } from 'react';
 import { Box, Typography } from '@mui/material';
 import { IBeamLoader } from '@/components/ui/IBeamLoader';
-import { Plus, Crown, Buildings } from '@phosphor-icons/react';
+import { Plus, Crown, CaretRight, ArrowLeft } from '@phosphor-icons/react';
 import { useRouter } from 'next/navigation';
-import { Button } from '@/components/ui/button';
 import { api } from '@/trpc/react';
 import { formatRole } from '@/lib/utils/formatting';
+import { canManageOrganization } from '@/lib/permissions';
 import OrgAvatar from '@/components/ui/OrgAvatar';
+import OrgDetailsForm from '@/components/organization/OrgDetailsForm';
 
 interface AccountTabContentProps {
   onCloseModal: () => void;
@@ -15,6 +17,8 @@ interface AccountTabContentProps {
 
 export default function AccountTabContent({ onCloseModal }: AccountTabContentProps) {
   const router = useRouter();
+  const [editingOrgId, setEditingOrgId] = useState<string | null>(null);
+
   const { data: organizations = [], isLoading } = api.organization.list.useQuery(
     undefined,
     { retry: false },
@@ -33,6 +37,41 @@ export default function AccountTabContent({ onCloseModal }: AccountTabContentPro
     );
   }
 
+  if (editingOrgId) {
+    const editingOrg = organizations.find((o) => o.id === editingOrgId);
+    const canEdit = editingOrg ? canManageOrganization(editingOrg.role) : false;
+
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box
+          component="button"
+          onClick={() => setEditingOrgId(null)}
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.75,
+            alignSelf: 'flex-start',
+            px: 0.5,
+            py: 0.25,
+            bgcolor: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+            color: 'text.secondary',
+            fontSize: '0.75rem',
+            fontWeight: 500,
+            borderRadius: '6px',
+            transition: 'color 0.15s',
+            '&:hover': { color: 'text.primary' },
+          }}
+        >
+          <ArrowLeft size={13} weight="bold" />
+          Back to teams
+        </Box>
+        <OrgDetailsForm organizationId={editingOrgId} canEdit={canEdit} />
+      </Box>
+    );
+  }
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
       {/* Section header */}
@@ -47,56 +86,108 @@ export default function AccountTabContent({ onCloseModal }: AccountTabContentPro
 
       {/* Org list */}
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-        {organizations.map((org) => (
-          <Box
-            key={org.id}
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 1.5,
-              px: 1.5,
-              py: 1.25,
-              borderRadius: '8px',
-              bgcolor: 'action.hover',
-            }}
-          >
-            <OrgAvatar
-              name={org.name}
-              seed={org.slug ?? org.id}
-              logoUrl={org.logoUrl}
-              size={36}
-              borderRadius="10px"
-            />
-            <Box sx={{ minWidth: 0, flex: 1 }}>
-              <Typography
-                sx={{
-                  fontSize: '0.875rem',
-                  fontWeight: 500,
-                  lineHeight: 1.2,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {org.name}
-              </Typography>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
-                {org.role === 'owner' && (
-                  <Crown size={10} weight="fill" style={{ color: 'inherit' }} />
-                )}
+        {organizations.map((org) => {
+          const canEdit = canManageOrganization(org.role);
+
+          const rowContent = (
+            <>
+              <OrgAvatar
+                name={org.name}
+                seed={org.slug ?? org.id}
+                logoUrl={org.logoUrl}
+                size={36}
+                borderRadius="10px"
+              />
+              <Box sx={{ minWidth: 0, flex: 1, textAlign: 'left' }}>
                 <Typography
                   sx={{
-                    fontSize: '0.6875rem',
-                    color: 'text.disabled',
-                    lineHeight: 1,
+                    fontSize: '0.875rem',
+                    fontWeight: 500,
+                    lineHeight: 1.2,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
                   }}
                 >
-                  {formatRole(org.role)}
+                  {org.name}
                 </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
+                  {org.role === 'owner' && (
+                    <Crown size={10} weight="fill" style={{ color: 'inherit' }} />
+                  )}
+                  <Typography
+                    sx={{
+                      fontSize: '0.6875rem',
+                      color: 'text.disabled',
+                      lineHeight: 1,
+                    }}
+                  >
+                    {formatRole(org.role)}
+                  </Typography>
+                </Box>
               </Box>
+              {canEdit && (
+                <CaretRight
+                  className="row-chevron"
+                  size={14}
+                  weight="bold"
+                  style={{ color: 'var(--mui-palette-text-disabled)', flexShrink: 0 }}
+                />
+              )}
+            </>
+          );
+
+          if (canEdit) {
+            return (
+              <Box
+                key={org.id}
+                component="button"
+                onClick={() => setEditingOrgId(org.id)}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1.5,
+                  px: 1.5,
+                  py: 1.25,
+                  width: '100%',
+                  border: 'none',
+                  borderRadius: '8px',
+                  bgcolor: 'action.hover',
+                  cursor: 'pointer',
+                  transition: 'background-color 0.15s',
+                  '& .row-chevron': {
+                    transition: 'transform 0.15s',
+                  },
+                  '&:hover': {
+                    bgcolor: 'action.selected',
+                    '& .row-chevron': {
+                      transform: 'translateX(2px)',
+                    },
+                  },
+                }}
+              >
+                {rowContent}
+              </Box>
+            );
+          }
+
+          return (
+            <Box
+              key={org.id}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.5,
+                px: 1.5,
+                py: 1.25,
+                borderRadius: '8px',
+                bgcolor: 'action.hover',
+              }}
+            >
+              {rowContent}
             </Box>
-          </Box>
-        ))}
+          );
+        })}
       </Box>
 
       {/* Create new team */}

--- a/src/components/organization/OrgDetailsForm.tsx
+++ b/src/components/organization/OrgDetailsForm.tsx
@@ -1,0 +1,312 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Box,
+  TextField,
+  Typography,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+} from '@mui/material';
+import { IBeamLoader } from '@/components/ui/IBeamLoader';
+import { Button } from '@/components/ui/button';
+import { api } from '@/trpc/react';
+import { useSnackbar } from '@/hooks/useSnackbar';
+import {
+  updateOrganizationSchema,
+  type UpdateOrganizationInput,
+} from '@/lib/validations/organization';
+import { COMPANY_TYPES } from '@/lib/constants/companyTypes';
+import OrgLogoUploader from './OrgLogoUploader';
+
+interface OrgDetailsFormProps {
+  organizationId: string;
+  canEdit: boolean;
+}
+
+const emptyDefaults: UpdateOrganizationInput = {
+  name: '',
+  companyType: '',
+  phone: '',
+  website: '',
+  address: '',
+  city: '',
+  state: '',
+  zip: '',
+  licenseNumber: '',
+  logoUrl: undefined,
+};
+
+export default function OrgDetailsForm({ organizationId, canEdit }: OrgDetailsFormProps) {
+  const { showSnackbar } = useSnackbar();
+  const utils = api.useUtils();
+
+  const { data: org, isLoading } = api.organization.getById.useQuery({ organizationId });
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors, isDirty },
+  } = useForm<UpdateOrganizationInput>({
+    resolver: zodResolver(updateOrganizationSchema),
+    defaultValues: emptyDefaults,
+  });
+
+  useEffect(() => {
+    if (org) {
+      reset(
+        {
+          name: org.name ?? '',
+          companyType: org.companyType ?? '',
+          phone: org.phone ?? '',
+          website: org.website ?? '',
+          address: org.address ?? '',
+          city: org.city ?? '',
+          state: org.state ?? '',
+          zip: org.zip ?? '',
+          licenseNumber: org.licenseNumber ?? '',
+          logoUrl: org.logoUrl ?? undefined,
+        },
+        { keepDirtyValues: true },
+      );
+    }
+  }, [org, reset]);
+
+  const updateOrg = api.organization.update.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.organization.getById.invalidate({ organizationId }),
+        utils.organization.list.invalidate(),
+      ]);
+    },
+    onError: (error) => {
+      showSnackbar(error.message || 'Failed to update organization', 'error');
+    },
+  });
+
+  const handleSave = handleSubmit(async (data) => {
+    await updateOrg.mutateAsync({ ...data, organizationId });
+    showSnackbar('Organization updated', 'success');
+  });
+
+  const handleLogoUpload = async (url: string) => {
+    await updateOrg.mutateAsync({ organizationId, logoUrl: url });
+    reset((prev) => ({ ...prev, logoUrl: url }), { keepDirty: true, keepDirtyValues: true });
+    showSnackbar('Logo updated', 'success');
+  };
+
+  if (isLoading || !org) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
+        <IBeamLoader size={28} />
+      </Box>
+    );
+  }
+
+  const watchedLogoUrl = watch('logoUrl');
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      {/* Logo + name row */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <OrgLogoUploader
+          name={org.name}
+          seed={org.slug ?? org.id}
+          logoUrl={watchedLogoUrl || org.logoUrl}
+          disabled={!canEdit}
+          onUpload={handleLogoUpload}
+          onError={(msg) => showSnackbar(msg, 'error')}
+        />
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography sx={{ fontSize: '1rem', fontWeight: 600, lineHeight: 1.3 }}>
+            {org.name}
+          </Typography>
+          <Typography sx={{ fontSize: '0.75rem', color: 'text.disabled', lineHeight: 1.3 }}>
+            {canEdit ? 'Click the logo to upload a new image.' : 'View-only — only owners can edit.'}
+          </Typography>
+        </Box>
+      </Box>
+
+      <form onSubmit={handleSave} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <Controller
+          name="name"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="Company name"
+              fullWidth
+              size="small"
+              disabled={!canEdit}
+              error={!!errors.name}
+              helperText={errors.name?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="companyType"
+          control={control}
+          render={({ field }) => (
+            <FormControl fullWidth size="small" disabled={!canEdit} error={!!errors.companyType}>
+              <InputLabel id="company-type-label">Company type</InputLabel>
+              <Select
+                labelId="company-type-label"
+                label="Company type"
+                {...field}
+                value={field.value ?? ''}
+              >
+                {COMPANY_TYPES.map((type) => (
+                  <MenuItem key={type} value={type}>
+                    {type}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+        />
+
+        <Controller
+          name="phone"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="Phone"
+              fullWidth
+              size="small"
+              disabled={!canEdit}
+              error={!!errors.phone}
+              helperText={errors.phone?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="website"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="Website"
+              placeholder="https://example.com"
+              fullWidth
+              size="small"
+              disabled={!canEdit}
+              error={!!errors.website}
+              helperText={errors.website?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="address"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="Street address"
+              fullWidth
+              size="small"
+              disabled={!canEdit}
+              error={!!errors.address}
+              helperText={errors.address?.message}
+            />
+          )}
+        />
+
+        <Box sx={{ display: 'flex', gap: 1.5 }}>
+          <Controller
+            name="city"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="City"
+                fullWidth
+                size="small"
+                disabled={!canEdit}
+                error={!!errors.city}
+                helperText={errors.city?.message}
+              />
+            )}
+          />
+          <Controller
+            name="state"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="State"
+                size="small"
+                disabled={!canEdit}
+                error={!!errors.state}
+                helperText={errors.state?.message}
+                sx={{ width: 110 }}
+              />
+            )}
+          />
+          <Controller
+            name="zip"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="ZIP"
+                size="small"
+                disabled={!canEdit}
+                error={!!errors.zip}
+                helperText={errors.zip?.message}
+                sx={{ width: 130 }}
+              />
+            )}
+          />
+        </Box>
+
+        <Controller
+          name="licenseNumber"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="License number"
+              fullWidth
+              size="small"
+              disabled={!canEdit}
+              error={!!errors.licenseNumber}
+              helperText={errors.licenseNumber?.message}
+            />
+          )}
+        />
+
+        {canEdit && (
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', pt: 0.5 }}>
+            <Button
+              type="submit"
+              variant="contained"
+              size="small"
+              disabled={!isDirty}
+              loading={updateOrg.isPending}
+            >
+              Save changes
+            </Button>
+          </Box>
+        )}
+      </form>
+    </Box>
+  );
+}

--- a/src/components/organization/OrgLogoUploader.tsx
+++ b/src/components/organization/OrgLogoUploader.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { Box, CircularProgress } from '@mui/material';
+import { Camera } from '@phosphor-icons/react';
+import OrgAvatar from '@/components/ui/OrgAvatar';
+
+interface OrgLogoUploaderProps {
+  name: string;
+  seed: string;
+  logoUrl?: string | null;
+  size?: number;
+  borderRadius?: number | string;
+  disabled?: boolean;
+  onUpload: (url: string) => void | Promise<void>;
+  onError: (message: string) => void;
+}
+
+export default function OrgLogoUploader({
+  name,
+  seed,
+  logoUrl,
+  size = 72,
+  borderRadius = '14px',
+  disabled = false,
+  onUpload,
+  onError,
+}: OrgLogoUploaderProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const busy = uploading || disabled;
+
+  const handlePick = () => {
+    if (!busy) inputRef.current?.click();
+  };
+
+  const handleFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const res = await fetch('/api/organization/logo', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const data = (await res.json().catch(() => ({}))) as { logoUrl?: string; error?: string };
+
+      if (!res.ok || !data.logoUrl) {
+        throw new Error(data.error ?? 'Upload failed');
+      }
+
+      await onUpload(data.logoUrl);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <Box
+      onClick={handlePick}
+      role="button"
+      aria-label="Change organization logo"
+      sx={{
+        position: 'relative',
+        width: size,
+        height: size,
+        flexShrink: 0,
+        cursor: busy ? 'default' : 'pointer',
+        borderRadius,
+        overflow: 'hidden',
+        '&:hover .logo-overlay': {
+          opacity: busy ? 0 : 1,
+        },
+      }}
+    >
+      <OrgAvatar name={name} seed={seed} logoUrl={logoUrl} size={size} borderRadius={borderRadius} />
+
+      {!busy && (
+        <Box
+          className="logo-overlay"
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            bgcolor: 'rgba(0,0,0,0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            opacity: 0,
+            transition: 'opacity 0.15s ease',
+            color: 'common.white',
+          }}
+        >
+          <Camera size={20} weight="regular" />
+        </Box>
+      )}
+
+      {uploading && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            bgcolor: 'rgba(0,0,0,0.45)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <CircularProgress size={Math.round(size * 0.4)} sx={{ color: 'white' }} />
+        </Box>
+      )}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/gif"
+        hidden
+        onChange={handleFile}
+      />
+    </Box>
+  );
+}

--- a/src/lib/validations/organization.ts
+++ b/src/lib/validations/organization.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+import { createOrganizationSchema } from "./onboarding";
+
+export const updateOrganizationSchema = createOrganizationSchema.partial();
+
+export type UpdateOrganizationInput = z.infer<typeof updateOrganizationSchema>;

--- a/src/server/api/routers/organization.ts
+++ b/src/server/api/routers/organization.ts
@@ -2,7 +2,9 @@ import { createTRPCRouter, protectedProcedure, orgProcedure } from "@/server/api
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { createOrganizationSchema } from "@/lib/validations/onboarding";
+import { updateOrganizationSchema } from "@/lib/validations/organization";
 import { generateUniqueSlug } from "@/server/api/helpers/slug";
+import { canManageOrganization } from "@/lib/permissions";
 
 export const organizationRouter = createTRPCRouter({
   create: protectedProcedure
@@ -84,6 +86,53 @@ export const organizationRouter = createTRPCRouter({
       role: m.role,
     }));
   }),
+
+  getById: orgProcedure.query(async ({ ctx }) => {
+    return ctx.db.organization.findUnique({
+      where: { id: ctx.organization.id },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        logoUrl: true,
+        phone: true,
+        website: true,
+        address: true,
+        city: true,
+        state: true,
+        zip: true,
+        licenseNumber: true,
+        companyType: true,
+      },
+    });
+  }),
+
+  update: orgProcedure
+    .input(updateOrganizationSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!canManageOrganization(ctx.membership.role)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only organization owners can edit organization details.",
+        });
+      }
+
+      return ctx.db.organization.update({
+        where: { id: ctx.organization.id },
+        data: {
+          name: input.name?.trim(),
+          companyType: input.companyType,
+          phone: input.phone,
+          website: input.website,
+          address: input.address,
+          city: input.city,
+          state: input.state,
+          zip: input.zip,
+          licenseNumber: input.licenseNumber,
+          logoUrl: input.logoUrl,
+        },
+      });
+    }),
 
   stats: orgProcedure
     .input(z.object({ organizationId: z.string() }))


### PR DESCRIPTION
## Summary
- Adds an inline org details editor (name, company type, phone, website, address, license, logo) reached by tapping an editable org row in the account modal, with a "Back to teams" affordance.
- New `organization.getById` and `organization.update` tRPC procedures; `update` is gated server-side by `canManageOrganization`, and `updateOrganizationSchema` reuses `createOrganizationSchema.partial()`.
- New `OrgLogoUploader` component wraps `OrgAvatar` with a camera-overlay uploader that POSTs to `/api/organization/logo` and round-trips the URL through `organization.update`.
- Seeds the form's `logoUrl` as `undefined` (not `''`) so `z.string().url().optional()` doesn't silently block Save for orgs that don't yet have a logo.

## Test plan
- [ ] Sign in as an org owner, open the account modal, tap an org row, edit name/phone/etc., click Save, confirm snackbar + persisted values.
- [ ] Upload a new logo, confirm preview updates and DB `logoUrl` is written.
- [ ] Sign in as a non-owner, confirm the org row has no chevron and the details surface is unreachable.
- [ ] Edit an org that has never had a logo set, change a field, confirm Save succeeds (regression guard for the empty-string logoUrl bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)