### PR TITLE
Rename Gantt/File Tree tabs and group sidebar nav by purpose

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,8 +30,8 @@ const t = {
 function DashboardPreview() {
   const sidebarItems = [
     { label: 'Dashboard', icon: House, active: true },
-    { label: 'Gantt', icon: ChartBar, badge: '14' },
-    { label: 'File Tree', icon: FolderOpen },
+    { label: 'Timeline', icon: ChartBar, badge: '14' },
+    { label: 'Tree', icon: FolderOpen },
     { label: 'Documents', icon: BookOpen, chevron: true },
     { label: 'Team', icon: UsersThree },
     { label: 'Settings', icon: Gear },

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,8 +21,8 @@ import ProjectSwitcher from './ProjectSwitcher';
 import LocationWeather from './LocationWeather';
 
 const PAGE_TITLES: Record<string, string> = {
-  gantt: 'Gantt Chart',
-  files: 'File Tree',
+  gantt: 'Timeline',
+  files: 'Tree',
   'document-explorer': 'Document Explorer',
   team: 'Team',
   settings: 'Project Settings',

--- a/src/components/layout/navItems.ts
+++ b/src/components/layout/navItems.ts
@@ -1,4 +1,4 @@
-export type NavSection = 'navigation' | 'workspace';
+export type NavSection = 'project-plan' | 'documents' | 'workspace';
 
 export interface NavItem {
   id: string;
@@ -14,7 +14,8 @@ export interface NavSectionDef {
 }
 
 export const SIDEBAR_SECTIONS: NavSectionDef[] = [
-  { id: 'navigation', label: 'Navigation' },
+  { id: 'project-plan', label: 'Project Plan' },
+  { id: 'documents', label: 'Documents' },
   { id: 'workspace', label: 'Workspace' },
 ];
 
@@ -23,10 +24,10 @@ export const orgNavItems: NavItem[] = [];
 
 // Project-level navigation (requires a selected project)
 export const projectNavItems: NavItem[] = [
-  { id: 'gantt', label: 'Gantt', icon: 'ChartBar', segment: 'gantt', section: 'navigation' },
-  { id: 'files', label: 'File Tree', icon: 'FolderSimple', segment: 'files', section: 'navigation' },
-  { id: 'document-explorer', label: 'Document Explorer', icon: 'FileMagnifyingGlass', segment: 'document-explorer', section: 'navigation' },
-  { id: 'reviews', label: 'Review Queue', icon: 'SealCheck', segment: 'reviews', section: 'navigation' },
+  { id: 'gantt', label: 'Timeline', icon: 'ChartBar', segment: 'gantt', section: 'project-plan' },
+  { id: 'files', label: 'Tree', icon: 'FolderSimple', segment: 'files', section: 'project-plan' },
+  { id: 'document-explorer', label: 'Document Explorer', icon: 'FileMagnifyingGlass', segment: 'document-explorer', section: 'documents' },
+  { id: 'reviews', label: 'Review Queue', icon: 'SealCheck', segment: 'reviews', section: 'documents' },
   { id: 'team', label: 'Team', icon: 'UsersThree', segment: 'team', section: 'workspace' },
   { id: 'project-settings', label: 'Project Settings', icon: 'GearSix', segment: 'settings', section: 'workspace' },
 ];

--- a/src/components/projects/ProjectsTree.tsx
+++ b/src/components/projects/ProjectsTree.tsx
@@ -504,7 +504,7 @@ export default function ProjectsTree({ selectedNodeId, onSelect, projectId, orga
           letterSpacing: '-0.01em',
         }}
       >
-        File Tree
+        Tree
       </Typography>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <Box


### PR DESCRIPTION
## Summary
- Rename project tabs: "Gantt" → "Timeline", "File Tree" → "Tree" (sidebar nav, header page titles, landing-page dashboard preview, ProjectsTree panel header)
- Reorganize sidebar from a single "Navigation" section into "Project Plan" (Timeline, Tree) and "Documents" (Document Explorer, Review Queue); "Workspace" unchanged
- URL segments (`gantt`, `files`) are unchanged, so existing links/bookmarks still work

## Test plan
- [ ] Verify sidebar shows three sections in this order: Project Plan, Documents, Workspace
- [ ] Verify header title reads "Timeline" on the Gantt page and "Tree" on the files page
- [ ] Verify landing page dashboard preview shows the new labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)