### PR TITLE
Add CI guard against schema/migration drift

### DIFF
--- a/.github/workflows/db-migration-check.yml
+++ b/.github/workflows/db-migration-check.yml
@@ -1,0 +1,67 @@
+name: DB Migration Drift Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main, preview]
+
+jobs:
+  drift-check:
+    name: Migrations match schema.prisma
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: drift_check
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Enable pgvector and pg_trgm extensions
+        run: |
+          psql -h localhost -U postgres -d drift_check -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          psql -h localhost -U postgres -d drift_check -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+        env:
+          PGPASSWORD: postgres
+
+      - name: Check migrations match schema.prisma
+        run: |
+          npx prisma migrate diff \
+            --from-migrations prisma/migrations \
+            --to-schema-datamodel prisma/schema.prisma \
+            --shadow-database-url "postgresql://postgres:postgres@localhost:5432/drift_check" \
+            --exit-code
+        env:
+          POSTGRES_PRISMA_URL: postgresql://postgres:postgres@localhost:5432/drift_check
+          POSTGRES_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/drift_check
+          SKIP_ENV_VALIDATION: true
+
+      - name: Drift detected — guidance
+        if: failure()
+        run: |
+          echo "::error title=Migration drift::schema.prisma and prisma/migrations/ disagree."
+          echo "::error::This usually means schema.prisma was edited without a matching migration file (often via 'prisma db push')."
+          echo "::error::Fix: run 'npx prisma migrate dev --name <descriptive_name>' locally, commit the new migration directory, then push."
+          echo "::error::Full guide: claudedocs/database-migrations.md"

--- a/claudedocs/database-migrations.md
+++ b/claudedocs/database-migrations.md
@@ -126,9 +126,13 @@ If anyone has ever run `db push` against a DB that also receives migrations, tho
 # Reports unapplied or missing migrations. Does NOT compare DB schema to schema.prisma.
 npx prisma migrate status
 
-# Compares migration history (what files would produce on a fresh DB) ↔ live DB.
-# Returns SQL representing the actual drift. Empty output means clean.
-# Requires a shadow DB.
+# Compares migration history (what files would produce on a fresh DB) ↔ schema.prisma.
+# Exits 0 if in sync, 2 if drift, 1 on error. Same check that runs in CI on every PR.
+npm run db:check
+
+# Compares migration history ↔ live DB. Returns SQL representing the actual drift.
+# Use this when you suspect the live DB is out of sync with what migrations would create
+# (e.g. someone ran db push against it).
 npx prisma migrate diff \
   --from-migrations prisma/migrations \
   --to-url "$POSTGRES_PRISMA_URL" \
