### PR TITLE
Add per-document approval toggle to task popover folders

### DIFF
--- a/scripts/seed-employee.mjs
+++ b/scripts/seed-employee.mjs
@@ -1,0 +1,93 @@
+import { PrismaClient } from "../generated/prisma/index.js";
+import { hashPassword } from "better-auth/crypto";
+import { randomUUID } from "node:crypto";
+
+const EMAIL = process.env.SEED_EMAIL ?? "employee@example.com";
+const PASSWORD = process.env.SEED_PASSWORD ?? "Password123!";
+const NAME = process.env.SEED_NAME ?? "Test Employee";
+const ORG_SLUG = process.env.SEED_ORG_SLUG ?? "lawrences";
+const PROJECT_SLUG = process.env.SEED_PROJECT_SLUG ?? "cats";
+const ROLE = process.env.SEED_ROLE ?? "member";
+
+const db = new PrismaClient();
+
+async function main() {
+  const org = await db.organization.findUnique({ where: { slug: ORG_SLUG } });
+  if (!org) throw new Error(`Organization '${ORG_SLUG}' not found`);
+
+  const project = await db.project.findFirst({
+    where: { slug: PROJECT_SLUG, organizationId: org.id },
+  });
+  if (!project) throw new Error(`Project '${PROJECT_SLUG}' not found in '${ORG_SLUG}'`);
+
+  const existing = await db.user.findUnique({ where: { email: EMAIL } });
+  if (existing) {
+    console.log(`User ${EMAIL} already exists (id=${existing.id})`);
+    return;
+  }
+
+  const hashed = await hashPassword(PASSWORD);
+  const userId = randomUUID();
+  const now = new Date();
+
+  await db.$transaction(async (tx) => {
+    await tx.user.create({
+      data: {
+        id: userId,
+        email: EMAIL,
+        name: NAME,
+        emailVerified: true,
+        onboardingComplete: true,
+        activeOrganizationId: org.id,
+        activeProjectId: project.id,
+        createdAt: now,
+        updatedAt: now,
+      },
+    });
+
+    await tx.account.create({
+      data: {
+        id: randomUUID(),
+        accountId: userId,
+        providerId: "credential",
+        userId,
+        password: hashed,
+        createdAt: now,
+        updatedAt: now,
+      },
+    });
+
+    await tx.membership.create({
+      data: {
+        userId,
+        organizationId: org.id,
+        role: ROLE,
+      },
+    });
+
+    await tx.projectMember.create({
+      data: {
+        userId,
+        projectId: project.id,
+        role: ROLE,
+      },
+    });
+  });
+
+  console.log(JSON.stringify({
+    ok: true,
+    email: EMAIL,
+    password: PASSWORD,
+    userId,
+    organization: { id: org.id, slug: org.slug, name: org.name },
+    project: { id: project.id, slug: project.slug, name: project.name },
+    role: ROLE,
+  }, null, 2));
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => db.$disconnect());

