### PR TITLE
Restyle document explorer search bar with AI mode

### DIFF
--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/document-explorer/page.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/document-explorer/page.tsx
@@ -189,6 +189,7 @@ export default function DocumentExplorerPage() {
         query={query}
         onQueryChange={setQuery}
         onKeyDown={handleKeyDown}
+        onSubmit={handleAiSubmit}
         aiEnabled={aiEnabled}
         isAiSearching={aiEnabled && !!aiSearchQuery && aiQuery.isFetching}
         onAiToggle={handleAiToggle}

--- a/src/components/documents/DocumentToolbar.tsx
+++ b/src/components/documents/DocumentToolbar.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Box, InputBase, Typography, Tooltip, keyframes, useTheme } from '@mui/material';
-import { Sparkles, Search, Upload } from 'lucide-react';
+import { alpha } from '@mui/material/styles';
+import { Sparkles, Search, Upload, ArrowUp } from 'lucide-react';
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import SearchSuggestionsPopover from './SearchSuggestionsPopover';
 import type { RecentSearch } from '@/hooks/useRecentSearches';
@@ -10,6 +11,7 @@ interface DocumentToolbarProps {
   query: string;
   onQueryChange: (value: string) => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
+  onSubmit: () => void;
   aiEnabled: boolean;
   isAiSearching: boolean;
   onAiToggle: () => void;
@@ -24,6 +26,7 @@ export default function DocumentToolbar({
   query,
   onQueryChange,
   onKeyDown,
+  onSubmit,
   aiEnabled,
   isAiSearching,
   onAiToggle,
@@ -41,18 +44,26 @@ export default function DocumentToolbar({
   const inputRef = useRef<HTMLInputElement>(null);
   const [isFocused, setIsFocused] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
-  const showSuggestions = isFocused && !query.trim();
 
   const listboxId = useId();
   const optionIdPrefix = useId();
 
+  const displayRecents = useMemo(
+    () => recents.filter((r) => r.aiMode === aiEnabled),
+    [recents, aiEnabled],
+  );
+  const displayExamples = aiEnabled ? examples : [];
+
   const items = useMemo(
     () => [
-      ...recents.map((r) => ({ query: r.query, aiMode: r.aiMode })),
-      ...examples.map((q) => ({ query: q, aiMode: true })),
+      ...displayRecents.map((r) => ({ query: r.query, aiMode: r.aiMode })),
+      ...displayExamples.map((q) => ({ query: q, aiMode: true })),
     ],
-    [recents, examples],
+    [displayRecents, displayExamples],
   );
+
+  const hasSuggestions = displayRecents.length > 0 || displayExamples.length > 0;
+  const showSuggestions = isFocused && !query.trim() && hasSuggestions;
 
   useEffect(() => {
     if (!showSuggestions) setHighlightedIndex(-1);
@@ -124,146 +135,324 @@ export default function DocumentToolbar({
     to { transform: rotate(360deg); }
   `;
 
+  const shimmerAnim = keyframes`
+    0% { transform: translateX(-100%); }
+    55%, 100% { transform: translateX(100%); }
+  `;
+
+  const twinkleAnim = keyframes`
+    0%, 100% { opacity: 0.55; transform: rotate(0deg) scale(1); }
+    50% { opacity: 1; transform: rotate(8deg) scale(1.08); }
+  `;
+
+  const pulseDotAnim = keyframes`
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.5; transform: scale(1.4); }
+  `;
+
+  const canSubmit = !!query.trim();
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mb: 2 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
         {/* Search input */}
         <Box
           ref={searchBoxRef}
           sx={{
             display: 'flex',
-            alignItems: 'center',
-            gap: '10px',
+            flexDirection: aiEnabled ? 'column' : 'row',
+            alignItems: aiEnabled ? 'stretch' : 'center',
+            gap: aiEnabled ? '14px' : '10px',
             flex: 1,
-            borderRadius: '8px',
+            borderRadius: aiEnabled ? '16px' : '8px',
             bgcolor: 'background.paper',
-            px: 2,
-            py: 1.5,
-            border: '1.5px solid transparent',
+            px: aiEnabled ? '20px' : 2,
+            py: aiEnabled ? '16px' : 1.5,
+            border: aiEnabled ? '1px solid' : '1.5px solid transparent',
+            borderColor: aiEnabled ? 'divider' : undefined,
             backgroundImage: aiEnabled
-              ? `linear-gradient(${theme.palette.background.paper}, ${theme.palette.background.paper}), linear-gradient(90deg, ${primary}, ${primaryDark})`
+              ? undefined
               : `linear-gradient(${theme.palette.background.paper}, ${theme.palette.background.paper}), linear-gradient(90deg, ${primary}66, ${primaryDark}66)`,
-            backgroundOrigin: 'border-box',
-            backgroundClip: 'padding-box, border-box',
-            transition: 'background-image 0.4s, background-color 0.4s, box-shadow 0.4s',
+            backgroundOrigin: aiEnabled ? undefined : 'border-box',
+            backgroundClip: aiEnabled ? undefined : 'padding-box, border-box',
+            boxShadow: aiEnabled ? '0 1px 2px rgba(0,0,0,0.04)' : undefined,
+            transition: 'background-image 0.4s, background-color 0.4s, box-shadow 0.4s, border-color 0.3s, border-radius 0.3s, padding 0.3s',
             animation: aiEnabled ? `${glowPulse} 0.6s ease-out` : 'none',
-            '&:focus-within': {
-              backgroundImage: `linear-gradient(${theme.palette.background.paper}, ${theme.palette.background.paper}), linear-gradient(90deg, ${primary}, ${primaryDark})`,
-            },
+            '&:focus-within': aiEnabled
+              ? { borderColor: 'primary.main' }
+              : {
+                  backgroundImage: `linear-gradient(${theme.palette.background.paper}, ${theme.palette.background.paper}), linear-gradient(90deg, ${primary}, ${primaryDark})`,
+                },
           }}
         >
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 16,
-              height: 16,
-              flexShrink: 0,
-              transition: 'transform 0.3s ease',
-              transform: aiEnabled ? 'rotate(72deg) scale(1.1)' : 'rotate(0deg) scale(1)',
-            }}
-          >
-            {aiEnabled ? (
-              <Sparkles size={16} style={{ color: primary }} />
-            ) : (
-              <Search size={16} style={{ color: theme.palette.text.secondary }} />
-            )}
-          </Box>
-          <InputBase
-            inputRef={inputRef}
-            placeholder={aiEnabled ? 'Ask AI to find a document...' : 'Search documents...'}
-            value={query}
-            onChange={(e) => onQueryChange(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onFocus={() => setIsFocused(true)}
-            onBlur={() => setIsFocused(false)}
-            fullWidth
-            role="combobox"
-            aria-expanded={showSuggestions}
-            aria-controls={listboxId}
-            aria-autocomplete="list"
-            aria-activedescendant={activeOptionId}
-            sx={{
-              fontSize: 14,
-              '& .MuiInputBase-input': {
-                p: 0,
-                '&::placeholder': {
-                  color: aiEnabled ? 'primary.main' : 'text.secondary',
-                  opacity: aiEnabled ? 0.7 : 1,
-                  transition: 'color 0.3s, opacity 0.3s',
-                },
-              },
-            }}
-          />
-          {isAiSearching && (
+          {/* Top row: icon + input */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: aiEnabled ? '12px' : '10px', width: '100%' }}>
             <Box
               sx={{
-                width: 14,
-                height: 14,
-                borderRadius: '3px',
-                bgcolor: 'primary.main',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: aiEnabled ? 18 : 16,
+                height: aiEnabled ? 18 : 16,
                 flexShrink: 0,
-                animation: `${spinSlow} 3s linear infinite`,
+                transition: 'transform 0.3s ease',
+                transform: aiEnabled ? 'scale(1)' : 'rotate(0deg) scale(1)',
+              }}
+            >
+              <Search size={aiEnabled ? 18 : 16} style={{ color: theme.palette.text.secondary }} />
+            </Box>
+            <InputBase
+              inputRef={inputRef}
+              placeholder={aiEnabled ? 'Ask anything...' : 'Search documents...'}
+              value={query}
+              onChange={(e) => onQueryChange(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
+              fullWidth
+              role="combobox"
+              aria-expanded={showSuggestions}
+              aria-controls={listboxId}
+              aria-autocomplete="list"
+              aria-activedescendant={activeOptionId}
+              sx={{
+                fontSize: aiEnabled ? 15 : 14,
+                '& .MuiInputBase-input': {
+                  p: 0,
+                  '&::placeholder': {
+                    color: 'text.secondary',
+                    opacity: aiEnabled ? 0.85 : 1,
+                    transition: 'color 0.3s, opacity 0.3s',
+                  },
+                },
               }}
             />
+            {!aiEnabled && isAiSearching && (
+              <Box
+                sx={{
+                  width: 14,
+                  height: 14,
+                  borderRadius: '3px',
+                  bgcolor: 'primary.main',
+                  flexShrink: 0,
+                  animation: `${spinSlow} 3s linear infinite`,
+                }}
+              />
+            )}
+          </Box>
+
+          {/* Bottom row (AI mode only): send button */}
+          {aiEnabled && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                gap: 1,
+              }}
+            >
+              {isAiSearching && (
+                <Box
+                  sx={{
+                    width: 14,
+                    height: 14,
+                    borderRadius: '3px',
+                    bgcolor: 'primary.main',
+                    animation: `${spinSlow} 3s linear infinite`,
+                  }}
+                />
+              )}
+              <Tooltip title={canSubmit ? 'Search' : 'Type a query'}>
+                <Box
+                  component="button"
+                  onClick={() => {
+                    if (!canSubmit) return;
+                    onSubmit();
+                  }}
+                  disabled={!canSubmit}
+                  aria-label="Submit AI search"
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: 30,
+                    height: 30,
+                    borderRadius: '8px',
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    bgcolor: canSubmit ? 'primary.main' : 'action.hover',
+                    color: canSubmit ? 'primary.contrastText' : 'text.secondary',
+                    cursor: canSubmit ? 'pointer' : 'not-allowed',
+                    transition: 'background-color 0.2s, color 0.2s, border-color 0.2s',
+                    '&:hover': canSubmit ? { opacity: 0.9 } : undefined,
+                  }}
+                >
+                  <ArrowUp size={16} />
+                </Box>
+              </Tooltip>
+            </Box>
           )}
         </Box>
 
-        {/* AI toggle */}
-      <Tooltip title={aiEnabled ? 'AI search on' : 'AI search off'}>
-        <Box
-          component="button"
-          onClick={onAiToggle}
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '10px',
-            borderRadius: '8px',
-            border: 1,
-            borderColor: 'divider',
-            bgcolor: 'background.paper',
-            px: '14px',
-            py: 1,
-            cursor: 'pointer',
-            whiteSpace: 'nowrap',
-            '&:hover': { bgcolor: 'action.hover' },
-          }}
-        >
-          <Sparkles size={16} style={{ color: primary }} />
-          <Typography sx={{ fontSize: 13, fontWeight: 600, lineHeight: 1.2, color: 'text.primary' }}>
-            AI
-          </Typography>
-          {/* Custom toggle track */}
+        {/* AI mode toggle (segmented + glow/shimmer) */}
+        <Box sx={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center', gap: '6px' }}>
           <Box
             sx={{
               position: 'relative',
-              width: 36,
-              height: 20,
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              alignItems: 'stretch',
+              height: 36,
+              p: '3px',
               borderRadius: '999px',
-              background: aiEnabled
-                ? `linear-gradient(90deg, ${primary}, ${primaryDark})`
-                : 'divider',
-              bgcolor: aiEnabled ? undefined : 'divider',
-              transition: 'background 0.3s ease',
+              bgcolor: 'action.selected',
+              border: '1px solid',
+              borderColor: 'divider',
+              userSelect: 'none',
+              transition: 'box-shadow 0.32s ease, border-color 0.32s ease',
+              boxShadow: aiEnabled ? `0 0 0 3px ${alpha(primary, 0.30)}` : 'none',
+            }}
+          >
+            {/* Sliding indicator */}
+            <Box
+              sx={{
+                position: 'absolute',
+                top: '3px',
+                bottom: '3px',
+                left: '3px',
+                width: 'calc(50% - 3px)',
+                borderRadius: '999px',
+                bgcolor: aiEnabled ? undefined : 'background.paper',
+                backgroundImage: aiEnabled
+                  ? `linear-gradient(90deg, ${primary}, ${primaryDark})`
+                  : undefined,
+                boxShadow: aiEnabled
+                  ? `0 1px 3px rgba(0,0,0,0.28), 0 0 12px ${alpha(primary, 0.30)}`
+                  : '0 1px 3px rgba(0,0,0,0.18)',
+                overflow: 'hidden',
+                transform: aiEnabled ? 'translateX(100%)' : 'translateX(0)',
+                transition:
+                  'transform 0.36s cubic-bezier(0.4, 0, 0.2, 1), background-image 0.32s ease, box-shadow 0.32s ease',
+                zIndex: 1,
+                '&::before': {
+                  content: '""',
+                  position: 'absolute',
+                  inset: 0,
+                  background:
+                    'linear-gradient(105deg, transparent 0%, transparent 38%, rgba(255,255,255,0.55) 50%, transparent 62%, transparent 100%)',
+                  transform: 'translateX(-100%)',
+                  animation: aiEnabled ? `${shimmerAnim} 2.6s ease-in-out infinite` : 'none',
+                  pointerEvents: 'none',
+                },
+              }}
+            />
+
+            {/* Search segment */}
+            <Tooltip title="Match exact keywords">
+              <Box
+                component="button"
+                type="button"
+                onClick={() => {
+                  if (aiEnabled) onAiToggle();
+                }}
+                aria-pressed={!aiEnabled}
+                sx={{
+                  position: 'relative',
+                  zIndex: 2,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: '6px',
+                  px: '14px',
+                  color: aiEnabled ? 'text.secondary' : 'text.primary',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  fontFamily: 'inherit',
+                  borderRadius: '999px',
+                  background: 'transparent',
+                  border: 'none',
+                  cursor: 'pointer',
+                  whiteSpace: 'nowrap',
+                  transition: 'color 0.28s ease',
+                  '&:hover': { color: 'text.primary' },
+                }}
+              >
+                <Search size={13} />
+                Search
+              </Box>
+            </Tooltip>
+
+            {/* AI segment */}
+            <Tooltip title="Ask in plain English">
+              <Box
+                component="button"
+                type="button"
+                onClick={() => {
+                  if (!aiEnabled) onAiToggle();
+                }}
+                aria-pressed={aiEnabled}
+                sx={{
+                  position: 'relative',
+                  zIndex: 2,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: '6px',
+                  px: '14px',
+                  color: aiEnabled ? 'primary.contrastText' : 'text.secondary',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  fontFamily: 'inherit',
+                  borderRadius: '999px',
+                  background: 'transparent',
+                  border: 'none',
+                  cursor: 'pointer',
+                  whiteSpace: 'nowrap',
+                  transition: 'color 0.28s ease',
+                  '&:hover': aiEnabled ? undefined : { color: 'text.primary' },
+                }}
+              >
+                <Box
+                  component="span"
+                  sx={{
+                    display: 'inline-flex',
+                    animation: aiEnabled ? 'none' : `${twinkleAnim} 3.2s ease-in-out infinite`,
+                  }}
+                >
+                  <Sparkles size={13} />
+                </Box>
+                AI
+              </Box>
+            </Tooltip>
+          </Box>
+
+          {/* Microcopy — names what each mode does */}
+          <Box
+            sx={{
+              height: 14,
+              fontSize: 11,
+              color: aiEnabled ? 'text.secondary' : 'text.disabled',
+              lineHeight: 1,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '4px',
+              whiteSpace: 'nowrap',
+              transition: 'color 0.28s',
             }}
           >
             <Box
               sx={{
-                position: 'absolute',
-                top: 2,
-                left: aiEnabled ? 18 : 2,
-                width: 16,
-                height: 16,
+                width: 4,
+                height: 4,
                 borderRadius: '50%',
-                bgcolor: 'background.paper',
-                boxShadow: 1,
-                transition: 'left 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+                bgcolor: aiEnabled ? 'primary.main' : 'text.disabled',
+                animation: aiEnabled ? `${pulseDotAnim} 2s ease-in-out infinite` : 'none',
+                transition: 'background-color 0.28s',
               }}
             />
+            {aiEnabled ? 'Understands meaning & context' : 'Matches keywords in filenames & tags'}
           </Box>
         </Box>
-      </Tooltip>
 
       {/* Upload button */}
       <Box
@@ -297,8 +486,8 @@ export default function DocumentToolbar({
       <SearchSuggestionsPopover
         open={showSuggestions}
         anchorEl={searchBoxRef.current}
-        recents={recents}
-        examples={examples}
+        recents={displayRecents}
+        examples={displayExamples}
         highlightedIndex={highlightedIndex}
         onHighlightChange={setHighlightedIndex}
         listboxId={listboxId}

--- a/src/components/documents/DocumentToolbar.tsx
+++ b/src/components/documents/DocumentToolbar.tsx
@@ -355,6 +355,7 @@ export default function DocumentToolbar({
                 onClick={() => {
                   if (aiEnabled) onAiToggle();
                 }}
+                aria-label="Search mode"
                 aria-pressed={!aiEnabled}
                 sx={{
                   position: 'relative',
@@ -390,6 +391,7 @@ export default function DocumentToolbar({
                 onClick={() => {
                   if (!aiEnabled) onAiToggle();
                 }}
+                aria-label="AI mode"
                 aria-pressed={aiEnabled}
                 sx={{
                   position: 'relative',

--- a/src/components/documents/SearchSuggestionsPopover.tsx
+++ b/src/components/documents/SearchSuggestionsPopover.tsx
@@ -30,6 +30,9 @@ export default function SearchSuggestionsPopover({
   onClearRecents,
 }: SearchSuggestionsPopoverProps) {
   const showRecents = recents.length > 0;
+  const showExamples = examples.length > 0;
+
+  if (!showRecents && !showExamples) return null;
 
   return (
     <Popper
@@ -83,25 +86,27 @@ export default function SearchSuggestionsPopover({
             ))}
           </Box>
         )}
-        {showRecents && <Box sx={{ height: 1, bgcolor: 'divider' }} />}
-        <Box sx={{ p: 1 }}>
-          <SectionHeader icon={<Sparkles size={12} />} label="Try asking AI" />
-          {examples.map((example, j) => {
-            const index = recents.length + j;
-            return (
-              <SuggestionRow
-                key={example}
-                id={`${optionIdPrefix}-${index}`}
-                icon={<Sparkles size={14} />}
-                label={example}
-                italic
-                highlighted={highlightedIndex === index}
-                onMouseEnter={() => onHighlightChange(index)}
-                onSelect={() => onSelect(example, true)}
-              />
-            );
-          })}
-        </Box>
+        {showRecents && showExamples && <Box sx={{ height: 1, bgcolor: 'divider' }} />}
+        {showExamples && (
+          <Box sx={{ p: 1 }}>
+            <SectionHeader icon={<Sparkles size={12} />} label="Try asking AI" />
+            {examples.map((example, j) => {
+              const index = recents.length + j;
+              return (
+                <SuggestionRow
+                  key={example}
+                  id={`${optionIdPrefix}-${index}`}
+                  icon={<Sparkles size={14} />}
+                  label={example}
+                  italic
+                  highlighted={highlightedIndex === index}
+                  onMouseEnter={() => onHighlightChange(index)}
+                  onSelect={() => onSelect(example, true)}
+                />
+              );
+            })}
+          </Box>
+        )}
       </Paper>
     </Popper>
   );

--- a/tests/documents/ai-search.spec.ts
+++ b/tests/documents/ai-search.spec.ts
@@ -57,9 +57,7 @@ test.describe("Document explorer AI search", () => {
 
     // Placeholder should change to AI prompt
     const aiPlaceholder =
-      documentExplorerPage.page.getByPlaceholder(
-        "Ask AI to find a document..."
-      );
+      documentExplorerPage.page.getByPlaceholder("Ask anything...");
     await expect(aiPlaceholder).toBeVisible();
   });
 
@@ -80,7 +78,7 @@ test.describe("Document explorer AI search", () => {
 
     // Enable AI and type a query
     await documentExplorerPage.enableAi();
-    const searchInput = page.getByPlaceholder("Ask AI to find a document...");
+    const searchInput = page.getByPlaceholder("Ask anything...");
     await searchInput.fill("foundation inspection");
 
     // Set up a request listener for the aiSearch tRPC call

--- a/tests/pages/document-explorer.page.ts
+++ b/tests/pages/document-explorer.page.ts
@@ -3,13 +3,15 @@ import type { Locator, Page } from "@playwright/test";
 export class DocumentExplorerPage {
   readonly page: Page;
   readonly searchInput: Locator;
-  readonly aiToggle: Locator;
+  readonly aiSegment: Locator;
+  readonly searchSegment: Locator;
   readonly heading: Locator;
 
   constructor(page: Page) {
     this.page = page;
-    this.searchInput = page.getByPlaceholder(/search documents|ask ai/i);
-    this.aiToggle = page.getByRole("button", { name: /ai search/i });
+    this.searchInput = page.getByPlaceholder(/search documents|ask anything/i);
+    this.aiSegment = page.getByRole("button", { name: "AI", exact: true });
+    this.searchSegment = page.getByRole("button", { name: "Search", exact: true });
     this.heading = page.getByText("Document Explorer");
   }
 
@@ -18,17 +20,16 @@ export class DocumentExplorerPage {
   }
 
   async enableAi() {
-    // Click the AI toggle button if not already enabled
-    const placeholder = this.page.getByPlaceholder(/ask ai/i);
+    const placeholder = this.page.getByPlaceholder(/ask anything/i);
     if (!(await placeholder.isVisible())) {
-      await this.aiToggle.click();
+      await this.aiSegment.click();
     }
   }
 
   async disableAi() {
     const placeholder = this.page.getByPlaceholder(/search documents/i);
     if (!(await placeholder.isVisible())) {
-      await this.aiToggle.click();
+      await this.searchSegment.click();
     }
   }
 

--- a/tests/pages/document-explorer.page.ts
+++ b/tests/pages/document-explorer.page.ts
@@ -10,8 +10,8 @@ export class DocumentExplorerPage {
   constructor(page: Page) {
     this.page = page;
     this.searchInput = page.getByPlaceholder(/search documents|ask anything/i);
-    this.aiSegment = page.getByRole("button", { name: "AI", exact: true });
-    this.searchSegment = page.getByRole("button", { name: "Search", exact: true });
+    this.aiSegment = page.getByRole("button", { name: "AI mode" });
+    this.searchSegment = page.getByRole("button", { name: "Search mode" });
     this.heading = page.getByText("Document Explorer");
   }
 


### PR DESCRIPTION
## Summary
- Expand the search input into a multi-row layout in AI mode with a dedicated submit button (Enter still works in both modes)
- Replace the AI on/off toggle with a segmented Search/AI control featuring shimmer/glow animations and microcopy describing each mode
- Filter recent searches by the active mode and hide empty suggestion sections in the popover

## Test plan
- [ ] Toggle between Search and AI modes; verify the search bar restyles and recents filter to the active mode
- [ ] In AI mode, submit via the arrow button and via Enter; verify both trigger the AI search
- [ ] Focus the empty input with no recents/examples for the active mode and verify the popover stays closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)