@@ -136,7 +140,7 @@ npx prisma migrate diff \
   --script
 ```
 
-`migrate status` and `migrate diff` answer different questions. `status` checks whether all migration files have been applied. `diff` checks whether applying all the migration files to a clean DB would produce the same schema as your live DB. **The drift this project hit was invisible to `status` and only visible to `diff`** — `_prisma_migrations` had every file applied, but the DB had extra objects from past `db push`.
+`migrate status` and `migrate diff` answer different questions. `status` checks whether all migration files have been applied. `diff` checks whether the schemas match. **The drift this project hit was invisible to `status` and only visible to `diff`** — `_prisma_migrations` had every file applied, but the DB had extra objects from past `db push`. The `npm run db:check` script wraps `migrate diff` with sensible defaults and is the canonical local check.
 
 ### Fix drift
 
@@ -157,6 +161,39 @@ If you change `schema.prisma` and run `migrate dev` and Prisma says drift was de
 2. Run `prisma migrate diff --from-migrations ... --to-url ...` to see the actual drift SQL.
 3. If the drift is benign (orphan objects from a past `db push`), write an idempotent baseline migration like `20260429180000_baseline_orphan_schema_objects` that captures the orphan objects. Apply it with `migrate deploy`. Now the DB and migration history agree.
 4. Only then re-run `migrate dev` for your actual schema change.
+
+---
+
+## CI Enforcement
+
+`.github/workflows/db-migration-check.yml` runs on every PR and on pushes to `main`/`preview`. It spins up an ephemeral Postgres container, applies every migration file in `prisma/migrations/` to it, and then compares the resulting schema to `schema.prisma`. Any difference fails the check.
+
+The exact command is:
+
+```bash
+npx prisma migrate diff \
+  --from-migrations prisma/migrations \
+  --to-schema-datamodel prisma/schema.prisma \
+  --shadow-database-url "<ephemeral postgres>" \
+  --exit-code
+```
+
+`--exit-code` returns 2 if there is any difference, 0 if in sync, 1 on error. The CI job converts that into a pass/fail status and prints guidance on failure.
+
+**This is the layer that catches `db push` usage before it merges.** If you edit `schema.prisma` without writing a matching migration, this check will fail with a clear "added/changed/removed" diff. Run `npm run db:check` locally to catch the same drift before pushing.
+
+### Known false-positive surface
+
+`migrate diff` is generally accurate, but it can flag legitimate raw-SQL features that `schema.prisma` can't fully express. Two examples this project handles in `schema.prisma`:
+
+- **Generated columns** (`Document.searchVector`): declared as `Unsupported("tsvector")? @default(dbgenerated())`. `dbgenerated()` with no arguments tells Prisma "I know there's a DB-side default, don't validate it." This silences the diff for the generated expression.
+- **Indexes on Unsupported types** (`Document.searchVector` GIN index): declared via `@@index([searchVector], map: "idx_document_search_vector", type: Gin)`. This is the schema-level equivalent of the migration's raw SQL `CREATE INDEX ... USING GIN`.
+
+If you add new raw-SQL features (custom functions, triggers, additional generated columns), the CI check may flag them. The fix is usually one of:
+
+1. Add the matching declaration to `schema.prisma` (preferred — keeps the schema accurate)
+2. Use `dbgenerated()` for default expressions that schema can't express
+3. Accept that some features (custom functions, triggers) are invisible to `migrate diff` per Prisma's own [docs](https://www.prisma.io/docs/orm/reference/prisma-cli-reference) — these are silently ignored, not flagged as drift
 
 ---
 
@@ -225,13 +262,16 @@ npx prisma migrate dev
 # Check if local DB matches migration files
 npx prisma migrate status
 
-# Check if live DB schema actually matches what migrations would produce
+# Check if migrations and schema.prisma agree (same check CI runs).
+# Wraps prisma migrate diff with sensible defaults.
+npm run db:check
+
+# Check if live DB schema matches what migrations would produce (when you suspect db push happened)
 npx prisma migrate diff \
   --from-migrations prisma/migrations \
   --to-url "$POSTGRES_PRISMA_URL" \
   --shadow-database-url "postgresql://construction:construction@localhost:5432/construction_shadow" \
   --script
-# (create the shadow DB once: docker exec construction-postgres psql -U construction -d postgres -c "CREATE DATABASE construction_shadow")
 
 # Inspect what's actually in the DB
 npx prisma studio

--- a/claudedocs/environment-setup.md
+++ b/claudedocs/environment-setup.md
@@ -97,7 +97,7 @@ Quick reference:
 | Create a new migration after editing `schema.prisma` | `npx prisma migrate dev --name <descriptive_name>` |
 | Add raw SQL (function, generated column, custom index) | `npx prisma migrate dev --name <name> --create-only`, edit the SQL, then `npx prisma migrate dev` |
 | Check if migrations and `_prisma_migrations` agree | `npx prisma migrate status` |
-| Check if the DB schema actually matches what migrations would produce | `npx prisma migrate diff --from-migrations prisma/migrations --to-url "$POSTGRES_PRISMA_URL" --shadow-database-url "postgresql://construction:construction@localhost:5432/construction_shadow" --script` |
+| Check if migrations and `schema.prisma` agree (same check CI runs) | `npm run db:check` |
 | Open the data browser | `npx prisma studio` |
 
 The `run` script in `conductor.json` applies `prisma migrate deploy && prisma generate` on every workspace start, so the common path (`git pull` → restart) self-heals. The full doc covers what self-heal can't — including the cross-workspace shared-DB hazards (every Conductor workspace shares the same `construction-postgres` container) and how to recover from drift caused by past `db push` runs.
@@ -112,7 +112,7 @@ The `run` script in `conductor.json` applies `prisma migrate deploy && prisma ge
 | `preview` | `next build && next start` | Build and preview locally |
 | `db:generate` | `prisma migrate dev` | Create and apply a new migration (use this when changing `schema.prisma`) |
 | `db:migrate` | `prisma migrate deploy` | Apply pending migrations to a fresh DB (used by Vercel build and local first-run) |
-| `db:push` | `prisma db push` | **Avoid.** Skips raw-SQL migrations and causes silent drift. See "Database workflow" above |
+| `db:check` | `scripts/db-check.sh` | Verify migrations and `schema.prisma` agree. Same check CI runs on every PR. |
 | `db:studio` | `prisma studio` | Open Prisma Studio GUI |
 | `test` | `vitest run` | Run tests once |
 | `test:watch` | `vitest` | Run tests in watch mode |

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "prisma migrate deploy && prisma generate && next build",
     "db:generate": "prisma migrate dev",
     "db:migrate": "prisma migrate deploy",