--- a/src/__tests__/approvals/ApprovalToggleSwitch.test.tsx
+++ b/src/__tests__/approvals/ApprovalToggleSwitch.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import ApprovalToggleSwitch from "@/components/bryntum/components/task-popover/ApprovalToggleSwitch";
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  invalidate: vi.fn(),
+  isPending: false,
+}));
+
+vi.mock("@/trpc/react", () => ({
+  api: {
+    approval: {
+      setStatus: {
+        useMutation: () => ({
+          mutate: mocks.mutate,
+          isPending: mocks.isPending,
+        }),
+      },
+      listAll: { invalidate: mocks.invalidate },
+      summary: { invalidate: mocks.invalidate },
+    },
+    document: {
+      search: { invalidate: mocks.invalidate },
+      aiSearch: { invalidate: mocks.invalidate },
+      listByFolder: { invalidate: mocks.invalidate },
+      listByTask: { invalidate: mocks.invalidate },
+    },
+    useUtils: () => ({
+      approval: {
+        listAll: { invalidate: mocks.invalidate },
+        summary: { invalidate: mocks.invalidate },
+      },
+      document: {
+        search: { invalidate: mocks.invalidate },
+        aiSearch: { invalidate: mocks.invalidate },
+        listByFolder: { invalidate: mocks.invalidate },
+        listByTask: { invalidate: mocks.invalidate },
+      },
+    }),
+  },
+}));
+
+const baseProps = {
+  documentId: "doc-1",
+  documentName: "submittal-spec.pdf",
+  organizationId: "org-1",
+};
+
+describe("ApprovalToggleSwitch (admin)", () => {
+  beforeEach(() => {
+    mocks.mutate.mockReset();
+    mocks.invalidate.mockReset();
+    mocks.isPending = false;
+  });
+
+  it("renders an interactive switch when the user can approve", () => {
+    render(
+      <ApprovalToggleSwitch
+        {...baseProps}
+        approvalStatus="unapproved"
+        memberRole="admin"
+      />,
+    );
+
+    const sw = screen.getByRole("switch");
+    expect(sw).toBeInTheDocument();
+    expect(sw).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("opens the confirm popover when an unapproved switch is clicked, and does not fire the mutation yet", async () => {
+    const user = userEvent.setup();
+    render(
+      <ApprovalToggleSwitch
+        {...baseProps}
+        approvalStatus="unapproved"
+        memberRole="admin"
+      />,
+    );
+
+    await user.click(screen.getByRole("switch"));
+
+    // No mutation yet — waiting on confirmation
+    expect(mocks.mutate).not.toHaveBeenCalled();
+    // Confirm popover appears
+    expect(screen.getByText("Approve this submittal?")).toBeInTheDocument();
+    expect(screen.getByText("submittal-spec.pdf")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /approve/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it("fires setStatus with approved=true after the user confirms", async () => {
+    const user = userEvent.setup();
+    render(
+      <ApprovalToggleSwitch
+        {...baseProps}
+        approvalStatus="unapproved"
+        memberRole="admin"
+      />,
+    );
+
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("button", { name: /^approve$/i }));
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate).toHaveBeenCalledWith({
+      documentId: "doc-1",
+      organizationId: "org-1",
+      approved: true,
+    });
+  });
+
+  it("does not fire setStatus when the user cancels the confirm", async () => {
+    const user = userEvent.setup();
+    render(
+      <ApprovalToggleSwitch
+        {...baseProps}
+        approvalStatus="unapproved"
+        memberRole="admin"
+      />,
+    );
+
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it("flips an approved doc to unapproved with one click — no confirm", async () => {
+    const user = userEvent.setup();
+    render(
+      <ApprovalToggleSwitch
+        {...baseProps}
+        approvalStatus="approved"
+        memberRole="admin"
+      />,
+    );
+
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    await user.click(screen.getByRole("switch"));
+
+    // No confirm popover for un-approve — straight to mutation
+    expect(screen.queryByText("Approve this submittal?")).not.toBeInTheDocument();
+    expect(mocks.mutate).toHaveBeenCalledWith({
+      documentId: "doc-1",
+      organizationId: "org-1",
+      approved: false,
+    });
+  });
+
+  it("does not fire the mutation while a request is pending", async () => {
+    mocks.isPending = true;
+    const user = userEvent.setup();
+    render(
+      <ApprovalToggleSwitch
+        {...baseProps}
+        approvalStatus="approved"
+        memberRole="admin"
+      />,
+    );
+
+    await user.click(screen.getByRole("switch"));
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+});
+
+describe("ApprovalToggleSwitch (employee)", () => {
+  beforeEach(() => {
+    mocks.mutate.mockReset();
+    mocks.isPending = false;
+  });
+
+  it("renders a read-only badge instead of a switch", () => {
+    render(
+      <ApprovalToggleSwitch
+        {...baseProps}
+        approvalStatus="unapproved"
+        memberRole="member"
+      />,
+    );
+
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+
+  it('shows "Approved" when approved', () => {
+    render(
+      <ApprovalToggleSwitch
+        {...baseProps}
+        approvalStatus="approved"
+        approvedBy={{ id: "u-1", name: "Mark Diaz" }}
+        memberRole="viewer"
+      />,
+    );
+
+    expect(screen.getByText("Approved")).toBeInTheDocument();
+  });
+
+  it("does not fire the mutation when an employee clicks the badge", async () => {
+    const user = userEvent.setup();
+    render(
+      <ApprovalToggleSwitch
+        {...baseProps}
+        approvalStatus="unapproved"
+        memberRole="member"
+      />,
+    );
+
+    await user.click(screen.getByText("Pending"));
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -356,6 +356,7 @@ export function TaskDetailsPopover({
                       taskId={taskId}
                       organizationId={organizationId}
                       pinnedDocId={coverDocumentId}
+                      memberRole={memberRole}
                     />
                   );
                 })}
@@ -368,7 +369,11 @@ export function TaskDetailsPopover({
             <>
               <Divider orientation="vertical" flexItem />
               {rightPanel.type === 'preview' ? (
-                <FilePreviewPanel previewDoc={rightPanel.doc} />
+                <FilePreviewPanel
+                  previewDoc={rightPanel.doc}
+                  organizationId={organizationId}
+                  memberRole={memberRole}
+                />
               ) : (
                 <CsiCodePanel
                   csiCode={taskDetail?.csiCode}

--- a/src/components/bryntum/components/task-popover/ApprovalToggleSwitch.tsx
+++ b/src/components/bryntum/components/task-popover/ApprovalToggleSwitch.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useState } from 'react';
+import { Box, Popover, Tooltip, Typography, CircularProgress, Button } from '@mui/material';
+import { Check } from '@phosphor-icons/react';
+import { api } from '@/trpc/react';
+import { canApproveDocuments } from '@/lib/permissions';
+import type { ApprovedByUser } from './types';
+
+type ApprovalStatus = 'approved' | 'unapproved' | string;
+type Size = 'sm' | 'md';
+
+interface ApprovalToggleSwitchProps {
+  documentId: string;
+  documentName: string;
+  approvalStatus: ApprovalStatus;
+  approvedBy?: ApprovedByUser | null;
+  organizationId: string;
+  memberRole: string;
+  size?: Size;
+}
+
+const SIZES: Record<Size, { trackW: number; trackH: number; thumb: number; offset: number }> = {
+  sm: { trackW: 26, trackH: 16, thumb: 12, offset: 10 },
+  md: { trackW: 32, trackH: 18, thumb: 14, offset: 14 },
+};
+
+export default function ApprovalToggleSwitch({
+  documentId,
+  documentName,
+  approvalStatus,
+  approvedBy,
+  organizationId,
+  size = 'sm',
+  memberRole,
+}: ApprovalToggleSwitchProps) {
+  const canApprove = canApproveDocuments(memberRole);
+  const [optimistic, setOptimistic] = useState<ApprovalStatus | null>(null);
+  const [confirmAnchor, setConfirmAnchor] = useState<HTMLElement | null>(null);
+
+  const utils = api.useUtils();
+  const setStatusMutation = api.approval.setStatus.useMutation({
+    onSuccess: () => {
+      void utils.approval.listAll.invalidate();
+      void utils.approval.summary.invalidate();
+      void utils.document.search.invalidate();
+      void utils.document.aiSearch.invalidate();
+      void utils.document.listByFolder.invalidate();
+      void utils.document.listByTask.invalidate();
+    },
+    onError: () => setOptimistic(null),
+  });
+
+  const effectiveStatus = optimistic ?? approvalStatus;
+  const isApproved = effectiveStatus === 'approved';
+  const isPending = setStatusMutation.isPending;
+  const dims = SIZES[size];
+
+  // ── Read-only badge for non-approvers ──
+  if (!canApprove) {
+    const tooltip = isApproved
+      ? approvedBy?.name
+        ? `Approved by ${approvedBy.name}`
+        : 'Approved by an admin'
+      : 'Awaiting approval from an admin';
+
+    return (
+      <Tooltip title={tooltip} arrow disableInteractive>
+        <Box
+          component="span"
+          aria-label={isApproved ? 'Approved' : 'Awaiting approval'}
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '4px',
+            flexShrink: 0,
+            fontSize: 10,
+            fontWeight: 600,
+            color: isApproved ? 'success.main' : 'text.secondary',
+            userSelect: 'none',
+            lineHeight: 1.2,
+          }}
+        >
+          <Box
+            sx={{
+              width: 14,
+              height: 14,
+              borderRadius: '50%',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              bgcolor: isApproved ? 'success.main' : 'action.selected',
+              color: isApproved ? 'success.contrastText' : 'text.disabled',
+            }}
+          >
+            {isApproved ? (
+              <Check size={9} weight="bold" />
+            ) : (
+              <Box sx={{ width: 4, height: 4, borderRadius: '50%', bgcolor: 'currentColor' }} />
+            )}
+          </Box>
+          {isApproved ? 'Approved' : 'Pending'}
+        </Box>
+      </Tooltip>
+    );
+  }
+
+  // ── Interactive toggle for approvers ──
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isPending) return;
+
+    if (isApproved) {
+      // Un-approve: one-click flip, no confirm
+      setOptimistic('unapproved');
+      setStatusMutation.mutate({
+        documentId,
+        organizationId,
+        approved: false,
+      });
+    } else {
+      // Approve: open confirm popover anchored to the toggle
+      setConfirmAnchor(e.currentTarget);
+    }
+  };
+
+  const handleConfirm = () => {
+    setConfirmAnchor(null);
+    setOptimistic('approved');
+    setStatusMutation.mutate({
+      documentId,
+      organizationId,
+      approved: true,
+    });
+  };
+
+  const handleCancel = () => setConfirmAnchor(null);
+
+  const tooltipText = isPending
+    ? 'Saving…'
+    : isApproved
+      ? 'Approved · click to unapprove'
+      : 'Click to approve';
+
+  return (
+    <>
+      <Tooltip title={tooltipText} arrow disableInteractive>
+        {/* span wrapper so Tooltip still receives mouse events when the button is disabled */}
+        <Box component="span" sx={{ display: 'inline-flex', flexShrink: 0 }}>
+        <Box
+          component="button"
+          type="button"
+          role="switch"
+          aria-checked={isApproved}
+          aria-label={isApproved ? 'Mark as unapproved' : 'Approve document'}
+          onClick={handleClick}
+          disabled={isPending}
+          sx={{
+            position: 'relative',
+            flexShrink: 0,
+            width: dims.trackW,
+            height: dims.trackH,
+            borderRadius: '999px',
+            border: '1px solid',
+            borderColor: isApproved ? 'success.main' : 'divider',
+            bgcolor: isApproved ? 'success.main' : 'action.selected',
+            cursor: isPending ? 'progress' : 'pointer',
+            opacity: isPending ? 0.7 : 1,
+            transition: 'background-color 0.2s, border-color 0.2s, box-shadow 0.2s',
+            p: 0,
+            outline: 'none',
+            boxShadow: confirmAnchor ? '0 0 0 3px rgba(22,163,74,0.2)' : 'none',
+            '&:hover': isPending
+              ? {}
+              : isApproved
+                ? { bgcolor: 'success.dark', borderColor: 'success.dark' }
+                : { borderColor: 'success.main' },
+            '&:focus-visible': { boxShadow: '0 0 0 3px rgba(22,163,74,0.3)' },
+          }}
+        >
+          <Box
+            sx={{
+              position: 'absolute',
+              top: '50%',
+              left: 1,
+              transform: `translateY(-50%) translateX(${isApproved ? dims.offset : 0}px)`,
+              width: dims.thumb,
+              height: dims.thumb,
+              borderRadius: '50%',
+              bgcolor: '#fff',
+              boxShadow: '0 1px 2px rgba(0,0,0,0.20)',
+              transition: 'transform 0.22s cubic-bezier(0.4,0,0.2,1)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {isPending && (
+              <CircularProgress
+                size={dims.thumb - 4}
+                thickness={6}
+                sx={{ color: 'success.main' }}
+              />
+            )}
+          </Box>
+        </Box>
+        </Box>
+      </Tooltip>
+
+      <Popover
+        open={!!confirmAnchor}
+        anchorEl={confirmAnchor}
+        onClose={handleCancel}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{
+          paper: {
+            sx: {
+              mt: 1,
+              p: '14px 16px',
+              borderRadius: '10px',
+              border: '1px solid',
+              borderColor: 'divider',
+              boxShadow: '0 12px 32px rgba(0,0,0,0.14)',
+              width: 240,
+            },
+          },
+        }}
+      >
+        <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 0.5, color: 'text.primary' }}>
+          Approve this submittal?
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: 11,
+            color: 'text.secondary',
+            mb: 1.5,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          title={documentName}
+        >
+          {documentName}
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 0.75, justifyContent: 'flex-end' }}>
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={handleCancel}
+            sx={{ fontSize: 11, py: 0.5, px: 1.25, minWidth: 0, textTransform: 'none' }}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="small"
+            variant="contained"
+            color="success"
+            onClick={handleConfirm}
+            sx={{ fontSize: 11, py: 0.5, px: 1.5, minWidth: 0, textTransform: 'none' }}
+          >
+            Approve
+          </Button>
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/src/components/bryntum/components/task-popover/BaseFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/BaseFolderContent.tsx
@@ -77,6 +77,10 @@ function BaseFolderContentInner({
           size: doc.size,
           createdAt: doc.createdAt,
           uploadedBy: doc.uploadedBy ?? null,
+          folderId: doc.folderId,
+          approvalStatus: doc.approvalStatus,
+          approvedAt: doc.approvedAt,
+          approvedBy: doc.approvedBy,
         };
 
         return (

--- a/src/components/bryntum/components/task-popover/FilePreviewPanel.tsx
+++ b/src/components/bryntum/components/task-popover/FilePreviewPanel.tsx
@@ -3,13 +3,37 @@
 import { Box, Typography, Divider } from '@mui/material';
 import { ImageSquare, FileText, DownloadSimple, ArrowsOut } from '@phosphor-icons/react';
 import { formatFileSize } from '@/lib/utils/formatting';
+import { isApprovableFolder } from '@/lib/folders';
 import type { PreviewDoc } from './types';
+import ApprovalToggleSwitch from './ApprovalToggleSwitch';
 
 interface FilePreviewPanelProps {
   previewDoc: PreviewDoc;
+  organizationId?: string;
+  memberRole?: string;
 }
 
-export default function FilePreviewPanel({ previewDoc }: FilePreviewPanelProps) {
+export default function FilePreviewPanel({
+  previewDoc,
+  organizationId,
+  memberRole,
+}: FilePreviewPanelProps) {
+  const showApproval =
+    isApprovableFolder(previewDoc.folderId) &&
+    !!organizationId &&
+    typeof memberRole === 'string';
+  const approvedByName = previewDoc.approvedBy?.name ?? null;
+  const approvedAtLabel = previewDoc.approvedAt
+    ? new Date(previewDoc.approvedAt).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    : null;
+  const approvedByDisplay =
+    previewDoc.approvalStatus === 'approved' && (approvedByName || approvedAtLabel)
+      ? [approvedByName, approvedAtLabel].filter(Boolean).join(' · ')
+      : null;
   return (
     <Box
       sx={{
@@ -26,7 +50,7 @@ export default function FilePreviewPanel({ previewDoc }: FilePreviewPanelProps) 
       }}
     >
       {/* Header */}
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: '20px', py: '14px' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: '20px', py: '14px', gap: 1 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
           {previewDoc.mimeType.startsWith('image/') ? (
             <ImageSquare size={16} color="var(--text-secondary)" style={{ flexShrink: 0 }} />
@@ -38,6 +62,17 @@ export default function FilePreviewPanel({ previewDoc }: FilePreviewPanelProps) 
           </Typography>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
+          {showApproval && (
+            <ApprovalToggleSwitch
+              documentId={previewDoc.id}
+              documentName={previewDoc.name}
+              approvalStatus={previewDoc.approvalStatus}
+              approvedBy={previewDoc.approvedBy}
+              organizationId={organizationId!}
+              memberRole={memberRole!}
+              size="md"
+            />
+          )}
           {[
             { icon: DownloadSimple, label: 'Download' },
             { icon: ArrowsOut, label: 'Expand' },
@@ -99,6 +134,9 @@ export default function FilePreviewPanel({ previewDoc }: FilePreviewPanelProps) 
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0, px: '20px', py: '12px' }}>
         {previewDoc.uploadedBy?.name && (
           <MetaRow label="Uploaded by" value={previewDoc.uploadedBy.name} hasBorder />
+        )}
+        {approvedByDisplay && (
+          <MetaRow label="Approved by" value={approvedByDisplay} hasBorder />
         )}
         <MetaRow
           label="Date"

--- a/src/components/bryntum/components/task-popover/FolderRow.tsx
+++ b/src/components/bryntum/components/task-popover/FolderRow.tsx
@@ -54,6 +54,8 @@ interface FolderRowProps {
   taskId?: string;
   organizationId?: string;
   pinnedDocId?: string | null;
+  // Approval context (only used by trackable folders)
+  memberRole?: string;
 }
 
 function FolderRowInner({
@@ -74,6 +76,7 @@ function FolderRowInner({
   taskId,
   organizationId,
   pinnedDocId,
+  memberRole,
 }: FolderRowProps) {
   const FolderIcon = folderIconMap[folder.id] ?? (isExpanded ? FolderOpen : FolderSimple);
   const isTrackable = folder.trackable && !!onSaveRequirement;
@@ -88,6 +91,7 @@ function FolderRowInner({
     taskId,
     organizationId,
     pinnedDocId,
+    memberRole,
   };
 
   const renderContent = () => {

--- a/src/components/bryntum/components/task-popover/PhotosFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/PhotosFolderContent.tsx
@@ -91,6 +91,10 @@ function PhotosFolderContentInner({
     size: doc.size,
     createdAt: doc.createdAt,
     uploadedBy: doc.uploadedBy ?? null,
+    folderId: doc.folderId,
+    approvalStatus: doc.approvalStatus,
+    approvedAt: doc.approvedAt,
+    approvedBy: doc.approvedBy,
   });
 
   return (

--- a/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, alpha, useTheme } from '@mui/material';
 import { CloudArrowUp, FileText, CheckCircle } from '@phosphor-icons/react';
 import type { FolderContentProps, PreviewDoc } from './types';
+import ApprovalToggleSwitch from './ApprovalToggleSwitch';
 
 interface TrackableFolderContentProps extends FolderContentProps {
   required: number | null;
@@ -18,7 +19,13 @@ function TrackableFolderContentInner({
   folderName,
   required,
   folderColor,
+  organizationId,
+  memberRole,
 }: TrackableFolderContentProps) {
+  const theme = useTheme();
+  const successMain = theme.palette.success.main;
+  const canShowApproval =
+    !!organizationId && typeof memberRole === 'string';
   // No requirement set — empty state (no dropzones until a requirement is configured)
   if (required === null || required === 0) {
     return (
@@ -67,7 +74,12 @@ function TrackableFolderContentInner({
             size: doc.size,
             createdAt: doc.createdAt,
             uploadedBy: doc.uploadedBy ?? null,
+            folderId: doc.folderId,
+            approvalStatus: doc.approvalStatus,
+            approvedAt: doc.approvedAt,
+            approvedBy: doc.approvedBy,
           };
+          const isApproved = doc.approvalStatus === 'approved';
 
           return (
             <Box
@@ -86,7 +98,7 @@ function TrackableFolderContentInner({
                 transition: 'background-color 0.15s',
               }}
             >
-              {/* Slot number badge — filled */}
+              {/* Slot number badge — green when approved, folder-colored otherwise */}
               <Box
                 sx={{
                   display: 'flex',
@@ -95,11 +107,16 @@ function TrackableFolderContentInner({
                   width: 18,
                   height: 18,
                   borderRadius: '50%',
-                  bgcolor: `${folderColor}18`,
+                  bgcolor: isApproved ? alpha(successMain, 0.12) : `${folderColor}18`,
                   flexShrink: 0,
+                  transition: 'background-color 0.2s',
                 }}
               >
-                <CheckCircle size={11} weight="fill" color={folderColor} />
+                <CheckCircle
+                  size={11}
+                  weight="fill"
+                  color={isApproved ? successMain : folderColor}
+                />
               </Box>
 
               <FileText
@@ -121,6 +138,17 @@ function TrackableFolderContentInner({
               >
                 {doc.name}
               </Typography>
+              {canShowApproval && (
+                <ApprovalToggleSwitch
+                  documentId={doc.id}
+                  documentName={doc.name}
+                  approvalStatus={doc.approvalStatus}
+                  approvedBy={doc.approvedBy}
+                  organizationId={organizationId!}
+                  memberRole={memberRole!}
+                  size="sm"
+                />
+              )}
               {doc.createdAt != null && (
                 <Typography sx={{ fontSize: 11, color: 'text.secondary', flexShrink: 0 }}>
                   {new Date(doc.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}

--- a/src/components/bryntum/components/task-popover/types.ts
+++ b/src/components/bryntum/components/task-popover/types.ts
@@ -1,3 +1,9 @@
+export interface ApprovedByUser {
+  id: string;
+  name: string | null;
+  email?: string;
+}
+
 export interface PreviewDoc {
   id: string;
   name: string;
@@ -6,6 +12,10 @@ export interface PreviewDoc {
   size: number;
   createdAt: string | Date;
   uploadedBy: { name: string | null } | null;
+  folderId: string;
+  approvalStatus: string;
+  approvedAt: Date | string | null;
+  approvedBy: ApprovedByUser | null;
 }
 
 export interface DocumentItem {
@@ -17,6 +27,9 @@ export interface DocumentItem {
   folderId: string;
   createdAt: Date;
   uploadedBy: { name: string | null } | null;
+  approvalStatus: string;
+  approvedAt: Date | string | null;
+  approvedBy: ApprovedByUser | null;
 }
 
 export interface FolderContentProps {
@@ -30,4 +43,6 @@ export interface FolderContentProps {
   taskId?: string;
   organizationId?: string;
   pinnedDocId?: string | null;
+  // Approval context — only consumed by trackable folders (submittals, inspections)
+  memberRole?: string;
 }


### PR DESCRIPTION
## Summary
- Adds an `ApprovalToggleSwitch` to trackable folder rows and the file preview header, with a confirm popover for approving and a one-click flip to unapprove for users with `APPROVE_DOCUMENTS`; non-approvers see a read-only Pending/Approved badge.
- Threads `approvalStatus` / `approvedBy` / `approvedAt` and `folderId` through `PreviewDoc` and `DocumentItem` so the trackable, photos, and base folder content all surface approval state, and renders an "Approved by" meta row in the preview panel.
- Uses `theme.palette.success.main` (via `useTheme()` + `alpha`) for the approved-state badge color so it flips correctly in dark mode and stays consistent with the toggle.
- Adds `scripts/seed-employee.mjs` to seed a verified test user with org + project membership for E2E auth scenarios.

## Test plan
- [x] `vitest run src/__tests__/approvals/ApprovalToggleSwitch.test.tsx` (9 passed)
- [x] `tsc --noEmit`
- [ ] Manually approve / unapprove a submittal as an admin and confirm a member sees a read-only badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)