### PR TITLE
Baseline orphan schema objects and document migration workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 
 ## Codebase Reference
 @claudedocs/environment-setup.md
+@claudedocs/database-migrations.md
 @claudedocs/auth-and-permissions.md
 @claudedocs/architecture-and-typescript.md
 @claudedocs/testing-guide.md
@@ -16,6 +17,7 @@
 ## Documentation Update Rules
 When making changes that affect these docs, update them in the same task:
 - New/modified env vars → update `claudedocs/environment-setup.md`
+- Schema changes, migrations, drift recovery, raw SQL patterns → update `claudedocs/database-migrations.md`
 - Auth, roles, permissions, or middleware changes → update `claudedocs/auth-and-permissions.md`
 - Architecture or TypeScript pattern changes → update `claudedocs/architecture-and-typescript.md`
 - New tests added or test patterns change → update `claudedocs/testing-guide.md`

--- a/claudedocs/database-migrations.md
+++ b/claudedocs/database-migrations.md
@@ -1,0 +1,260 @@
+# Database Migrations
+
+How to evolve the database schema in this project without causing drift. Read this before running any Prisma CLI command that touches the database.
+
+This project has been bitten by drift before — that's why this document exists. The cleanup migration `prisma/migrations/20260429180000_baseline_orphan_schema_objects/` was created to recover from a `db push` that left `WaitlistEntry`, `GanttTask.requiredSubmittals`, `GanttTask.requiredInspections`, and an orphan trigram index out of migration history. The rules below are how we don't do that again.
+
+---
+
+## Golden Rules
+
+1. **`prisma migrate dev` is the only way to change the schema.** Never `prisma db push`.
+2. **Migration files in `prisma/migrations/` are the source of truth.** The local DB, Neon preview, and Neon production all derive from those files. If a change isn't in a file, it isn't real.
+3. **Never edit an applied migration.** Once a migration has been deployed anywhere (local, preview, prod), it is immutable. To change something, write a new migration.
+4. **Never delete an applied migration file.** The `_prisma_migrations` table on every environment that ran it will be out of sync with the directory and you'll spend an afternoon recovering.
+5. **Raw SQL goes in migrations, not in `schema.prisma`.** Generated columns, GIN/GIST indexes, custom Postgres functions, extensions, and triggers can't be expressed in `schema.prisma`. Add them to a migration via `--create-only` (see below).
+6. **Commit the migration file in the same PR as the `schema.prisma` change.** A schema change without a migration file is the textbook recipe for the drift this project just recovered from.
+
+---
+
+## The Three Commands
+
+| Command | When to use | What it does | What it doesn't do |
+|---|---|---|---|
+| `prisma migrate dev` | **Development only.** When you change `schema.prisma` and want a migration file. | Creates a new migration file from the schema diff, applies it to the local DB, regenerates Prisma Client. Uses a shadow database to detect drift and evaluate data loss. | Never run in CI or production — it can prompt to reset the DB. |
+| `prisma migrate deploy` | **CI / preview / production.** Run by Vercel on every deploy via `npm run db:migrate`. Also run on every Conductor workspace start by `conductor.json` so a fresh workspace can never start with unapplied migrations. | Applies pending migrations in order. Idempotent — already-applied ones are skipped. | Does **not** detect drift, does **not** use the shadow DB, does **not** generate the Prisma Client (we run `prisma generate` separately in the build script). |
+| `prisma db push` | **Never in this project.** | Mutates the DB directly to match `schema.prisma` with no migration file. | Does not record what changed. Re-runs lose data on column renames. Mixes badly with a project that has migration history (this is exactly what caused our orphan-schema drift). |
+
+The official Prisma guidance is unambiguous: `db push` is for "prototyping" only and "Avoid `migrate dev` and `db push` in production as they can be destructive or lead to a migrationless workflow." ([Prisma docs: Migration strategies](https://www.prisma.io/docs/orm/more/best-practices)). Once a project commits its first migration file, `db push` becomes hostile to the migration history.
+
+---
+
+## Standard Workflow: Schema Change
+
+Use this for any change you can express in `schema.prisma` (adding/removing fields, indexes, relations, models).
+
+```bash
+# 1. Make sure you're up to date and applied
+git pull
+npx prisma migrate status         # should say "Database schema is up to date"
+
+# 2. Edit prisma/schema.prisma
+
+# 3. Generate the migration. Pick a descriptive snake_case name.
+npx prisma migrate dev --name add_document_review_status
+
+# 4. Inspect the generated SQL before committing — Prisma sometimes generates
+#    expensive operations (full-table rewrites, locking index creates) you'll
+#    want to know about.
+cat prisma/migrations/<timestamp>_add_document_review_status/migration.sql
+
+# 5. Commit the migration file AND the schema change together
+git add prisma/schema.prisma prisma/migrations/<timestamp>_add_document_review_status/
+git commit -m "Add document review status"
+
+# 6. Restart the dev server so it picks up the regenerated Prisma Client
+#    (HMR doesn't re-import @prisma/client)
+```
+
+`prisma migrate dev` writes the SQL to a new directory under `prisma/migrations/`, applies it to the local DB, regenerates the Prisma Client, and inserts a row into `_prisma_migrations`. ([Prisma docs: Mental model](https://www.prisma.io/docs/orm/prisma-migrate/understanding-prisma-migrate/mental-model))
+
+---
+
+## Raw SQL Workflow
+
+Use this when the change can't be expressed in `schema.prisma`. Examples in this project:
+
+| Migration | What it adds in raw SQL | Why |
+|---|---|---|
+| `20260221200655_add_document_search` | `Document.searchVector tsvector GENERATED ALWAYS AS (...)` | Prisma can't express generated columns. |
+| `20260223000000_add_trigram_and_vector_search` | `CREATE EXTENSION pg_trgm`, `CREATE EXTENSION vector`, GIN indexes | Extensions and GIN indexes aren't `schema.prisma` constructs. |
+| `20260224000000_openai_embeddings_1536` | `Document.embedding vector(1536)` | pgvector types via `Unsupported("vector(1536)")` in schema, but the column type itself goes in raw SQL. |
+| `20260405000000_hybrid_search` | `CREATE FUNCTION hybrid_document_search(...)` | Custom Postgres function for hybrid search. |
+| `20260429180000_baseline_orphan_schema_objects` | `CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, `DROP INDEX IF EXISTS` | Idempotent baseline to recover from past `db push` drift. |
+
+**Workflow:**
+
+```bash
+# 1. Generate an empty migration file. This stages a directory but does NOT apply it.
+npx prisma migrate dev --name add_my_function --create-only
+
+# 2. Edit prisma/migrations/<timestamp>_add_my_function/migration.sql to add raw SQL.
+#    If schema.prisma also changed, the auto-generated SQL is already in the file —
+#    add your raw SQL alongside it.
+
+# 3. Apply it.
+npx prisma migrate dev
+```
+
+The `--create-only` flag is the official escape hatch for raw SQL. ([Prisma docs: Postgres extensions](https://www.prisma.io/docs/postgres/database/postgres-extensions))
+
+### Idempotent SQL guards
+
+For migrations that may run on environments in slightly different states (true of any baseline or recovery migration), use Postgres's idempotent forms:
+
+```sql
+CREATE TABLE IF NOT EXISTS ...
+CREATE INDEX IF NOT EXISTS ...
+CREATE EXTENSION IF NOT EXISTS ...
+ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...
+DROP INDEX IF EXISTS ...
+DROP TABLE IF EXISTS ...
+```
+
+These are standard Postgres syntax and the official docs use them directly (e.g. `CREATE EXTENSION IF NOT EXISTS "postgis";`).
+
+For normal forward-evolution migrations from `migrate dev`, the auto-generated SQL is **not** idempotent — it assumes a known starting state. That's correct: every environment runs the migrations in the same order, so each one starts from a deterministic state. Don't sprinkle `IF NOT EXISTS` on every routine migration.
+
+---
+
+## Drift Detection and Recovery
+
+### What "drift" means here
+
+Drift is any disagreement between three things that should always agree:
+
+1. `prisma/migrations/` directory on disk
+2. The `_prisma_migrations` table in the database
+3. The actual schema of the database (tables, columns, indexes, etc.)
+
+If anyone has ever run `db push` against a DB that also receives migrations, those three diverge. You won't notice immediately because Prisma Client doesn't re-validate the DB schema at runtime — it trusts what `schema.prisma` says. The pain shows up when the next person runs `prisma migrate dev` and it refuses to proceed.
+
+### Detect drift
+
+```bash
+# Compares prisma/migrations/ ↔ _prisma_migrations table.
+# Reports unapplied or missing migrations. Does NOT compare DB schema to schema.prisma.
+npx prisma migrate status
+
+# Compares migration history (what files would produce on a fresh DB) ↔ live DB.
+# Returns SQL representing the actual drift. Empty output means clean.
+# Requires a shadow DB.
+npx prisma migrate diff \
+  --from-migrations prisma/migrations \
+  --to-url "$POSTGRES_PRISMA_URL" \
+  --shadow-database-url "postgresql://construction:construction@localhost:5432/construction_shadow" \
+  --script
+```
+
+`migrate status` and `migrate diff` answer different questions. `status` checks whether all migration files have been applied. `diff` checks whether applying all the migration files to a clean DB would produce the same schema as your live DB. **The drift this project hit was invisible to `status` and only visible to `diff`** — `_prisma_migrations` had every file applied, but the DB had extra objects from past `db push`.
+
+### Fix drift
+
+| Drift type | Fix |
+|---|---|
+| Migration file exists, not applied to DB | `npx prisma migrate deploy` |
+| Migration applied to DB, file deleted (someone removed an applied migration) | Restore the file from git history. If the file is truly gone, `prisma migrate resolve --rolled-back <name>` then write a new migration. **Never recover by deleting the row from `_prisma_migrations`.** |
+| Object in DB that no migration creates (the case this project hit) | Write an idempotent baseline migration that creates the object with `IF NOT EXISTS`. See `prisma/migrations/20260429180000_baseline_orphan_schema_objects/migration.sql` as the canonical example. |
+| Drift on local only (multiple workspaces share `construction-postgres`) and you have no important local data | `docker volume rm construction-pgdata`, restart the container, `npx prisma migrate deploy`. Nuclear option but legitimate. |
+
+`prisma migrate resolve --applied <name>` only inserts a row in `_prisma_migrations` — it does not run the SQL. Use it when you've already applied a migration manually and want Prisma to know. ([Prisma docs: From Drizzle](https://www.prisma.io/docs/guides/switch-to-prisma-orm/from-drizzle))
+
+### When `migrate dev` says "drift detected"
+
+If you change `schema.prisma` and run `migrate dev` and Prisma says drift was detected and offers to reset the DB:
+
+1. **Don't accept the reset reflexively.** It deletes all local data including across every Conductor workspace sharing this DB.
+2. Run `prisma migrate diff --from-migrations ... --to-url ...` to see the actual drift SQL.
+3. If the drift is benign (orphan objects from a past `db push`), write an idempotent baseline migration like `20260429180000_baseline_orphan_schema_objects` that captures the orphan objects. Apply it with `migrate deploy`. Now the DB and migration history agree.
+4. Only then re-run `migrate dev` for your actual schema change.
+
+---
+
+## Conductor Workspaces (Local Development)
+
+A single Docker container `construction-postgres` is shared across every Conductor workspace. The migration files in `prisma/migrations/` are per-branch (per-worktree), but the DB is one shared mutable object. Two consequences:
+
+- **A migration applied in workspace A is permanent for workspace B.** When workspace B checks out a branch that doesn't have that migration file, `prisma migrate status` will report drift (file missing, row in `_prisma_migrations` exists). It still runs, just with a warning.
+- **Never delete a migration file after it has been applied to the shared DB.** The orphan row in `_prisma_migrations` will haunt every other workspace. If the change needs to be undone, write a forward migration that reverses it.
+
+`conductor.json`'s `run` script applies `prisma migrate deploy && prisma generate` on every workspace start. The common path (pull, switch workspace, restart) self-heals. The two rules above cover what self-heal can't.
+
+---
+
+## Production Deployment (Vercel + Neon)
+
+`vercel.json`'s `buildCommand` is:
+
+```
+npx prisma migrate deploy && npx prisma generate && npx next build
+```
+
+Every Vercel deploy applies pending migrations against that environment's Neon DB before the Next.js build runs. Database branching is handled by the Vercel-Neon integration:
+
+- **Production deploys** target the `main` Neon branch.
+- **Preview deploys** target an auto-created `preview/...` Neon branch forked from `main` at deploy time.
+
+`migrate deploy` does not detect drift, does not reset, and does not use a shadow DB. ([Prisma docs: CLI reference](https://www.prisma.io/docs/orm/reference/prisma-cli-reference)) That's intentional — production deploys must be deterministic and never destructive. The corollary is that any drift introduced into a production DB by hand will not be auto-corrected by deploys; it has to be addressed with a baseline migration.
+
+### Long-running migrations and backfills
+
+If a migration is going to take more than a few seconds (large table rewrites, index builds on millions of rows), it shouldn't run inside the build. Options:
+
+- **Two-phase additive change.** Add a nullable column in one migration. Backfill via a separate one-off script run out of band. Add the `NOT NULL` constraint in a later migration.
+- **`CREATE INDEX CONCURRENTLY`** for indexes on hot tables (does not block writes; cannot run inside a transaction — Prisma migrations run each statement in autocommit mode by default but verify if you depend on this).
+
+We haven't hit this problem yet at our scale, but if you write a migration that touches every row in `Document` or `GanttTask`, plan for it.
+
+---
+
+## Common Pitfalls (Real-World)
+
+| Pitfall | Why it bites | Fix |
+|---|---|---|
+| Editing an applied migration | Other environments already ran the old version. Their `_prisma_migrations` records the old checksum. The next deploy reports drift. | Write a new migration with the correction. The old one stays as-is forever. |
+| `db push` "just to test something" | Side effects survive the test. Future `migrate dev` runs see drift. | Use `--create-only` and discard the file if you don't want to keep the change. |
+| Deleting a migration file because "it didn't work" | If it was applied anywhere, `_prisma_migrations` keeps the row. Restoring later is messy. | Write a reversal migration. |
+| Schema change in PR without a migration file | Reviewer can't tell what SQL will run on prod. Often means `db push` was used. | PR checklist (see `claudedocs/vercel.md`) catches this; CI should too. |
+| Adding `NOT NULL` to existing column | Migration fails on populated tables. | Two-phase: add nullable column, backfill data, add constraint. |
+| Forgetting the shadow DB exists during `migrate dev` | First-run on a new machine fails with "shadow database does not exist." | Either let Prisma manage it (default) or pre-create `<dbname>_shadow` and pass `shadowDatabaseUrl`. We don't currently configure one for `migrate dev`. |
+| Running `migrate dev` on production by accident | Prompts to reset the production DB. | Never run `migrate dev` outside of local. CI should only ever run `migrate deploy`. |
+
+---
+
+## Quick Reference Card
+
+```bash
+# Adding a schema change (the 99% case)
+npx prisma migrate dev --name <descriptive_name>
+
+# Adding raw SQL (extensions, generated columns, custom functions, GIN indexes)
+npx prisma migrate dev --name <descriptive_name> --create-only
+# ... edit migration.sql ...
+npx prisma migrate dev
+
+# Check if local DB matches migration files
+npx prisma migrate status
+
+# Check if live DB schema actually matches what migrations would produce
+npx prisma migrate diff \
+  --from-migrations prisma/migrations \
+  --to-url "$POSTGRES_PRISMA_URL" \
+  --shadow-database-url "postgresql://construction:construction@localhost:5432/construction_shadow" \
+  --script
+# (create the shadow DB once: docker exec construction-postgres psql -U construction -d postgres -c "CREATE DATABASE construction_shadow")
+
+# Inspect what's actually in the DB
+npx prisma studio
+
+# Mark a manually-run migration as applied (for baselines)
+npx prisma migrate resolve --applied <migration_name>
+
+# Apply pending migrations (CI, restart, fresh workspace)
+npx prisma migrate deploy
+```
+
+**Forbidden in this project:**
+
+```bash
+npx prisma db push          # ← do not run, ever
+```
+
+---
+
+## Further Reading
+
+- [Prisma Migrate mental model](https://www.prisma.io/docs/orm/prisma-migrate/understanding-prisma-migrate/mental-model)
+- [Shadow database](https://www.prisma.io/docs/orm/prisma-migrate/understanding-prisma-migrate/shadow-database)
+- [CLI reference: migrate dev / deploy / status / diff / resolve](https://www.prisma.io/docs/orm/reference/prisma-cli-reference)
+- [Best practices: deployment & migration strategies](https://www.prisma.io/docs/orm/more/best-practices)
+- [Postgres extensions in Prisma migrations](https://www.prisma.io/docs/postgres/database/postgres-extensions)

--- a/claudedocs/environment-setup.md
+++ b/claudedocs/environment-setup.md
@@ -85,32 +85,22 @@ npm run dev          # http://localhost:3000
 - Better Auth trusts any localhost origin in development, and `APP_URL` in production (see `src/lib/auth.ts`).
 - In Conductor, `conductor.json` handles setup and run automatically. The `setup` script starts Docker, pulls env vars, overrides DB URLs, installs dependencies, and applies migrations. The `run` script re-applies migrations (`prisma migrate deploy`) and regenerates the Prisma client (`prisma generate`) on every workspace start before launching `next dev`, so a workspace can never start with a stale client or unapplied migrations.
 
-### Database workflow: always use `prisma migrate`, never `prisma db push`
+### Database workflow
 
-This project uses Prisma's **migration files** as the single source of truth for the schema. Always go through `prisma migrate dev` / `prisma migrate deploy` — never `prisma db push`.
+This project uses Prisma's **migration files** as the single source of truth for the schema. Always go through `prisma migrate dev` / `prisma migrate deploy` — **never** `prisma db push`. See `claudedocs/database-migrations.md` for the full workflow, drift recovery, raw-SQL patterns, and the rationale.
 
-**Why this matters**: `db push` only syncs the declarative `schema.prisma`. It silently skips anything that lives only in raw SQL files — custom Postgres functions, generated columns, GIN indexes, triggers, extensions. Several migrations in this project rely on raw SQL (e.g. `hybrid_document_search()` for hybrid search, `Document.searchVector` as a GENERATED column, GIN trigram indexes). A DB managed via `db push` will look fine in `prisma studio` but features that depend on those bits silently fail or return empty results — and you won't notice until you exercise the affected code path.
-
-**Workflow:**
+Quick reference:
 
 | Action | Command |
 |---|---|
 | Apply existing migrations to a fresh local DB | `npx prisma migrate deploy` |
 | Create a new migration after editing `schema.prisma` | `npx prisma migrate dev --name <descriptive_name>` |
-| Add raw SQL (function, generated column, custom index) | Create the migration with `--create-only`, then edit the generated `migration.sql` before running `npx prisma migrate dev` |
-| Inspect what's pending vs applied | `npx prisma migrate status` |
+| Add raw SQL (function, generated column, custom index) | `npx prisma migrate dev --name <name> --create-only`, edit the SQL, then `npx prisma migrate dev` |
+| Check if migrations and `_prisma_migrations` agree | `npx prisma migrate status` |
+| Check if the DB schema actually matches what migrations would produce | `npx prisma migrate diff --from-migrations prisma/migrations --to-url "$POSTGRES_PRISMA_URL" --shadow-database-url "postgresql://construction:construction@localhost:5432/construction_shadow" --script` |
 | Open the data browser | `npx prisma studio` |
 
-**If a workspace was set up via the old `db push` flow** and you suspect drift (missing functions, indexes, or generated columns), check with `npx prisma migrate status`. If it reports migrations as not applied even though the schema looks correct, the DB needs to be baselined: apply any missing raw-SQL bits manually, then mark each migration applied with `npx prisma migrate resolve --applied <name>` until status is clean. The simpler reset (if you have no important local data) is `docker volume rm construction-pgdata`, restart the container, then `npx prisma migrate deploy`.
-
-### Cross-workspace drift hazards (shared Postgres)
-
-Because every Conductor workspace shares one `construction-postgres` container, the database is mutable shared state while `prisma/schema.prisma`, `prisma/migrations/`, and `generated/prisma/` are per-workspace (each branch's view). A migration applied in workspace A is permanently visible to every other workspace, even ones whose branch doesn't have that migration file. Two rules avoid the worst failure modes:
-
-1. **Never delete a migration file after it has been applied to the shared DB.** If a schema change needs to be undone, write a new migration that reverses it. Deleting an applied migration leaves an orphan row in `_prisma_migrations` plus orphan column changes — and any other workspace that re-runs `prisma migrate dev` will then see drift it can't reconcile against files on disk.
-2. **When a workspace starts behaving strangely after a pull, run `npx prisma migrate status` first.** It compares files on disk to `_prisma_migrations` rows and surfaces drift before runtime errors do. Do this before assuming the dev server is broken.
-
-The `run` script in `conductor.json` already applies `prisma migrate deploy && prisma generate` on every workspace start, so the common path (`git pull` → restart) self-heals. These two rules cover the cases the `run` script can't.
+The `run` script in `conductor.json` applies `prisma migrate deploy && prisma generate` on every workspace start, so the common path (`git pull` → restart) self-heals. The full doc covers what self-heal can't — including the cross-workspace shared-DB hazards (every Conductor workspace shares the same `construction-postgres` container) and how to recover from drift caused by past `db push` runs.
 
 ## Available Scripts
 

--- a/prisma/migrations/20260429180000_baseline_orphan_schema_objects/migration.sql
+++ b/prisma/migrations/20260429180000_baseline_orphan_schema_objects/migration.sql
@@ -1,0 +1,36 @@
+-- Baseline migration: align _prisma_migrations history with schema.prisma + DB state
+-- after schema changes were applied via `db push` instead of `prisma migrate dev`.
+--
+-- Every statement is idempotent so this migration is safe on every environment:
+--   - Local DBs that already received these objects via past db push (the common case)
+--   - Fresh DBs (recreates the orphan objects from scratch)
+--   - Neon preview/production DBs (whether already drifted or clean)
+--
+-- See claudedocs/database-migrations.md for guidance on avoiding drift in the future.
+
+-- 1. WaitlistEntry: model exists in schema.prisma but no prior migration created it.
+CREATE TABLE IF NOT EXISTS "WaitlistEntry" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WaitlistEntry_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "WaitlistEntry_email_key" ON "WaitlistEntry"("email");
+CREATE INDEX IF NOT EXISTS "WaitlistEntry_email_idx" ON "WaitlistEntry"("email");
+
+-- 2. GanttTask: nullable INT columns added to schema.prisma without a migration.
+ALTER TABLE "GanttTask" ADD COLUMN IF NOT EXISTS "requiredSubmittals" INTEGER;
+ALTER TABLE "GanttTask" ADD COLUMN IF NOT EXISTS "requiredInspections" INTEGER;
+
+-- 3. GanttTask.updatedAt: schema is `@updatedAt` (no SQL default needed); some
+-- environments still carry a legacy DEFAULT from an earlier migration. DROP DEFAULT
+-- is a no-op when no default exists, so this is safe everywhere.
+ALTER TABLE "GanttTask" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- 4. Drop orphan trigram index. Created by 20260223000000_add_trigram_and_vector_search,
+-- intentionally dropped by 20260223222302_add_project_member_table, but reappeared in
+-- some local DBs via db push. No code uses trigram similarity on Document.name —
+-- the GIN index on Document.searchVector covers all hybrid-search needs.
+DROP INDEX IF EXISTS "Document_name_trgm_idx";


### PR DESCRIPTION
## Summary

- Adds an idempotent baseline migration that brings `_prisma_migrations` into agreement with `schema.prisma` and the live DB. Recovers from past `db push` runs that left `WaitlistEntry`, `GanttTask.requiredSubmittals/requiredInspections`, and an orphan `Document_name_trgm_idx` out of the migration history.
- Adds `claudedocs/database-migrations.md` as the canonical reference for schema changes, drift recovery, raw-SQL patterns, and Conductor shared-DB hazards. Trims duplicated content from `environment-setup.md` and links it from `CLAUDE.md`.

## Why

`prisma migrate diff` against `origin/preview` reported four pieces of drift on the local DB:
1. `WaitlistEntry` table + 2 indexes — defined in `schema.prisma` but no migration creates it
2. `GanttTask.requiredSubmittals INTEGER` — defined in `schema.prisma`, used heavily in `src/server/api/routers/gantt.ts`, but no migration creates it
3. `GanttTask.requiredInspections INTEGER` — same as above
4. `Document_name_trgm_idx` — created and intentionally dropped by `20260223222302`, but reappeared in some DBs (no code uses it; `Document.searchVector` covers all hybrid-search needs)

The schema fields exist on `origin/preview`, so the drift is preview-wide, not just local. Without this PR the next `prisma migrate dev` will refuse to proceed for any contributor.

## How

Every statement in `prisma/migrations/20260429180000_baseline_orphan_schema_objects/migration.sql` is idempotent (`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, `DROP DEFAULT`, `DROP INDEX IF EXISTS`). That makes it safe whether the target environment has already been drifted by past `db push` (skips), is a clean fresh DB (creates), or somewhere in between.

## Test plan

- [x] Apply on locally drifted DB — `prisma migrate deploy` runs cleanly, `prisma migrate diff` shows empty afterwards
- [x] Apply on a fresh shadow DB simulating `origin/preview` — all 27 migrations + cleanup applies cleanly, `prisma migrate diff` against `schema.prisma` shows empty
- [x] Verify expected DB state: `WaitlistEntry` exists, `GanttTask.requiredSubmittals/Inspections` exist, `Document_name_trgm_idx` is gone
- [ ] CI runs the migration on Vercel preview's Neon branch — confirm the deployment passes (will be visible after PR is opened)

🤖 Generated with [Claude Code](https://claude.com/claude-code)