-    "db:push": "prisma db push",
+    "db:check": "scripts/db-check.sh",
     "db:studio": "prisma studio",
     "dev": "next dev --turbo",
     "postinstall": "prisma generate && node scripts/sync-bryntum-theme.mjs",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -165,7 +165,7 @@ model Document {
     description  String
     notes        String                         @default("")
     embedding    Unsupported("vector(1536)")?
-    searchVector Unsupported("tsvector")?
+    searchVector Unsupported("tsvector")?         @default(dbgenerated())
     taskId       String
     folderId     String
     projectId    String
@@ -178,6 +178,7 @@ model Document {
 
     @@index([projectId, taskId, folderId])
     @@index([projectId])
+    @@index([searchVector], map: "idx_document_search_vector", type: Gin)
 }
 
 model Membership {

--- a/scripts/db-check.sh
+++ b/scripts/db-check.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Local equivalent of the CI drift-check workflow.
+# Compares prisma/migrations/ to schema.prisma against a shadow DB.
+# Exits 0 if in sync, 2 if drift detected, 1 on error.
+
+set -euo pipefail
+
+CONTAINER="construction-postgres"
+SHADOW_DB="construction_shadow"
+SHADOW_URL="postgresql://construction:construction@localhost:5432/${SHADOW_DB}"
+
+if ! docker ps --format '{{.Names}}' | grep -q "^${CONTAINER}$"; then
+  echo "Error: Docker container '${CONTAINER}' is not running."
+  echo "Start it with: docker start ${CONTAINER}"
+  exit 1
+fi
+
+# Ensure shadow DB exists (idempotent).
+docker exec "${CONTAINER}" psql -U construction -d postgres -tAc \
+  "SELECT 1 FROM pg_database WHERE datname='${SHADOW_DB}'" | grep -q 1 \
+  || docker exec "${CONTAINER}" createdb -U construction "${SHADOW_DB}"
+
+# Ensure required extensions exist on the shadow DB (idempotent).
+docker exec "${CONTAINER}" psql -U construction -d "${SHADOW_DB}" -c \
+  "CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pg_trgm;" >/dev/null
+
+exec npx prisma migrate diff \
+  --from-migrations prisma/migrations \
+  --to-schema-datamodel prisma/schema.prisma \
+  --shadow-database-url "${SHADOW_URL}" \
+  --exit-code


### PR DESCRIPTION
## Summary

Adds a GitHub Action workflow that catches schema-vs-migration drift on every PR — the prevention layer that makes PR #133's cleanup durable.

**Stacked on PR #133.** Base set to \`lawrence1470/cleanup-orphan-schema-baseline\` so the CI check passes against the cleanup-applied state. Once #133 merges to preview, this PR's base should be re-targeted to \`preview\` (or simply rebased).

## What it does

\`\`\`bash
# CI runs this on every PR via .github/workflows/db-migration-check.yml
npx prisma migrate diff \\
  --from-migrations prisma/migrations \\
  --to-schema-datamodel prisma/schema.prisma \\
  --shadow-database-url \"<ephemeral postgres>\" \\
  --exit-code
\`\`\`

\`--exit-code\` returns 2 if migrations and schema disagree, 0 if in sync. The job runs an ephemeral pgvector Postgres service container (same image as local dev) with pg_trgm + vector extensions enabled.

If a contributor edits \`schema.prisma\` without writing a matching migration, this fails with a clear \`[+] Added column ...\` diff and an annotated guidance message pointing at \`claudedocs/database-migrations.md\`.

## Schema changes required for a clean diff

\`Document.searchVector\` is a Postgres \`GENERATED ALWAYS AS\` column that \`schema.prisma\` can't fully express. Without two small additions, \`migrate diff\` would always report two stable false positives:

| Diff before | Fix |
|---|---|
| \`[*] Altered column searchVector (default changed from Some(DbGenerated(...)) to None)\` | \`@default(dbgenerated())\` — Prisma's escape hatch for \"there is a DB-side default, don't validate the expression\" |
| \`[-] Removed index on columns (searchVector)\` | \`@@index([searchVector], map: \"idx_document_search_vector\", type: Gin)\` — the schema-level equivalent of the migration's raw SQL \`CREATE INDEX ... USING GIN\` |

Both make \`schema.prisma\` a more accurate description of the live DB, independent of CI.

## Other changes

- **New \`npm run db:check\`** (\`scripts/db-check.sh\`) — wraps the same \`migrate diff\` for local use. Ensures the shadow DB and extensions exist before running.
- **Removed \`db:push\` npm script** — \`claudedocs/database-migrations.md\` forbids \`prisma db push\` in this project, so making it a one-liner npm command was a footgun. \`npx prisma db push\` still works for anyone who genuinely needs it; this just removes the convenience surface.
- **Doc updates** — both \`database-migrations.md\` and \`environment-setup.md\` now reference \`npm run db:check\` and document the known false-positive surface so future contributors know what's expected.

## Verification

Locally on the cleanup branch:
\`\`\`
$ npm run db:check
No difference detected.
EXIT_CODE=0
\`\`\`

Drift is correctly detected when a fake field is added to \`schema.prisma\`:
\`\`\`
$ # added fakeField to Document model
$ npm run db:check
[*] Changed the \`Document\` table
  [+] Added column \`fakeField\`
EXIT_CODE=2
\`\`\`

## Out of scope

- The existing \`tests/.github/workflows/test.yml\` E2E job uses \`npx prisma db push\` to set up the test DB (line 82). That's against the doc's spirit but harmless because each CI run gets an ephemeral Postgres container — \`db push\` against a throwaway DB doesn't drift anything. Worth flagging but not changing here.

## Test plan

- [x] Locally: \`npm run db:check\` exits 0 on clean state
- [x] Locally: drift introduced in \`schema.prisma\` triggers exit 2 with descriptive output
- [x] Schema-level changes (dbgenerated, Gin index) verified against migrations on a fresh shadow DB
- [ ] CI runs the new workflow on this PR's first push — will be visible immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)