### PR TITLE
Use CircularProgress spinner inside buttons

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,9 +3,9 @@
 import { forwardRef } from 'react';
 import {
   Button as MuiButton,
+  CircularProgress,
   type ButtonProps as MuiButtonProps,
 } from '@mui/material';
-import { IBeamLoader } from './IBeamLoader';
 
 const spinnerSizeMap = {
   small: 14,
@@ -35,7 +35,13 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ref,
   ) => {
     const spinnerSize = spinnerSizeMap[size];
-    const spinner = <IBeamLoader size={spinnerSize} color="currentColor" />;
+    const spinner = (
+      <CircularProgress
+        size={spinnerSize}
+        thickness={4.5}
+        sx={{ color: 'currentColor' }}
+      />
+    );
 
     return (
       <MuiButton


### PR DESCRIPTION
## Summary
- Swap the Button component's loading spinner from the branded `IBeamLoader` to MUI `CircularProgress` so in-button spinners feel like standard UI affordances.
- `IBeamLoader` stays in place for `LoadingSpinner` (full-page / section loading screens), so the custom animation is preserved where it belongs.
- All existing call sites that already passed `loading={mutation.isPending}` (auth forms, onboarding, invite/delete dialogs, profile/org forms, snapshot dialog, etc.) now render the new spinner with no further edits.

## Test plan
- [ ] Click a primary action (e.g. create project, invite member, save snapshot) and confirm the circular spinner replaces the icon during the pending state.
- [ ] Load a page that renders `LoadingSpinner` and confirm the I-beam animation still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)