### PR TITLE
Add per-slot tracking for submittals and inspections

### DIFF
--- a/claudedocs/components-guide.md
+++ b/claudedocs/components-guide.md
@@ -14,7 +14,7 @@ Conventions for adding, naming, and structuring components in `src/components/`.
 | `dashboard/` | Dashboard feature components (StatsCards, ProjectsList, TeamActivity) |
 | `projects/` | Project CRUD dialogs and trees (AddProjectDialog, ProjectFormBody, ProjectsTree, ProjectDetailPanel) |
 | `documents/` | Document feature components (DocumentList, UploadDialog, FileDropzone) |
-| `approvals/` | Submittal/inspection approval workflow (ApprovalToggle, ReviewQueueContent, ReviewCard) |
+| `approvals/` | Submittal/inspection approval workflow (ApprovalToggle, ReviewQueueContent, ReviewCard). The Review Queue's "Overdue" tab reads from `gantt.listSlots` / `approval.listOverdueSlots` so per-task slot due dates surface here. |
 | `team/` | Team/invite management (MembersList, InviteDialog, RoleSelect, PendingInvitesList) |
 | `onboarding/` | Onboarding wizard and step components |
 | `bryntum/` | Gantt chart integration — has its own internal structure (see below) |
@@ -250,6 +250,7 @@ bryntum/
     ganttConfig.ts          ← Bryntum config object
   components/
     TaskDetailsPopover.tsx
+    SubmittalDrawer.tsx       ← right-side drawer for managing per-slot submittals/inspections
     BryntumPanelHeader.tsx
     CsiCodeSelector.tsx
     task-popover/             ← extracted sub-components for TaskDetailsPopover

--- a/claudedocs/trpc-guide.md
+++ b/claudedocs/trpc-guide.md
@@ -209,6 +209,15 @@ await ctx.db.$transaction(async (tx) => {
 
 ---
 
+### Lazy backfill on first read
+
+A few procedures deal with data that was migrated additively — a new table sits next to a legacy column without backfilling rows in the migration itself. The pattern is to backfill **on first read** inside the read procedure:
+
+- `gantt.listSlots` lazily creates `TaskRequirementSlot` rows the first time a task with a non-zero `requiredSubmittals` / `requiredInspections` is read. The legacy count column remains the source of truth for the count; the new table holds the per-slot metadata (`name`, `dueDate`, `approverId`).
+- Mutations that change the count (`gantt.setSlotCount`) keep the legacy column synced inside the same `$transaction` so existing readers (`gantt.taskDetail`, `gantt.requirementStats`, the inline popover progress) don't need to change.
+
+Use this pattern when a migration is purely additive and the read path can self-heal — it avoids destructive bulk-write migrations on the shared dev DB.
+
 ## 6. Helper Functions
 
 **File location:** `src/server/api/helpers/`

--- a/prisma/migrations/20260506000000_add_task_requirement_slot/migration.sql
+++ b/prisma/migrations/20260506000000_add_task_requirement_slot/migration.sql
@@ -1,0 +1,41 @@
+-- Adds the TaskRequirementSlot table for per-slot metadata (name, due date, approver).
+-- Existing GanttTask.requiredSubmittals / requiredInspections columns remain as
+-- denormalized count fields and are kept in sync by the application's setSlotCount
+-- mutation. Slot rows are lazily backfilled from the legacy counts on first read,
+-- so no destructive data migration is needed here.
+
+CREATE TABLE "TaskRequirementSlot" (
+    "id" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "index" INTEGER NOT NULL,
+    "name" TEXT,
+    "dueDate" TIMESTAMP(3),
+    "approverId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TaskRequirementSlot_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "TaskRequirementSlot_taskId_kind_index_key"
+    ON "TaskRequirementSlot"("taskId", "kind", "index");
+
+CREATE INDEX "TaskRequirementSlot_taskId_kind_idx"
+    ON "TaskRequirementSlot"("taskId", "kind");
+
+CREATE INDEX "TaskRequirementSlot_approverId_idx"
+    ON "TaskRequirementSlot"("approverId");
+
+CREATE INDEX "TaskRequirementSlot_dueDate_idx"
+    ON "TaskRequirementSlot"("dueDate");
+
+ALTER TABLE "TaskRequirementSlot"
+    ADD CONSTRAINT "TaskRequirementSlot_taskId_fkey"
+    FOREIGN KEY ("taskId") REFERENCES "GanttTask"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "TaskRequirementSlot"
+    ADD CONSTRAINT "TaskRequirementSlot_approverId_fkey"
+    FOREIGN KEY ("approverId") REFERENCES "User"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
     invitations        Invitation[]     @relation("InvitedByUser")
     documents          Document[]
     approvedDocuments  Document[]       @relation("ApprovedByUser")
+    approverSlots      TaskRequirementSlot[] @relation("SlotApprover")
     notifications      Notification[]
     activeOrganization Organization?    @relation("ActiveOrganization", fields: [activeOrganizationId], references: [id], onDelete: SetNull)
     activeProject      Project?         @relation("ActiveProject", fields: [activeProjectId], references: [id], onDelete: SetNull)
@@ -297,10 +298,31 @@ model GanttTask {
     dependenciesFrom GanttDependency[] @relation("FromTask")
     dependenciesTo   GanttDependency[] @relation("ToTask")
     coverDocument    Document? @relation("TaskCoverDocument", fields: [coverDocumentId], references: [id], onDelete: SetNull)
+    requirementSlots TaskRequirementSlot[]
 
     @@index([projectId])
     @@index([projectId, parentId])
     @@index([parentId])
+}
+
+model TaskRequirementSlot {
+    id          String    @id @default(cuid())
+    taskId      String
+    kind        String    // 'submittal' | 'inspection'
+    index       Int
+    name        String?
+    dueDate     DateTime?
+    approverId  String?
+    createdAt   DateTime  @default(now())
+    updatedAt   DateTime  @updatedAt
+
+    task     GanttTask @relation(fields: [taskId], references: [id], onDelete: Cascade)
+    approver User?     @relation("SlotApprover", fields: [approverId], references: [id], onDelete: SetNull)
+
+    @@unique([taskId, kind, index])
+    @@index([taskId, kind])
+    @@index([approverId])
+    @@index([dueDate])
 }
 
 model GanttDependency {

--- a/src/__tests__/approvals/ReviewQueueContent.test.tsx
+++ b/src/__tests__/approvals/ReviewQueueContent.test.tsx
@@ -49,6 +49,9 @@ vi.mock("@/trpc/react", () => ({
           return mocks.listAllResult;
         },
       },
+      listOverdueSlots: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
       // ApprovalToggle mocks (we don't render the toggle in these tests but
       // ReviewCard imports the toggle which calls these).
       setStatus: {

--- a/src/__tests__/lib/folder-row-state.test.ts
+++ b/src/__tests__/lib/folder-row-state.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * The four states ManageChipRow renders are derived from a tiny pure function.
+ * We extract that resolution here to lock its contract independent of MUI/JSX.
+ * Mirror this in the component if you change the rules.
+ */
+type State = "not-set-up" | "in-progress" | "pending-review" | "complete";
+
+function resolveFolderState(args: {
+  required: number | null;
+  approved: number;
+  pending: number;
+}): State {
+  const total = args.required ?? 0;
+  if (total === 0) return "not-set-up";
+  if (args.approved >= total) return "complete";
+  if (args.pending > 0) return "pending-review";
+  return "in-progress";
+}
+
+describe("resolveFolderState", () => {
+  it("returns 'not-set-up' when required is null", () => {
+    expect(resolveFolderState({ required: null, approved: 0, pending: 0 })).toBe("not-set-up");
+  });
+
+  it("returns 'not-set-up' when required is 0", () => {
+    expect(resolveFolderState({ required: 0, approved: 0, pending: 0 })).toBe("not-set-up");
+  });
+
+  it("returns 'in-progress' when nothing has been uploaded yet", () => {
+    expect(resolveFolderState({ required: 3, approved: 0, pending: 0 })).toBe("in-progress");
+  });
+
+  it("returns 'pending-review' when uploads are awaiting approval", () => {
+    expect(resolveFolderState({ required: 3, approved: 0, pending: 2 })).toBe("pending-review");
+  });
+
+  it("returns 'pending-review' when some are approved and some pending", () => {
+    expect(resolveFolderState({ required: 3, approved: 1, pending: 1 })).toBe("pending-review");
+  });
+
+  it("returns 'complete' only when approved meets the requirement", () => {
+    expect(resolveFolderState({ required: 3, approved: 3, pending: 0 })).toBe("complete");
+  });
+
+  it("treats over-approval as still complete (defensive)", () => {
+    expect(resolveFolderState({ required: 3, approved: 4, pending: 0 })).toBe("complete");
+  });
+
+  it("complete wins over pending when approved already meets the requirement", () => {
+    // Edge case: someone uploads an extra doc beyond the required count and it's pending review.
+    // We don't surface "pending review" once the requirement is satisfied — the work is done.
+    expect(resolveFolderState({ required: 3, approved: 3, pending: 1 })).toBe("complete");
+  });
+});

--- a/src/__tests__/lib/slot-validations.test.ts
+++ b/src/__tests__/lib/slot-validations.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  setSlotCountSchema,
+  updateSlotSchema,
+  slotKindSchema,
+} from "@/lib/validations/gantt";
+
+describe("slotKindSchema", () => {
+  it("accepts submittal and inspection", () => {
+    expect(slotKindSchema.parse("submittal")).toBe("submittal");
+    expect(slotKindSchema.parse("inspection")).toBe("inspection");
+  });
+  it("rejects other kinds", () => {
+    expect(() => slotKindSchema.parse("rfi")).toThrow();
+  });
+});
+
+describe("setSlotCountSchema", () => {
+  const valid = { taskId: "t1", kind: "submittal", count: 3 } as const;
+
+  it("accepts valid input", () => {
+    expect(setSlotCountSchema.parse(valid)).toEqual(valid);
+  });
+
+  it("clamps count to non-negative", () => {
+    expect(() => setSlotCountSchema.parse({ ...valid, count: -1 })).toThrow();
+  });
+
+  it("clamps count to <= 50", () => {
+    expect(() => setSlotCountSchema.parse({ ...valid, count: 51 })).toThrow();
+  });
+
+  it("requires integer count", () => {
+    expect(() => setSlotCountSchema.parse({ ...valid, count: 2.5 })).toThrow();
+  });
+});
+
+describe("updateSlotSchema", () => {
+  it("accepts a name update", () => {
+    const result = updateSlotSchema.parse({ slotId: "s1", name: "Shop Drawing" });
+    expect(result.name).toBe("Shop Drawing");
+  });
+
+  it("accepts a null name (to clear it)", () => {
+    expect(updateSlotSchema.parse({ slotId: "s1", name: null }).name).toBeNull();
+  });
+
+  it("trims whitespace from names", () => {
+    expect(updateSlotSchema.parse({ slotId: "s1", name: "  Shop Drawing  " }).name).toBe(
+      "Shop Drawing",
+    );
+  });
+
+  it("rejects names longer than 200 chars", () => {
+    expect(() =>
+      updateSlotSchema.parse({ slotId: "s1", name: "a".repeat(201) }),
+    ).toThrow();
+  });
+
+  it("accepts dueDate as ISO string", () => {
+    const result = updateSlotSchema.parse({ slotId: "s1", dueDate: "2026-05-12" });
+    expect(typeof result.dueDate).toBe("string");
+  });
+
+  it("accepts null dueDate to clear it", () => {
+    expect(updateSlotSchema.parse({ slotId: "s1", dueDate: null }).dueDate).toBeNull();
+  });
+
+  it("accepts approverId as nullable string", () => {
+    expect(updateSlotSchema.parse({ slotId: "s1", approverId: "u1" }).approverId).toBe("u1");
+    expect(updateSlotSchema.parse({ slotId: "s1", approverId: null }).approverId).toBeNull();
+  });
+});

--- a/src/__tests__/lib/slotNameLibrary.test.ts
+++ b/src/__tests__/lib/slotNameLibrary.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import {
+  SLOT_NAME_LIBRARY,
+  nextSuggestedSlotName,
+} from "@/lib/constants/slotNameLibrary";
+
+describe("nextSuggestedSlotName", () => {
+  it("returns the first library name when nothing is taken", () => {
+    expect(nextSuggestedSlotName("submittal", [])).toBe(SLOT_NAME_LIBRARY.submittal[0]);
+    expect(nextSuggestedSlotName("inspection", [])).toBe(SLOT_NAME_LIBRARY.inspection[0]);
+  });
+
+  it("skips names that are already taken (case-insensitive)", () => {
+    const first = SLOT_NAME_LIBRARY.submittal[0]!;
+    const second = SLOT_NAME_LIBRARY.submittal[1]!;
+    expect(nextSuggestedSlotName("submittal", [first.toUpperCase()])).toBe(second);
+  });
+
+  it("ignores null entries when checking taken names", () => {
+    expect(nextSuggestedSlotName("submittal", [null, null])).toBe(SLOT_NAME_LIBRARY.submittal[0]);
+  });
+
+  it("trims whitespace before comparing", () => {
+    const first = SLOT_NAME_LIBRARY.submittal[0]!;
+    expect(nextSuggestedSlotName("submittal", [`  ${first}  `])).toBe(SLOT_NAME_LIBRARY.submittal[1]);
+  });
+
+  it("returns null when every library name is taken", () => {
+    const allSubmittals = [...SLOT_NAME_LIBRARY.submittal];
+    expect(nextSuggestedSlotName("submittal", allSubmittals)).toBeNull();
+  });
+
+  it("treats submittals and inspections as separate libraries", () => {
+    // Taking all submittal names should not affect inspection suggestions.
+    const allSubmittals = [...SLOT_NAME_LIBRARY.submittal];
+    expect(nextSuggestedSlotName("inspection", allSubmittals)).toBe(
+      SLOT_NAME_LIBRARY.inspection[0],
+    );
+  });
+});

--- a/src/components/approvals/ReviewQueueContent.tsx
+++ b/src/components/approvals/ReviewQueueContent.tsx
@@ -2,15 +2,16 @@
 
 import { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Box, Typography, Tabs, Tab, ToggleButton, ToggleButtonGroup, Alert } from '@mui/material';
-import { SealCheck, Clock } from '@phosphor-icons/react';
+import { Box, Typography, Tabs, Tab, ToggleButton, ToggleButtonGroup, Alert, Avatar } from '@mui/material';
+import { SealCheck, Clock, WarningCircle, PaperPlaneTilt, ClipboardText } from '@phosphor-icons/react';
+import { format, formatDistanceToNow } from 'date-fns';
 import { api } from '@/trpc/react';
 import { useProjectContext } from '@/components/providers/ProjectProvider';
 import { useOrgContext } from '@/components/providers/OrgProvider';
 import { canApproveDocuments } from '@/lib/permissions';
 import ReviewCard, { type ReviewDocument } from './ReviewCard';
 
-type StatusTab = 'unapproved' | 'approved';
+type StatusTab = 'unapproved' | 'approved' | 'overdue';
 type CategoryFilter = 'all' | 'submittals' | 'inspections';
 
 export default function ReviewQueueContent() {
@@ -27,13 +28,24 @@ export default function ReviewQueueContent() {
   );
 
   const { data, isLoading } = api.approval.listAll.useQuery(
-    { organizationId, projectId, status, category },
-    { enabled: !!organizationId && !!projectId },
+    { organizationId, projectId, status: status === 'overdue' ? 'unapproved' : status, category },
+    { enabled: !!organizationId && !!projectId && status !== 'overdue' },
+  );
+
+  const { data: overdueSlots, isLoading: overdueLoading } = api.approval.listOverdueSlots.useQuery(
+    { organizationId, projectId },
+    { enabled: !!organizationId && !!projectId && status === 'overdue' },
   );
 
   const documents = (data?.documents ?? []) as ReviewDocument[];
   const pendingCount = summary?.pending ?? 0;
   const approvedCount = summary?.approved ?? 0;
+  const overdueCount = summary?.overdue ?? 0;
+  const filteredOverdue = (overdueSlots ?? []).filter((s) => {
+    if (category === 'all') return true;
+    if (category === 'submittals') return s.kind === 'submittal';
+    return s.kind === 'inspection';
+  });
 
   return (
     <Box
@@ -77,6 +89,13 @@ export default function ReviewQueueContent() {
             label={`Pending (${pendingCount})`}
           />
           <Tab
+            value="overdue"
+            iconPosition="start"
+            icon={<WarningCircle size={14} />}
+            label={`Overdue (${overdueCount})`}
+            sx={overdueCount > 0 ? { color: 'warning.main' } : undefined}
+          />
+          <Tab
             value="approved"
             iconPosition="start"
             icon={<SealCheck size={14} />}
@@ -108,12 +127,46 @@ export default function ReviewQueueContent() {
           <ToggleButton value="inspections">Inspections</ToggleButton>
         </ToggleButtonGroup>
         <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>
-          {documents.length} item{documents.length === 1 ? '' : 's'}
+          {status === 'overdue'
+            ? `${filteredOverdue.length} item${filteredOverdue.length === 1 ? '' : 's'}`
+            : `${documents.length} item${documents.length === 1 ? '' : 's'}`}
         </Typography>
       </Box>
 
-      {/* Body */}
-      {isLoading ? (
+      {/* Overdue tab body */}
+      {status === 'overdue' ? (
+        overdueLoading ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {[0, 1, 2].map((i) => (
+              <Box
+                key={i}
+                sx={{
+                  height: 60,
+                  borderRadius: '10px',
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  bgcolor: 'action.hover',
+                  opacity: 0.5,
+                }}
+              />
+            ))}
+          </Box>
+        ) : filteredOverdue.length === 0 ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 8, gap: 1, textAlign: 'center' }}>
+            <SealCheck size={40} weight="duotone" />
+            <Typography variant="h6" sx={{ color: 'text.secondary' }}>Nothing overdue</Typography>
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+              All required submittals and inspections are on schedule.
+            </Typography>
+          </Box>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {filteredOverdue.map((slot) => (
+              <OverdueSlotRow key={slot.id} slot={slot} />
+            ))}
+          </Box>
+        )
+      ) : isLoading ? (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
           {[0, 1, 2].map((i) => (
             <Box
@@ -164,6 +217,104 @@ export default function ReviewQueueContent() {
           ))}
         </Box>
       )}
+    </Box>
+  );
+}
+
+interface OverdueSlot {
+  id: string;
+  taskId: string;
+  taskName: string;
+  kind: 'submittal' | 'inspection';
+  index: number;
+  name: string | null;
+  dueDate: Date | string;
+  approver: { id: string; name: string | null; email: string; image: string | null } | null;
+}
+
+function OverdueSlotRow({ slot }: { slot: OverdueSlot }) {
+  const isSubmittal = slot.kind === 'submittal';
+  const Icon = isSubmittal ? PaperPlaneTilt : ClipboardText;
+  const accentColor = isSubmittal ? '#2563EB' : '#8E44AD';
+  const due = new Date(slot.dueDate);
+  const displayName = slot.name?.trim()
+    || `${isSubmittal ? 'Submittal' : 'Inspection'} ${slot.index + 1}`;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        px: 1.75,
+        py: 1.25,
+        borderRadius: '10px',
+        border: '1px solid',
+        borderColor: 'rgba(217,119,6,0.35)',
+        bgcolor: 'rgba(217,119,6,0.06)',
+      }}
+    >
+      <Box
+        sx={{
+          width: 28,
+          height: 28,
+          borderRadius: '8px',
+          bgcolor: `${accentColor}1F`,
+          color: accentColor,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <Icon size={14} />
+      </Box>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography
+          sx={{
+            fontSize: 13,
+            fontWeight: 500,
+            lineHeight: 1.2,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {displayName}
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: 11,
+            color: 'text.secondary',
+            mt: 0.25,
+            lineHeight: 1.3,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {slot.taskName}
+        </Typography>
+      </Box>
+      {slot.approver && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexShrink: 0, color: 'text.secondary' }}>
+          <Avatar
+            src={slot.approver.image ?? undefined}
+            sx={{ width: 18, height: 18, fontSize: 9, fontWeight: 600 }}
+          >
+            {(slot.approver.name ?? slot.approver.email).charAt(0).toUpperCase()}
+          </Avatar>
+          <Typography sx={{ fontSize: 11 }}>{slot.approver.name ?? slot.approver.email}</Typography>
+        </Box>
+      )}
+      <Box sx={{ textAlign: 'right', flexShrink: 0 }}>
+        <Typography sx={{ fontSize: 11, fontWeight: 600, color: 'warning.main' }}>
+          Due {format(due, 'MMM d')}
+        </Typography>
+        <Typography sx={{ fontSize: 10, color: 'text.secondary', mt: 0.25 }}>
+          {formatDistanceToNow(due, { addSuffix: true })}
+        </Typography>
+      </Box>
     </Box>
   );
 }

--- a/src/components/bryntum/components/SubmittalDrawer.tsx
+++ b/src/components/bryntum/components/SubmittalDrawer.tsx
@@ -1,0 +1,1186 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Drawer,
+  IconButton,
+  Typography,
+  Avatar,
+  Menu,
+  MenuItem,
+  CircularProgress,
+} from '@mui/material';
+import {
+  X,
+  Minus,
+  Plus,
+  PaperPlaneTilt,
+  ClipboardText,
+  CheckCircle,
+  UserCircle,
+  Trash,
+  CloudArrowUp,
+  WarningCircle,
+} from '@phosphor-icons/react';
+import { format, isBefore, startOfDay } from 'date-fns';
+
+import { api } from '@/trpc/react';
+import type { SlotKind } from '@/lib/validations/gantt';
+import type { DocumentItem } from './task-popover/types';
+
+const SUBMITTAL_COLOR = '#2563EB';
+const INSPECTION_COLOR = '#8E44AD';
+
+const KIND_META: Record<SlotKind, {
+  label: string;
+  pluralLabel: string;
+  color: string;
+  icon: typeof PaperPlaneTilt;
+  folderId: 'submittals' | 'inspections';
+  uploadCta: string;
+}> = {
+  submittal: {
+    label: 'submittal',
+    pluralLabel: 'submittals',
+    color: SUBMITTAL_COLOR,
+    icon: PaperPlaneTilt,
+    folderId: 'submittals',
+    uploadCta: 'Upload submittal',
+  },
+  inspection: {
+    label: 'inspection',
+    pluralLabel: 'inspections',
+    color: INSPECTION_COLOR,
+    icon: ClipboardText,
+    folderId: 'inspections',
+    uploadCta: 'Upload report',
+  },
+};
+
+interface SubmittalDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  organizationId: string;
+  projectId: string;
+  taskId: string;
+  taskName: string;
+  initialKind?: SlotKind;
+  /** Documents already uploaded under this task — used to mark slots as filled in order. */
+  docsByKind: Record<SlotKind, DocumentItem[]>;
+  /** Open the upload dialog for a given folder. Reuses the existing UploadDialog flow. */
+  onUploadToFolder: (folderId: 'submittals' | 'inspections') => void;
+}
+
+export default function SubmittalDrawer({
+  open,
+  onClose,
+  organizationId,
+  projectId,
+  taskId,
+  taskName,
+  initialKind = 'submittal',
+  docsByKind,
+  onUploadToFolder,
+}: SubmittalDrawerProps) {
+  const [activeKind, setActiveKind] = useState<SlotKind>(initialKind);
+
+  // Reset to the requested kind whenever the drawer (re)opens.
+  useEffect(() => {
+    if (open) setActiveKind(initialKind);
+  }, [open, initialKind]);
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      // Sit above the task popover (MUI Popover default is 1300).
+      sx={{ zIndex: 1500 }}
+      PaperProps={{
+        sx: {
+          width: 480,
+          maxWidth: '100vw',
+          bgcolor: 'background.paper',
+        },
+      }}
+    >
+      <DrawerHeader
+        kind={activeKind}
+        taskName={taskName}
+        onClose={onClose}
+      />
+
+      <KindTabs
+        activeKind={activeKind}
+        onChange={setActiveKind}
+        countSubmittal={docsByKind.submittal.length}
+        countInspection={docsByKind.inspection.length}
+      />
+
+      <DrawerContent
+        organizationId={organizationId}
+        projectId={projectId}
+        taskId={taskId}
+        kind={activeKind}
+        docs={docsByKind[activeKind]}
+        onUploadToFolder={() => onUploadToFolder(KIND_META[activeKind].folderId)}
+      />
+    </Drawer>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Header
+// ────────────────────────────────────────────────────────────────────────────
+function DrawerHeader({
+  kind,
+  taskName,
+  onClose,
+}: {
+  kind: SlotKind;
+  taskName: string;
+  onClose: () => void;
+}) {
+  const meta = KIND_META[kind];
+  const Icon = meta.icon;
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.25,
+        px: 2.5,
+        py: 1.75,
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+      }}
+    >
+      <Box
+        sx={{
+          width: 28,
+          height: 28,
+          borderRadius: '8px',
+          bgcolor: `${meta.color}1F`,
+          color: meta.color,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+          transition: 'background-color 0.2s, color 0.2s',
+        }}
+      >
+        <Icon size={14} weight="regular" />
+      </Box>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography sx={{ fontSize: 14, fontWeight: 600, lineHeight: 1.2, letterSpacing: '-0.005em' }}>
+          Manage {meta.pluralLabel}
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: 11,
+            color: 'text.secondary',
+            mt: 0.25,
+            lineHeight: 1.3,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {taskName}
+        </Typography>
+      </Box>
+      <IconButton size="small" onClick={onClose} sx={{ p: 0.5 }} aria-label="Close drawer">
+        <X size={16} />
+      </IconButton>
+    </Box>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tab toggle
+// ────────────────────────────────────────────────────────────────────────────
+function KindTabs({
+  activeKind,
+  onChange,
+  countSubmittal,
+  countInspection,
+}: {
+  activeKind: SlotKind;
+  onChange: (k: SlotKind) => void;
+  countSubmittal: number;
+  countInspection: number;
+}) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 0.25,
+        px: 1.75,
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        bgcolor: 'background.paper',
+      }}
+    >
+      <KindTab kind="submittal" active={activeKind === 'submittal'} onClick={() => onChange('submittal')} count={countSubmittal} />
+      <KindTab kind="inspection" active={activeKind === 'inspection'} onClick={() => onChange('inspection')} count={countInspection} />
+    </Box>
+  );
+}
+
+function KindTab({
+  kind,
+  active,
+  onClick,
+  count,
+}: {
+  kind: SlotKind;
+  active: boolean;
+  onClick: () => void;
+  count: number;
+}) {
+  const meta = KIND_META[kind];
+  const Icon = meta.icon;
+  return (
+    <Box
+      component="button"
+      onClick={onClick}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.875,
+        px: 1.5,
+        py: 1.25,
+        background: 'transparent',
+        border: 'none',
+        borderBottom: '2px solid',
+        borderColor: active ? meta.color : 'transparent',
+        marginBottom: '-1px',
+        cursor: 'pointer',
+        color: active ? meta.color : 'text.secondary',
+        fontFamily: 'inherit',
+        fontSize: 12,
+        fontWeight: 500,
+        transition: 'color 0.15s, border-color 0.15s',
+        '&:hover': { color: active ? meta.color : 'text.primary' },
+      }}
+    >
+      <Icon size={13} weight={active ? 'fill' : 'regular'} />
+      {meta.pluralLabel.charAt(0).toUpperCase() + meta.pluralLabel.slice(1)}
+      <Box
+        sx={{
+          fontSize: 10,
+          fontWeight: 600,
+          px: 0.875,
+          py: '1px',
+          borderRadius: '999px',
+          bgcolor: active ? `${meta.color}1F` : 'action.selected',
+          color: active ? meta.color : 'text.secondary',
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {count}
+      </Box>
+    </Box>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Body — required count stepper + slot list
+// ────────────────────────────────────────────────────────────────────────────
+function DrawerContent({
+  organizationId,
+  projectId,
+  taskId,
+  kind,
+  docs,
+  onUploadToFolder,
+}: {
+  organizationId: string;
+  projectId: string;
+  taskId: string;
+  kind: SlotKind;
+  docs: DocumentItem[];
+  onUploadToFolder: () => void;
+}) {
+  const meta = KIND_META[kind];
+  const utils = api.useUtils();
+
+  const slotsQuery = api.gantt.listSlots.useQuery(
+    { organizationId, projectId, taskId, kind },
+    { enabled: !!organizationId && !!projectId && !!taskId },
+  );
+  const slots = slotsQuery.data ?? [];
+
+  const setCountMutation = api.gantt.setSlotCount.useMutation({
+    onSuccess: () => {
+      void utils.gantt.listSlots.invalidate({ organizationId, projectId, taskId, kind });
+      void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId });
+      void utils.gantt.requirementStats.invalidate({ projectId });
+    },
+  });
+
+  const updateSlotMutation = api.gantt.updateSlot.useMutation({
+    onSuccess: () => {
+      void utils.gantt.listSlots.invalidate({ organizationId, projectId, taskId, kind });
+    },
+  });
+
+  // Members for the approver picker (cached at the org level).
+  const membersQuery = api.member.list.useQuery(
+    { organizationId },
+    { enabled: !!organizationId, staleTime: 60_000 },
+  );
+  const members = membersQuery.data ?? [];
+
+  // Decrement-with-data confirm state.
+  const [confirmRemove, setConfirmRemove] = useState<null | { trailingFilled: number; nextCount: number }>(null);
+
+  const filledCount = Math.min(docs.length, slots.length);
+
+  const handleStepCount = (next: number) => {
+    if (next < 0 || next > 50) return;
+    if (next < slots.length) {
+      // Removing slots — warn if any of the trailing slots map to an uploaded file.
+      const trailingFilled = Math.max(0, filledCount - next);
+      if (trailingFilled > 0) {
+        setConfirmRemove({ trailingFilled, nextCount: next });
+        return;
+      }
+    }
+    setCountMutation.mutate({ organizationId, projectId, taskId, kind, count: next });
+  };
+
+  const confirmAndShrink = () => {
+    if (!confirmRemove) return;
+    setCountMutation.mutate({
+      organizationId,
+      projectId,
+      taskId,
+      kind,
+      count: confirmRemove.nextCount,
+    });
+    setConfirmRemove(null);
+  };
+
+  const isPending = setCountMutation.isPending;
+  const isLoading = slotsQuery.isLoading;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+      <Box sx={{ flex: 1, overflowY: 'auto', px: 2.5, py: 2 }}>
+
+        {/* Required count card */}
+        <Box
+          sx={{
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: '10px',
+            px: 1.75,
+            py: 1.5,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.75,
+            bgcolor: 'background.default',
+            mb: 2.25,
+          }}
+        >
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography sx={{ fontSize: 12, fontWeight: 600, lineHeight: 1.2 }}>
+              Required {meta.pluralLabel}
+            </Typography>
+            <Typography sx={{ fontSize: 11, color: 'text.secondary', mt: 0.25, lineHeight: 1.3 }}>
+              How many must be received for this task
+            </Typography>
+          </Box>
+          <Stepper
+            value={slots.length}
+            onChange={handleStepCount}
+            disabled={isPending || isLoading}
+          />
+        </Box>
+
+        {/* Section label */}
+        <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.25 }}>
+          <Typography
+            sx={{
+              fontSize: '0.5625rem',
+              fontWeight: 600,
+              color: 'text.secondary',
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+            }}
+          >
+            Slots
+          </Typography>
+          <Typography sx={{ ml: 'auto', fontSize: 11, color: 'text.secondary' }}>
+            <SlotSummary slots={slots} filledCount={filledCount} />
+          </Typography>
+        </Box>
+
+        {/* Slot list / empty state */}
+        {isLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress size={16} />
+          </Box>
+        ) : slots.length === 0 ? (
+          <EmptyState kind={kind} onSeed={(count) => setCountMutation.mutate({ organizationId, projectId, taskId, kind, count })} />
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {slots.map((slot, i) => (
+              <SlotCard
+                key={slot.id}
+                slot={slot}
+                kind={kind}
+                doc={docs[i] ?? null}
+                members={members}
+                onRename={(name) =>
+                  updateSlotMutation.mutate({ organizationId, projectId, slotId: slot.id, name })
+                }
+                onSetDueDate={(dueDate) =>
+                  updateSlotMutation.mutate({ organizationId, projectId, slotId: slot.id, dueDate })
+                }
+                onSetApprover={(approverId) =>
+                  updateSlotMutation.mutate({ organizationId, projectId, slotId: slot.id, approverId })
+                }
+                onUpload={onUploadToFolder}
+              />
+            ))}
+          </Box>
+        )}
+      </Box>
+
+      <Box
+        sx={{
+          borderTop: '1px solid',
+          borderColor: 'divider',
+          px: 2.5,
+          py: 1.25,
+          bgcolor: 'background.default',
+        }}
+      >
+        <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>
+          Changes save automatically · close to return to the task
+        </Typography>
+      </Box>
+
+      {/* Decrement confirm */}
+      {confirmRemove && (
+        <ConfirmRemoveDialog
+          trailingFilled={confirmRemove.trailingFilled}
+          kind={kind}
+          onCancel={() => setConfirmRemove(null)}
+          onConfirm={confirmAndShrink}
+        />
+      )}
+    </Box>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Stepper
+// ────────────────────────────────────────────────────────────────────────────
+function Stepper({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: number;
+  onChange: (next: number) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Box
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: '8px',
+        overflow: 'hidden',
+        bgcolor: 'background.paper',
+      }}
+    >
+      <IconButton
+        size="small"
+        onClick={() => onChange(value - 1)}
+        disabled={disabled || value <= 0}
+        sx={{ width: 30, height: 32, borderRadius: 0, color: 'text.secondary' }}
+        aria-label="Decrease required count"
+      >
+        <Minus size={11} weight="bold" />
+      </IconButton>
+      <Box
+        sx={{
+          width: 38,
+          textAlign: 'center',
+          fontSize: 13,
+          fontWeight: 600,
+          fontVariantNumeric: 'tabular-nums',
+          borderLeft: '1px solid',
+          borderRight: '1px solid',
+          borderColor: 'divider',
+          lineHeight: '32px',
+        }}
+      >
+        {value}
+      </Box>
+      <IconButton
+        size="small"
+        onClick={() => onChange(value + 1)}
+        disabled={disabled || value >= 50}
+        sx={{ width: 30, height: 32, borderRadius: 0, color: 'text.secondary' }}
+        aria-label="Increase required count"
+      >
+        <Plus size={11} weight="bold" />
+      </IconButton>
+    </Box>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Slot summary text
+// ────────────────────────────────────────────────────────────────────────────
+function SlotSummary({
+  slots,
+  filledCount,
+}: {
+  slots: { dueDate: Date | null }[];
+  filledCount: number;
+}) {
+  const today = startOfDay(new Date());
+  const overdue = slots
+    .slice(filledCount) // only count *unfilled* slots as overdue
+    .filter((s) => s.dueDate && isBefore(new Date(s.dueDate), today)).length;
+  const pending = slots.length - filledCount;
+  const parts: React.ReactNode[] = [];
+  if (filledCount > 0) {
+    parts.push(
+      <Box key="r" component="span" sx={{ color: 'success.main', fontWeight: 600 }}>
+        {filledCount} received
+      </Box>,
+    );
+  }
+  if (overdue > 0) {
+    parts.push(
+      <Box key="o" component="span" sx={{ color: 'warning.main', fontWeight: 600 }}>
+        {overdue} overdue
+      </Box>,
+    );
+  }
+  if (pending - overdue > 0) {
+    parts.push(
+      <span key="p">{pending - overdue} pending</span>,
+    );
+  }
+  return (
+    <>
+      {parts.map((part, i) => (
+        <React.Fragment key={i}>
+          {i > 0 ? ' · ' : null}
+          {part}
+        </React.Fragment>
+      ))}
+      {parts.length === 0 ? '—' : null}
+    </>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Slot card
+// ────────────────────────────────────────────────────────────────────────────
+type SlotData = {
+  id: string;
+  index: number;
+  name: string | null;
+  dueDate: Date | null;
+  approverId: string | null;
+  approver: { id: string; name: string | null; email: string; image: string | null } | null;
+};
+
+type Member = {
+  user: { id: string; name: string | null; email: string; image: string | null };
+};
+
+function SlotCard({
+  slot,
+  kind,
+  doc,
+  members,
+  onRename,
+  onSetDueDate,
+  onSetApprover,
+  onUpload,
+}: {
+  slot: SlotData;
+  kind: SlotKind;
+  doc: DocumentItem | null;
+  members: Member[];
+  onRename: (name: string | null) => void;
+  onSetDueDate: (dueDate: string | null) => void;
+  onSetApprover: (approverId: string | null) => void;
+  onUpload: () => void;
+}) {
+  const meta = KIND_META[kind];
+  const isReceived = !!doc;
+  const isOverdue = !isReceived && slot.dueDate && isBefore(new Date(slot.dueDate), startOfDay(new Date()));
+
+  // Local input state so typing doesn't fire a mutation per keystroke.
+  const [draftName, setDraftName] = useState(slot.name ?? '');
+  useEffect(() => setDraftName(slot.name ?? ''), [slot.name]);
+
+  const commitName = () => {
+    const trimmed = draftName.trim();
+    const next = trimmed.length === 0 ? null : trimmed;
+    if (next === slot.name) return;
+    onRename(next);
+  };
+
+  // Approver menu
+  const [approverAnchor, setApproverAnchor] = useState<HTMLElement | null>(null);
+  const closeApprover = () => setApproverAnchor(null);
+  const handleApproverPick = (id: string | null) => {
+    onSetApprover(id);
+    closeApprover();
+  };
+
+  // Native date input — local state so calendar picker doesn't fire mid-edit.
+  const [draftDue, setDraftDue] = useState(slot.dueDate ? toInputDate(slot.dueDate) : '');
+  useEffect(() => setDraftDue(slot.dueDate ? toInputDate(slot.dueDate) : ''), [slot.dueDate]);
+  const commitDue = () => {
+    const next = draftDue || null;
+    const current = slot.dueDate ? toInputDate(slot.dueDate) : null;
+    if (next === current) return;
+    onSetDueDate(next);
+  };
+
+  const cardBg = isReceived
+    ? 'success.main'
+    : isOverdue
+      ? 'warning.main'
+      : null;
+
+  return (
+    <Box
+      sx={{
+        border: '1px solid',
+        borderColor: isOverdue ? 'warning.main' : 'divider',
+        borderRadius: '10px',
+        px: 1.75,
+        py: 1.5,
+        bgcolor: 'background.paper',
+        position: 'relative',
+        // Subtle tint for received/overdue states without losing the white surface
+        backgroundImage: cardBg
+          ? `linear-gradient(0deg, var(--mui-palette-background-paper, #fff), var(--mui-palette-background-paper, #fff))`
+          : 'none',
+        '&::before': cardBg ? {
+          content: '""',
+          position: 'absolute',
+          inset: 0,
+          borderRadius: '10px',
+          bgcolor: cardBg,
+          opacity: 0.05,
+          pointerEvents: 'none',
+        } : undefined,
+        transition: 'border-color 0.15s',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, mb: 1.25, position: 'relative' }}>
+        <SlotNumberBadge index={slot.index} kind={kind} isReceived={isReceived} />
+        <SlotNameInput
+          value={draftName}
+          onChange={setDraftName}
+          onCommit={commitName}
+          placeholder={`Name this ${meta.label}…`}
+          color={meta.color}
+        />
+        <SlotStatusPill received={isReceived} overdue={!!isOverdue} />
+      </Box>
+
+      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1, position: 'relative' }}>
+        <FieldSlot label="Due date">
+          <Box
+            component="input"
+            type="date"
+            value={draftDue}
+            onChange={(e) => setDraftDue(e.target.value)}
+            onBlur={commitDue}
+            sx={{
+              fontFamily: 'inherit',
+              fontSize: 12,
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: '6px',
+              bgcolor: 'background.default',
+              color: isOverdue ? 'warning.main' : 'text.primary',
+              px: 1,
+              py: 0.75,
+              outline: 'none',
+              width: '100%',
+              transition: 'border-color 0.15s',
+              '&:hover': { borderColor: 'text.disabled' },
+              '&:focus': { borderColor: meta.color },
+            }}
+          />
+        </FieldSlot>
+        <FieldSlot label="Approver">
+          <Box
+            component="button"
+            onClick={(e) => setApproverAnchor(e.currentTarget)}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.75,
+              fontFamily: 'inherit',
+              fontSize: 12,
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: '6px',
+              bgcolor: 'background.default',
+              color: slot.approver ? 'text.primary' : 'text.disabled',
+              px: 1,
+              py: 0.75,
+              cursor: 'pointer',
+              width: '100%',
+              minWidth: 0,
+              textAlign: 'left',
+              '&:hover': { borderColor: 'text.disabled' },
+            }}
+          >
+            {slot.approver ? (
+              <>
+                <Avatar
+                  src={slot.approver.image ?? undefined}
+                  sx={{ width: 18, height: 18, fontSize: 9, fontWeight: 600 }}
+                >
+                  {(slot.approver.name ?? slot.approver.email).charAt(0).toUpperCase()}
+                </Avatar>
+                <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+                  {slot.approver.name ?? slot.approver.email}
+                </Box>
+              </>
+            ) : (
+              <>
+                <UserCircle size={14} />
+                <span>Assign…</span>
+              </>
+            )}
+          </Box>
+        </FieldSlot>
+      </Box>
+
+      {/* Footer: file info or upload CTA */}
+      <Box
+        sx={{
+          mt: 1.25,
+          pt: 1.25,
+          borderTop: '1px dashed',
+          borderColor: 'divider',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          fontSize: 11,
+          position: 'relative',
+        }}
+      >
+        {isReceived ? (
+          <>
+            <CheckCircle size={13} weight="fill" color="var(--mui-palette-success-main, #16a34a)" />
+            <Box sx={{
+              flex: 1,
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              fontWeight: 500,
+            }}>
+              {doc.name}
+            </Box>
+            <Box sx={{ color: 'text.secondary', flexShrink: 0 }}>
+              {doc.createdAt ? format(new Date(doc.createdAt), 'MMM d') : ''}
+            </Box>
+          </>
+        ) : (
+          <Box
+            component="button"
+            onClick={onUpload}
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 0.75,
+              border: 'none',
+              background: 'transparent',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              fontSize: 11,
+              fontWeight: 500,
+              color: meta.color,
+              p: 0,
+              '&:hover': { textDecoration: 'underline' },
+            }}
+          >
+            <CloudArrowUp size={13} />
+            {meta.uploadCta}
+          </Box>
+        )}
+      </Box>
+
+      {/* Approver picker menu */}
+      <Menu
+        anchorEl={approverAnchor}
+        open={!!approverAnchor}
+        onClose={closeApprover}
+        slotProps={{
+          paper: {
+            sx: { minWidth: 220, maxHeight: 320, mt: 0.5, borderRadius: '10px' },
+          },
+        }}
+      >
+        {slot.approverId && (
+          <MenuItem onClick={() => handleApproverPick(null)} sx={{ fontSize: 12, color: 'error.main' }}>
+            <Trash size={14} style={{ marginRight: 8 }} />
+            Clear approver
+          </MenuItem>
+        )}
+        {members.length === 0 ? (
+          <MenuItem disabled sx={{ fontSize: 12 }}>No members in this org</MenuItem>
+        ) : (
+          members.map((m) => (
+            <MenuItem
+              key={m.user.id}
+              onClick={() => handleApproverPick(m.user.id)}
+              selected={m.user.id === slot.approverId}
+              sx={{ fontSize: 12, gap: 1 }}
+            >
+              <Avatar
+                src={m.user.image ?? undefined}
+                sx={{ width: 22, height: 22, fontSize: 10, fontWeight: 600 }}
+              >
+                {(m.user.name ?? m.user.email).charAt(0).toUpperCase()}
+              </Avatar>
+              <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+                <Box sx={{ fontWeight: 500, lineHeight: 1.2 }}>{m.user.name ?? m.user.email}</Box>
+                {m.user.name && (
+                  <Box sx={{ fontSize: 10, color: 'text.secondary', lineHeight: 1.2 }}>{m.user.email}</Box>
+                )}
+              </Box>
+            </MenuItem>
+          ))
+        )}
+      </Menu>
+    </Box>
+  );
+}
+
+function SlotNumberBadge({
+  index,
+  kind,
+  isReceived,
+}: {
+  index: number;
+  kind: SlotKind;
+  isReceived: boolean;
+}) {
+  const meta = KIND_META[kind];
+  const bg = isReceived ? 'var(--mui-palette-success-main, #16a34a)' : `${meta.color}1F`;
+  const color = isReceived ? '#fff' : meta.color;
+  return (
+    <Box
+      sx={{
+        width: 22,
+        height: 22,
+        borderRadius: '50%',
+        bgcolor: bg,
+        color,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 10,
+        fontWeight: 700,
+        flexShrink: 0,
+      }}
+    >
+      {isReceived ? <CheckCircle size={12} weight="fill" /> : index + 1}
+    </Box>
+  );
+}
+
+function SlotNameInput({
+  value,
+  onChange,
+  onCommit,
+  placeholder,
+  color,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onCommit: () => void;
+  placeholder: string;
+  color: string;
+}) {
+  return (
+    <Box
+      component="input"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onBlur={onCommit}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+      }}
+      placeholder={placeholder}
+      sx={{
+        flex: 1,
+        minWidth: 0,
+        fontFamily: 'inherit',
+        fontSize: 13,
+        fontWeight: 500,
+        background: 'transparent',
+        border: 'none',
+        borderBottom: '1px dashed transparent',
+        outline: 'none',
+        color: 'text.primary',
+        py: 0.5,
+        '&::placeholder': { color: 'text.disabled', fontStyle: 'italic' },
+        '&:hover': { borderBottomColor: 'divider' },
+        '&:focus': { borderBottomColor: color },
+      }}
+    />
+  );
+}
+
+function FieldSlot({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, minWidth: 0 }}>
+      <Typography
+        sx={{
+          fontSize: 9,
+          fontWeight: 600,
+          color: 'text.disabled',
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+        }}
+      >
+        {label}
+      </Typography>
+      {children}
+    </Box>
+  );
+}
+
+function SlotStatusPill({ received, overdue }: { received: boolean; overdue: boolean }) {
+  const config = received
+    ? { label: 'Received', bg: 'rgba(22,163,74,0.14)', color: 'success.main' }
+    : overdue
+      ? { label: 'Overdue', bg: 'rgba(217,119,6,0.14)', color: 'warning.main' }
+      : { label: 'Pending', bg: 'action.selected', color: 'text.secondary' };
+  return (
+    <Box
+      sx={{
+        fontSize: 10,
+        fontWeight: 600,
+        px: 0.875,
+        py: '2px',
+        borderRadius: '999px',
+        bgcolor: config.bg,
+        color: config.color,
+        letterSpacing: '0.02em',
+        flexShrink: 0,
+      }}
+    >
+      {config.label}
+    </Box>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Empty state with quick-seed buttons
+// ────────────────────────────────────────────────────────────────────────────
+function EmptyState({
+  kind,
+  onSeed,
+}: {
+  kind: SlotKind;
+  onSeed: (count: number) => void;
+}) {
+  const meta = KIND_META[kind];
+  const Icon = meta.icon;
+  const presets = [1, 3, 5];
+  return (
+    <Box
+      sx={{
+        border: '1.5px dashed',
+        borderColor: 'divider',
+        borderRadius: '12px',
+        px: 2.5,
+        py: 4,
+        textAlign: 'center',
+        bgcolor: 'background.default',
+      }}
+    >
+      <Box
+        sx={{
+          width: 40,
+          height: 40,
+          borderRadius: '12px',
+          bgcolor: 'background.paper',
+          border: '1px solid',
+          borderColor: 'divider',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          mb: 1.25,
+          color: 'text.disabled',
+        }}
+      >
+        <Icon size={20} />
+      </Box>
+      <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 0.5 }}>
+        No {meta.pluralLabel} required
+      </Typography>
+      <Typography sx={{ fontSize: 11, color: 'text.secondary', mb: 1.5, lineHeight: 1.5 }}>
+        Use the stepper above, or pick a starting count below.
+      </Typography>
+      <Box sx={{ display: 'inline-flex', gap: 0.75 }}>
+        {presets.map((n) => (
+          <Box
+            key={n}
+            component="button"
+            onClick={() => onSeed(n)}
+            sx={{
+              px: 1.25,
+              py: 0.625,
+              borderRadius: '7px',
+              border: '1px solid',
+              borderColor: 'divider',
+              bgcolor: 'background.paper',
+              color: 'text.primary',
+              fontFamily: 'inherit',
+              fontSize: 11,
+              fontWeight: 600,
+              cursor: 'pointer',
+              transition: 'all 0.15s',
+              '&:hover': { borderColor: meta.color, color: meta.color },
+            }}
+          >
+            {n} {n === 1 ? meta.label : meta.pluralLabel}
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Confirm dialog for destructive shrink
+// ────────────────────────────────────────────────────────────────────────────
+function ConfirmRemoveDialog({
+  trailingFilled,
+  kind,
+  onCancel,
+  onConfirm,
+}: {
+  trailingFilled: number;
+  kind: SlotKind;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const meta = KIND_META[kind];
+  return (
+    <Box
+      sx={{
+        position: 'fixed',
+        inset: 0,
+        bgcolor: 'rgba(0,0,0,0.32)',
+        backdropFilter: 'blur(2px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1400,
+      }}
+      onClick={onCancel}
+    >
+      <Box
+        onClick={(e) => e.stopPropagation()}
+        sx={{
+          width: 360,
+          bgcolor: 'background.paper',
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: '12px',
+          boxShadow: '0 24px 60px rgba(0,0,0,0.18)',
+          p: 2.25,
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.25, mb: 1.5 }}>
+          <Box
+            sx={{
+              width: 32,
+              height: 32,
+              borderRadius: '10px',
+              bgcolor: 'rgba(217,119,6,0.18)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >
+            <WarningCircle size={18} color="var(--mui-palette-warning-main, #d97706)" weight="fill" />
+          </Box>
+          <Box>
+            <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 0.5 }}>Remove filled slot?</Typography>
+            <Typography sx={{ fontSize: 12, color: 'text.secondary', lineHeight: 1.5 }}>
+              {trailingFilled === 1 ? '1 slot has' : `${trailingFilled} slots have`} an uploaded {meta.label}.
+              Removing will detach the file{trailingFilled === 1 ? '' : 's'} from the slot but keep
+              {trailingFilled === 1 ? ' it' : ' them'} in the project's library.
+            </Typography>
+          </Box>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+          <Box
+            component="button"
+            onClick={onCancel}
+            sx={{
+              px: 1.5, py: 0.875,
+              borderRadius: '8px',
+              border: '1px solid',
+              borderColor: 'divider',
+              bgcolor: 'background.paper',
+              fontFamily: 'inherit',
+              fontSize: 12, fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </Box>
+          <Box
+            component="button"
+            onClick={onConfirm}
+            sx={{
+              px: 1.5, py: 0.875,
+              borderRadius: '8px',
+              border: '1px solid',
+              borderColor: 'warning.main',
+              bgcolor: 'warning.main',
+              color: '#fff',
+              fontFamily: 'inherit',
+              fontSize: 12, fontWeight: 600,
+              cursor: 'pointer',
+              '&:hover': { filter: 'brightness(0.95)' },
+            }}
+          >
+            Remove
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+function toInputDate(d: Date | string): string {
+  const date = typeof d === 'string' ? new Date(d) : d;
+  return format(date, 'yyyy-MM-dd');
+}

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -19,6 +19,9 @@ import CoverImageBanner from './task-popover/CoverImageBanner';
 import FolderRow from './task-popover/FolderRow';
 import FilePreviewPanel from './task-popover/FilePreviewPanel';
 import CsiCodePanel from './task-popover/CsiCodePanel';
+import SubmittalDrawer from './SubmittalDrawer';
+import { canApproveDocuments } from '@/lib/permissions';
+import type { SlotKind } from '@/lib/validations/gantt';
 
 type RightPanel = { type: 'preview'; doc: PreviewDoc } | { type: 'csi' } | null;
 
@@ -40,10 +43,12 @@ export function TaskDetailsPopover({
   const { projectId, organizationId } = useProjectContext();
   const { memberRole } = useOrgContext();
   const canManageRequirements = memberRole === 'owner' || memberRole === 'admin';
+  const canManageSlots = canApproveDocuments(memberRole);
 
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
   const [uploadFolder, setUploadFolder] = useState<{ id: string; name: string } | null>(null);
   const [rightPanel, setRightPanel] = useState<RightPanel>(null);
+  const [drawerKind, setDrawerKind] = useState<SlotKind | null>(null);
 
   // ── Drag state ──
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
@@ -148,15 +153,28 @@ export function TaskDetailsPopover({
     onClose();
   };
 
-  // Compute current upload counts for trackable folders (submittals & inspections)
+  // Compute current upload + approval counts for trackable folders.
   const getTrackableCount = (folder: Folder) => {
     const allIds = expandFolderIds(folder.id);
-    return allIds.reduce((sum, id) => sum + (counts?.[id] ?? 0), 0);
+    let total = 0;
+    let approved = 0;
+    for (const id of allIds) {
+      const c = counts?.[id];
+      total += c?.total ?? 0;
+      approved += c?.approved ?? 0;
+    }
+    return { total, approved, pending: total - approved };
   };
   const submittalsFolder = folderData.find((f) => f.id === 'submittals');
   const inspectionsFolder = folderData.find((f) => f.id === 'inspections');
-  const submittalsCurrent = submittalsFolder ? getTrackableCount(submittalsFolder) : 0;
-  const inspectionsCurrent = inspectionsFolder ? getTrackableCount(inspectionsFolder) : 0;
+  const submittalsCounts = submittalsFolder
+    ? getTrackableCount(submittalsFolder)
+    : { total: 0, approved: 0, pending: 0 };
+  const inspectionsCounts = inspectionsFolder
+    ? getTrackableCount(inspectionsFolder)
+    : { total: 0, approved: 0, pending: 0 };
+  const submittalsCurrent = submittalsCounts.total;
+  const inspectionsCurrent = inspectionsCounts.total;
 
   const coverDocumentId = taskDetail?.coverDocumentId ?? null;
   const photos = ((allDocs ?? []) as DocumentItem[]).filter(
@@ -172,7 +190,13 @@ export function TaskDetailsPopover({
         open={open}
         anchorReference="anchorPosition"
         anchorPosition={popoverPlacement?.anchorPosition}
-        onClose={handleClose}
+        // While the drawer is open, ignore backdrop clicks and Esc on the
+        // popover so interacting with the drawer doesn't dismiss the popover
+        // underneath. The drawer has its own close button + backdrop.
+        onClose={(_event, reason) => {
+          if (drawerKind && (reason === 'backdropClick' || reason === 'escapeKeyDown')) return;
+          handleClose();
+        }}
         transformOrigin={
           popoverPlacement?.transformOrigin ?? { vertical: 'center', horizontal: 'left' }
         }
@@ -317,17 +341,28 @@ export function TaskDetailsPopover({
 
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
                 {folderData.map((folder) => {
-                  const count = counts?.[folder.id] ?? 0;
+                  const count = counts?.[folder.id]?.total ?? 0;
                   const folderDocs = ((allDocs ?? []) as DocumentItem[]).filter(
                     (d) => d.folderId === folder.id
                   );
 
                   // For trackable folders, sum counts across parent + child IDs
                   let trackingCurrent: number | undefined;
+                  let trackingApproved: number | undefined;
+                  let trackingPending: number | undefined;
                   let trackingRequired: number | null | undefined;
                   if (folder.trackable && folder.requirementField) {
                     const allIds = expandFolderIds(folder.id);
-                    trackingCurrent = allIds.reduce((sum, id) => sum + (counts?.[id] ?? 0), 0);
+                    let total = 0;
+                    let approved = 0;
+                    for (const id of allIds) {
+                      const c = counts?.[id];
+                      total += c?.total ?? 0;
+                      approved += c?.approved ?? 0;
+                    }
+                    trackingCurrent = total;
+                    trackingApproved = approved;
+                    trackingPending = total - approved;
                     trackingRequired = taskDetail?.[folder.requirementField] ?? null;
                   }
 
@@ -345,6 +380,8 @@ export function TaskDetailsPopover({
                       // Tracking props
                       required={trackingRequired}
                       current={trackingCurrent}
+                      approved={trackingApproved}
+                      pending={trackingPending}
                       canManage={canManageRequirements}
                       onSaveRequirement={
                         folder.requirementField
@@ -356,6 +393,11 @@ export function TaskDetailsPopover({
                       taskId={taskId}
                       organizationId={organizationId}
                       pinnedDocId={coverDocumentId}
+                      onManage={
+                        folder.trackable && canManageSlots
+                          ? () => setDrawerKind(folder.id === 'submittals' ? 'submittal' : 'inspection')
+                          : undefined
+                      }
                     />
                   );
                 })}
@@ -395,6 +437,31 @@ export function TaskDetailsPopover({
           folderId={uploadFolder.id}
           folderName={uploadFolder.name}
           onUploadComplete={handleUploadComplete}
+        />
+      )}
+
+      {/* Submittal/inspection management drawer */}
+      {drawerKind && taskId && (
+        <SubmittalDrawer
+          open
+          onClose={() => setDrawerKind(null)}
+          organizationId={organizationId}
+          projectId={projectId}
+          taskId={taskId}
+          taskName={taskName}
+          initialKind={drawerKind}
+          docsByKind={{
+            submittal: ((allDocs ?? []) as DocumentItem[]).filter((d) =>
+              expandFolderIds('submittals').includes(d.folderId),
+            ),
+            inspection: ((allDocs ?? []) as DocumentItem[]).filter((d) =>
+              expandFolderIds('inspections').includes(d.folderId),
+            ),
+          }}
+          onUploadToFolder={(folderId) => {
+            const folder = folderData.find((f) => f.id === folderId);
+            if (folder) setUploadFolder({ id: folder.id, name: folder.name });
+          }}
         />
       )}
     </>

--- a/src/components/bryntum/components/task-popover/FolderRow.tsx
+++ b/src/components/bryntum/components/task-popover/FolderRow.tsx
@@ -13,6 +13,9 @@ import {
   CaretDown,
   CaretRight,
   Plus,
+  Sliders,
+  CheckCircle,
+  Clock,
   type Icon as PhosphorIcon,
 } from '@phosphor-icons/react';
 import type { Folder } from '@/lib/folders';
@@ -46,6 +49,8 @@ interface FolderRowProps {
   // Tracking props (only used for trackable folders)
   required?: number | null;
   current?: number;
+  approved?: number;
+  pending?: number;
   canManage?: boolean;
   onSaveRequirement?: (count: number | null) => void;
   isRequirementPending?: boolean;
@@ -54,6 +59,8 @@ interface FolderRowProps {
   taskId?: string;
   organizationId?: string;
   pinnedDocId?: string | null;
+  // Drawer launch (only for trackable folders)
+  onManage?: () => void;
 }
 
 function FolderRowInner({
@@ -67,6 +74,8 @@ function FolderRowInner({
   selectedDocId,
   required,
   current,
+  approved,
+  pending,
   canManage,
   onSaveRequirement,
   isRequirementPending,
@@ -74,6 +83,7 @@ function FolderRowInner({
   taskId,
   organizationId,
   pinnedDocId,
+  onManage,
 }: FolderRowProps) {
   const FolderIcon = folderIconMap[folder.id] ?? (isExpanded ? FolderOpen : FolderSimple);
   const isTrackable = folder.trackable && !!onSaveRequirement;
@@ -95,11 +105,13 @@ function FolderRowInner({
 
     // Trackable folders (submittals, inspections) get numbered slot dropzones
     if (isTrackable) {
+      const kind = folder.id === 'submittals' ? 'submittal' : folder.id === 'inspections' ? 'inspection' : undefined;
       return (
         <TrackableFolderContent
           {...contentProps}
           required={required ?? null}
           folderColor={folder.color}
+          kind={kind}
         />
       );
     }
@@ -149,7 +161,16 @@ function FolderRowInner({
         </Typography>
 
         {/* Tracking indicator — inline in the header row */}
-        {isTrackable ? (
+        {isTrackable && onManage ? (
+          <ManageChipRow
+            current={current ?? 0}
+            approved={approved ?? 0}
+            pending={pending ?? 0}
+            required={required ?? null}
+            folderColor={folder.color}
+            onManage={onManage}
+          />
+        ) : isTrackable ? (
           <RequirementCounter
             current={current ?? 0}
             required={required ?? null}
@@ -221,3 +242,191 @@ function FolderRowInner({
 
 const FolderRow = React.memo(FolderRowInner);
 export default FolderRow;
+
+/**
+ * Inline progress + state-driven chip for trackable folder headers (admins).
+ *
+ * Four states derived from (required, approved, pending):
+ *   - Not set up        → required is null/0          → "Set up" chip
+ *   - In progress       → uploads exist, not complete → "Manage" chip
+ *   - Pending review    → some uploads awaiting       → "N in review" indigo pill
+ *   - Complete          → approved >= required         → no chip; ✓ next to count
+ */
+function ManageChipRow({
+  current,
+  approved,
+  pending,
+  required,
+  folderColor,
+  onManage,
+}: {
+  current: number;
+  approved: number;
+  pending: number;
+  required: number | null;
+  folderColor: string;
+  onManage: () => void;
+}) {
+  const total = required ?? 0;
+  const isComplete = total > 0 && approved >= total;
+  const hasPending = pending > 0;
+
+  // State 1 — Not set up: just the chip.
+  if (total === 0) {
+    return (
+      <Box
+        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+        sx={{ display: 'flex', alignItems: 'center', flex: 1, minWidth: 0, ml: 0.5 }}
+      >
+        <Box sx={{ flex: 1 }} />
+        <ChipButton color={folderColor} onClick={onManage} ariaLabel="Set up">
+          <Sliders size={10} weight="bold" />
+          Set up
+        </ChipButton>
+      </Box>
+    );
+  }
+
+  // Segment fill rule (left-to-right):
+  //   approved → solid green, pending → striped folder color, empty → muted
+  const segmentFill = (i: number) => {
+    if (i < approved) return { color: 'var(--status-green)', striped: false };
+    if (i < approved + pending) return { color: folderColor, striped: true };
+    return { color: 'rgba(43,45,66,0.08)', striped: false };
+  };
+
+  return (
+    <Box
+      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+      sx={{ display: 'flex', alignItems: 'center', gap: '5px', flex: 1, minWidth: 0, ml: 0.5 }}
+    >
+      <Box sx={{ display: 'flex', gap: '2px', flex: 1, alignItems: 'center', minWidth: 0 }}>
+        {Array.from({ length: Math.min(total, 10) }).map((_, i) => {
+          const fill = segmentFill(i);
+          return (
+            <Box
+              key={i}
+              sx={{
+                height: 3.5,
+                flex: 1,
+                maxWidth: 16,
+                borderRadius: '1.5px',
+                bgcolor: fill.striped ? 'transparent' : fill.color,
+                background: fill.striped
+                  ? `repeating-linear-gradient(135deg, ${fill.color} 0, ${fill.color} 2.5px, ${fill.color}55 2.5px, ${fill.color}55 5px)`
+                  : undefined,
+                transition: 'background-color 0.3s ease, background 0.3s ease',
+              }}
+            />
+          );
+        })}
+        {total > 10 && (
+          <Typography sx={{ fontSize: '0.5rem', color: 'text.disabled', lineHeight: 1, flexShrink: 0 }}>
+            +{total - 10}
+          </Typography>
+        )}
+      </Box>
+
+      {/* Count + completion check (clickable in complete state) */}
+      {isComplete ? (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '3px', flexShrink: 0 }}>
+          <Typography
+            component="button"
+            onClick={onManage}
+            sx={{
+              fontSize: '0.5625rem',
+              fontWeight: 600,
+              color: 'success.main',
+              lineHeight: 1,
+              fontVariantNumeric: 'tabular-nums',
+              letterSpacing: '-0.01em',
+              border: 'none',
+              background: 'transparent',
+              fontFamily: 'inherit',
+              cursor: 'pointer',
+              p: 0,
+              transition: 'color 0.15s',
+              '&:hover': { color: 'success.dark' },
+            }}
+            aria-label="Manage requirements"
+          >
+            {approved}/{total}
+          </Typography>
+          <CheckCircle size={11} weight="fill" color="var(--status-green)" />
+        </Box>
+      ) : (
+        <Typography
+          sx={{
+            fontSize: '0.5625rem',
+            fontWeight: 600,
+            color: 'text.secondary',
+            lineHeight: 1,
+            fontVariantNumeric: 'tabular-nums',
+            letterSpacing: '-0.01em',
+            flexShrink: 0,
+          }}
+        >
+          {current}/{total}
+        </Typography>
+      )}
+
+      {/* Trailing chip — varies by state */}
+      {isComplete ? null : hasPending ? (
+        <ChipButton
+          color="#4f46e5"
+          onClick={onManage}
+          ariaLabel={`${pending} awaiting approval`}
+        >
+          <Clock size={10} weight="bold" />
+          {pending} in review
+        </ChipButton>
+      ) : (
+        <ChipButton color={folderColor} onClick={onManage} ariaLabel="Manage requirements">
+          <Sliders size={10} weight="bold" />
+          Manage
+        </ChipButton>
+      )}
+    </Box>
+  );
+}
+
+function ChipButton({
+  color,
+  onClick,
+  ariaLabel,
+  children,
+}: {
+  color: string;
+  onClick: () => void;
+  ariaLabel: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box
+      component="button"
+      onClick={onClick}
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '3px',
+        py: '2px',
+        px: '6px',
+        borderRadius: '5px',
+        border: '1px solid transparent',
+        bgcolor: `${color}14`,
+        color,
+        cursor: 'pointer',
+        fontFamily: 'inherit',
+        fontSize: '0.5625rem',
+        fontWeight: 600,
+        letterSpacing: '0.02em',
+        flexShrink: 0,
+        transition: 'background-color 0.15s, border-color 0.15s',
+        '&:hover': { bgcolor: `${color}25`, borderColor: color },
+      }}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
@@ -4,10 +4,13 @@ import React from 'react';
 import { Box, Typography } from '@mui/material';
 import { CloudArrowUp, FileText, CheckCircle } from '@phosphor-icons/react';
 import type { FolderContentProps, PreviewDoc } from './types';
+import { api } from '@/trpc/react';
+import type { SlotKind } from '@/lib/validations/gantt';
 
 interface TrackableFolderContentProps extends FolderContentProps {
   required: number | null;
   folderColor: string;
+  kind?: SlotKind;
 }
 
 function TrackableFolderContentInner({
@@ -18,7 +21,17 @@ function TrackableFolderContentInner({
   folderName,
   required,
   folderColor,
+  kind,
+  taskId,
+  projectId,
+  organizationId,
 }: TrackableFolderContentProps) {
+  // Slot metadata (names) — shares the React Query cache with SubmittalDrawer.
+  const slotsQuery = api.gantt.listSlots.useQuery(
+    { organizationId: organizationId!, projectId: projectId!, taskId: taskId!, kind: kind! },
+    { enabled: !!kind && !!taskId && !!projectId && !!organizationId && (required ?? 0) > 0 },
+  );
+  const slotMeta = slotsQuery.data ?? [];
   // No requirement set — empty state (no dropzones until a requirement is configured)
   if (required === null || required === 0) {
     return (
@@ -172,8 +185,18 @@ function TrackableFolderContentInner({
             </Box>
 
             <CloudArrowUp size={14} color="var(--text-secondary)" style={{ flexShrink: 0 }} />
-            <Typography sx={{ fontSize: 11, color: 'text.secondary', lineHeight: 1 }}>
-              {singularName} {slotNum}
+            <Typography
+              sx={{
+                fontSize: 11,
+                color: 'text.secondary',
+                lineHeight: 1,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                minWidth: 0,
+              }}
+            >
+              {slotMeta[index]?.name?.trim() || `${singularName} ${slotNum}`}
             </Typography>
           </Box>
         );

--- a/src/components/projects/ProjectsTree.tsx
+++ b/src/components/projects/ProjectsTree.tsx
@@ -105,7 +105,7 @@ function FolderNode({ folder, taskId, projectId, organizationId, expandedItems }
     [allDocs, folder.id]
   );
 
-  const documentCount = counts?.[folder.id] || 0;
+  const documentCount = counts?.[folder.id]?.total ?? 0;
 
   const handleUploadComplete = () => {
     if (organizationId && projectId) {
@@ -177,9 +177,9 @@ function FolderNode({ folder, taskId, projectId, organizationId, expandedItems }
     >
       {!folder.isLeaf &&
         folder.children &&
-        folder.children.filter((child) => (counts?.[child.id] ?? 0) > 0).map((child) => {
+        folder.children.filter((child) => (counts?.[child.id]?.total ?? 0) > 0).map((child) => {
           const childId = `${folderId}-${child.id}`;
-          const childDocCount = counts?.[child.id] || 0;
+          const childDocCount = counts?.[child.id]?.total ?? 0;
           const childDocs = (allDocs ?? []).filter((d) => d.folderId === child.id);
 
           return (

--- a/src/lib/constants/slotNameLibrary.ts
+++ b/src/lib/constants/slotNameLibrary.ts
@@ -1,0 +1,50 @@
+// Smart-default names suggested when an admin adds a new submittal/inspection
+// slot. Used only as a starting value — admins rename freely. Order is the
+// natural fill order from the most common to the more specialized.
+
+import type { SlotKind } from "@/lib/validations/gantt";
+
+export const SLOT_NAME_LIBRARY: Record<SlotKind, readonly string[]> = {
+  submittal: [
+    "Shop Drawing",
+    "Product Data",
+    "Material Sample",
+    "Color Sample",
+    "Material Certification",
+    "Equipment Cut Sheet",
+    "Mockup",
+    "Coordination Drawing",
+    "Test Report",
+    "Safety Data Sheet",
+    "Fabrication Drawing",
+    "Hardware Schedule",
+  ],
+  inspection: [
+    "Foundation Inspection",
+    "Framing Inspection",
+    "Rough-in Electrical",
+    "Rough-in Plumbing",
+    "Insulation Inspection",
+    "Fire-stopping Inspection",
+    "Drywall Pre-cover",
+    "Final Inspection",
+  ],
+};
+
+/**
+ * Returns the next unused suggestion from the library, or `null` when every
+ * suggestion is already taken (caller should fall back to "Slot N" or leave
+ * the field empty for the admin to fill in).
+ */
+export function nextSuggestedSlotName(
+  kind: SlotKind,
+  existingNames: ReadonlyArray<string | null>,
+): string | null {
+  const taken = new Set(
+    existingNames.filter((n): n is string => !!n).map((n) => n.toLowerCase().trim()),
+  );
+  for (const candidate of SLOT_NAME_LIBRARY[kind]) {
+    if (!taken.has(candidate.toLowerCase())) return candidate;
+  }
+  return null;
+}

--- a/src/lib/validations/gantt.ts
+++ b/src/lib/validations/gantt.ts
@@ -104,6 +104,32 @@ export const updateRequirementSchema = z.object({
 
 export type UpdateRequirementInput = z.infer<typeof updateRequirementSchema>;
 
+// Per-slot tracking schemas (Tier 2/3)
+export const slotKindSchema = z.enum(['submittal', 'inspection']);
+export type SlotKind = z.infer<typeof slotKindSchema>;
+
+export const listSlotsSchema = z.object({
+  taskId: z.string(),
+  kind: slotKindSchema,
+});
+
+export const setSlotCountSchema = z.object({
+  taskId: z.string(),
+  kind: slotKindSchema,
+  count: z.number().int().min(0).max(50),
+});
+
+export const updateSlotSchema = z.object({
+  slotId: z.string(),
+  name: z.string().trim().max(200).nullable().optional(),
+  dueDate: z.string().or(z.date()).nullable().optional(),
+  approverId: z.string().nullable().optional(),
+});
+
+export type ListSlotsInput = z.infer<typeof listSlotsSchema>;
+export type SetSlotCountInput = z.infer<typeof setSlotCountSchema>;
+export type UpdateSlotInput = z.infer<typeof updateSlotSchema>;
+
 // Type exports
 export type GanttLoadInput = z.infer<typeof ganttLoadInputSchema>;
 export type GanttSyncInput = z.infer<typeof ganttSyncInputSchema>;

--- a/src/server/api/routers/approval.ts
+++ b/src/server/api/routers/approval.ts
@@ -4,6 +4,8 @@ import { createTRPCRouter, orgProcedure } from "@/server/api/trpc";
 import { canApproveDocuments } from "@/lib/permissions";
 import { APPROVABLE_FOLDER_ID_LIST, expandFolderIds } from "@/lib/folders";
 import { documentProxyUrl } from "@/lib/blobProxy";
+import type { SlotKind } from "@/lib/validations/gantt";
+import type { PrismaClient } from "../../../../generated/prisma";
 
 const approvalStatusSchema = z.enum(["unapproved", "approved", "all"]).default("all");
 const categorySchema = z.enum(["all", "submittals", "inspections"]).default("all");
@@ -64,7 +66,8 @@ export const approvalRouter = createTRPCRouter({
 
   /**
    * Counts of pending and approved submittals/inspections for the
-   * Review Queue header / sidebar badge.
+   * Review Queue header / sidebar badge. Also includes overdue slot count
+   * (slots with a passed dueDate that don't have an upload yet).
    */
   summary: orgProcedure
     .input(z.object({ projectId: z.string() }))
@@ -73,16 +76,19 @@ export const approvalRouter = createTRPCRouter({
         where: { id: input.projectId, organizationId: ctx.organization.id },
         select: { id: true },
       });
-      if (!project) return { pending: 0, approved: 0 };
+      if (!project) return { pending: 0, approved: 0, overdue: 0 };
 
-      const grouped = await ctx.db.document.groupBy({
-        by: ["approvalStatus"],
-        where: {
-          projectId: input.projectId,
-          folderId: { in: APPROVABLE_FOLDER_ID_LIST },
-        },
-        _count: { _all: true },
-      });
+      const [grouped, overdue] = await Promise.all([
+        ctx.db.document.groupBy({
+          by: ["approvalStatus"],
+          where: {
+            projectId: input.projectId,
+            folderId: { in: APPROVABLE_FOLDER_ID_LIST },
+          },
+          _count: { _all: true },
+        }),
+        countOverdueSlots(ctx.db, input.projectId),
+      ]);
 
       let pending = 0;
       let approved = 0;
@@ -90,7 +96,79 @@ export const approvalRouter = createTRPCRouter({
         if (row.approvalStatus === "approved") approved = row._count._all;
         else if (row.approvalStatus === "unapproved") pending = row._count._all;
       }
-      return { pending, approved };
+      return { pending, approved, overdue };
+    }),
+
+  /**
+   * Slots whose dueDate has passed and don't yet have an upload mapped to them.
+   * Maps a slot to "filled" by index: if N docs exist under the kind's folder
+   * for that task, slots 0..N-1 are filled. Mirrors the per-task popover logic.
+   */
+  listOverdueSlots: orgProcedure
+    .input(z.object({ projectId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const project = await ctx.db.project.findFirst({
+        where: { id: input.projectId, organizationId: ctx.organization.id },
+        select: { id: true },
+      });
+      if (!project) return [];
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      const candidates = await ctx.db.taskRequirementSlot.findMany({
+        where: {
+          dueDate: { not: null, lt: today },
+          task: { projectId: input.projectId },
+        },
+        orderBy: { dueDate: "asc" },
+        include: {
+          task: { select: { id: true, name: true } },
+          approver: { select: { id: true, name: true, email: true, image: true } },
+        },
+      });
+
+      if (candidates.length === 0) return [];
+
+      const taskIds = Array.from(new Set(candidates.map((c) => c.task.id)));
+      const submittalIds = expandFolderIds("submittals");
+      const inspectionIds = expandFolderIds("inspections");
+
+      const grouped = await ctx.db.document.groupBy({
+        by: ["taskId", "folderId"],
+        where: {
+          projectId: input.projectId,
+          taskId: { in: taskIds },
+          folderId: { in: [...submittalIds, ...inspectionIds] },
+        },
+        _count: { _all: true },
+      });
+
+      // count[taskId][kind] = number of docs uploaded under that folder family
+      const counts = new Map<string, { submittal: number; inspection: number }>();
+      for (const row of grouped) {
+        const bucket = counts.get(row.taskId) ?? { submittal: 0, inspection: 0 };
+        if (submittalIds.includes(row.folderId)) bucket.submittal += row._count._all;
+        if (inspectionIds.includes(row.folderId)) bucket.inspection += row._count._all;
+        counts.set(row.taskId, bucket);
+      }
+
+      return candidates
+        .filter((slot) => {
+          const c = counts.get(slot.task.id) ?? { submittal: 0, inspection: 0 };
+          const filledForKind = slot.kind === "submittal" ? c.submittal : c.inspection;
+          return slot.index >= filledForKind;
+        })
+        .map((slot) => ({
+          id: slot.id,
+          taskId: slot.task.id,
+          taskName: slot.task.name,
+          kind: slot.kind as SlotKind,
+          index: slot.index,
+          name: slot.name,
+          dueDate: slot.dueDate!,
+          approver: slot.approver,
+        }));
     }),
 
   /**
@@ -182,3 +260,49 @@ export const approvalRouter = createTRPCRouter({
       };
     }),
 });
+
+/**
+ * Returns the number of slots whose dueDate has passed and which don't yet
+ * have an upload covering them. Used by `summary` for the overdue badge.
+ */
+async function countOverdueSlots(db: PrismaClient, projectId: string): Promise<number> {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const candidates = await db.taskRequirementSlot.findMany({
+    where: {
+      dueDate: { not: null, lt: today },
+      task: { projectId },
+    },
+    select: { id: true, taskId: true, kind: true, index: true },
+  });
+  if (candidates.length === 0) return 0;
+
+  const taskIds = Array.from(new Set(candidates.map((c) => c.taskId)));
+  const submittalIds = expandFolderIds("submittals");
+  const inspectionIds = expandFolderIds("inspections");
+
+  const grouped = await db.document.groupBy({
+    by: ["taskId", "folderId"],
+    where: {
+      projectId,
+      taskId: { in: taskIds },
+      folderId: { in: [...submittalIds, ...inspectionIds] },
+    },
+    _count: { _all: true },
+  });
+
+  const counts = new Map<string, { submittal: number; inspection: number }>();
+  for (const row of grouped) {
+    const bucket = counts.get(row.taskId) ?? { submittal: 0, inspection: 0 };
+    if (submittalIds.includes(row.folderId)) bucket.submittal += row._count._all;
+    if (inspectionIds.includes(row.folderId)) bucket.inspection += row._count._all;
+    counts.set(row.taskId, bucket);
+  }
+
+  return candidates.filter((slot) => {
+    const c = counts.get(slot.taskId) ?? { submittal: 0, inspection: 0 };
+    const filledForKind = slot.kind === "submittal" ? c.submittal : c.inspection;
+    return slot.index >= filledForKind;
+  }).length;
+}

--- a/src/server/api/routers/document.ts
+++ b/src/server/api/routers/document.ts
@@ -213,17 +213,22 @@ export const documentRouter = createTRPCRouter({
       }
 
       const grouped = await ctx.db.document.groupBy({
-        by: ["folderId"],
+        by: ["folderId", "approvalStatus"],
         where: {
           projectId: input.projectId,
           taskId: input.taskId,
         },
-        _count: { folderId: true },
+        _count: { _all: true },
       });
 
-      return Object.fromEntries(
-        grouped.map((g) => [g.folderId, g._count.folderId])
-      );
+      const result: Record<string, { total: number; approved: number }> = {};
+      for (const row of grouped) {
+        const bucket = result[row.folderId] ?? { total: 0, approved: 0 };
+        bucket.total += row._count._all;
+        if (row.approvalStatus === "approved") bucket.approved += row._count._all;
+        result[row.folderId] = bucket;
+      }
+      return result;
     }),
 
   search: orgProcedure

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -2,8 +2,17 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { Prisma } from "../../../../generated/prisma";
 import { createTRPCRouter, orgProcedure, projectProcedure } from "@/server/api/trpc";
-import { canManageProjects } from "@/lib/permissions";
-import { ganttLoadInputSchema, ganttSyncInputSchema, updateRequirementSchema } from "@/lib/validations/gantt";
+import { canManageProjects, canApproveDocuments } from "@/lib/permissions";
+import {
+  ganttLoadInputSchema,
+  ganttSyncInputSchema,
+  updateRequirementSchema,
+  listSlotsSchema,
+  setSlotCountSchema,
+  updateSlotSchema,
+  type SlotKind,
+} from "@/lib/validations/gantt";
+import { nextSuggestedSlotName } from "@/lib/constants/slotNameLibrary";
 import { CSI_SUBDIVISION_MAP, CSI_DIVISION_MAP } from "@/lib/constants/csiCodes";
 import { APPROVABLE_FOLDER_ID_LIST } from "@/lib/folders";
 import { buildTaskTree, mapDependencyToGantt, mapResourceToGantt, mapAssignmentToGantt, mapTimeRangeToGantt } from "@/server/api/helpers/ganttTree";
@@ -532,4 +541,192 @@ export const ganttRouter = createTRPCRouter({
 
       return { totalRequired, totalUploaded, latestEndDate: latestEndDate._max.endDate ?? null };
     }),
+
+  // ─── Per-slot tracking (Tier 2/3) ──────────────────────────────────────
+  // Slots carry the metadata that the legacy requiredSubmittals/Inspections
+  // integers don't: name, due date, approver. They are kept in sync with those
+  // count columns by setSlotCount so the popover and existing readers keep
+  // working. listSlots auto-backfills from the legacy count on first read.
+
+  listSlots: orgProcedure
+    .input(z.object({ projectId: z.string() }).merge(listSlotsSchema))
+    .query(async ({ ctx, input }) => {
+      const { projectId, taskId, kind } = input;
+
+      const task = await ctx.db.ganttTask.findFirst({
+        where: { id: taskId, projectId, project: { organizationId: ctx.organization.id } },
+        select: { id: true, requiredSubmittals: true, requiredInspections: true },
+      });
+      if (!task) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Task not found" });
+      }
+
+      const existing = await ctx.db.taskRequirementSlot.findMany({
+        where: { taskId, kind },
+        orderBy: { index: "asc" },
+        include: {
+          approver: { select: { id: true, name: true, email: true, image: true } },
+        },
+      });
+
+      const legacyCount = legacyCountForKind(task, kind);
+
+      // Lazy backfill: legacy count > 0 but no slot rows yet → create N anonymous slots.
+      if (existing.length === 0 && legacyCount > 0) {
+        await ctx.db.taskRequirementSlot.createMany({
+          data: Array.from({ length: legacyCount }, (_, i) => ({
+            taskId,
+            kind,
+            index: i,
+          })),
+          skipDuplicates: true,
+        });
+        return ctx.db.taskRequirementSlot.findMany({
+          where: { taskId, kind },
+          orderBy: { index: "asc" },
+          include: {
+            approver: { select: { id: true, name: true, email: true, image: true } },
+          },
+        });
+      }
+
+      return existing;
+    }),
+
+  setSlotCount: orgProcedure
+    .input(z.object({ projectId: z.string() }).merge(setSlotCountSchema))
+    .mutation(async ({ ctx, input }) => {
+      if (!canApproveDocuments(ctx.membership.role)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have permission to manage requirements",
+        });
+      }
+
+      const { projectId, taskId, kind, count } = input;
+
+      const task = await ctx.db.ganttTask.findFirst({
+        where: { id: taskId, projectId, project: { organizationId: ctx.organization.id } },
+        select: { id: true },
+      });
+      if (!task) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Task not found" });
+      }
+
+      const legacyField = kind === "submittal" ? "requiredSubmittals" : "requiredInspections";
+
+      return ctx.db.$transaction(async (tx) => {
+        const current = await tx.taskRequirementSlot.findMany({
+          where: { taskId, kind },
+          orderBy: { index: "asc" },
+          select: { id: true, index: true, name: true },
+        });
+
+        if (count > current.length) {
+          // Add slots at the end with smart-default names from the library,
+          // skipping any names already taken by existing slots.
+          const names: (string | null)[] = current.map((s) => s.name);
+          const newSlots: Array<{ taskId: string; kind: string; index: number; name: string | null }> = [];
+          for (let i = 0; i < count - current.length; i++) {
+            const name = nextSuggestedSlotName(kind, names);
+            names.push(name);
+            newSlots.push({
+              taskId,
+              kind,
+              index: current.length + i,
+              name,
+            });
+          }
+          await tx.taskRequirementSlot.createMany({ data: newSlots });
+        } else if (count < current.length) {
+          // Remove the last (current.length - count) slots
+          const toRemove = current.slice(count).map((s) => s.id);
+          await tx.taskRequirementSlot.deleteMany({ where: { id: { in: toRemove } } });
+        }
+
+        // Keep the legacy count column in sync so existing readers (popover header,
+        // requirementStats, TrackableFolderContent) don't need to change.
+        await tx.ganttTask.update({
+          where: { id: taskId },
+          data: { [legacyField]: count === 0 ? null : count },
+        });
+
+        return tx.taskRequirementSlot.findMany({
+          where: { taskId, kind },
+          orderBy: { index: "asc" },
+          include: {
+            approver: { select: { id: true, name: true, email: true, image: true } },
+          },
+        });
+      });
+    }),
+
+  updateSlot: orgProcedure
+    .input(z.object({ projectId: z.string() }).merge(updateSlotSchema))
+    .mutation(async ({ ctx, input }) => {
+      if (!canApproveDocuments(ctx.membership.role)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have permission to manage requirements",
+        });
+      }
+
+      const { projectId, slotId, ...patch } = input;
+
+      const slot = await ctx.db.taskRequirementSlot.findUnique({
+        where: { id: slotId },
+        select: { id: true, task: { select: { projectId: true, project: { select: { organizationId: true } } } } },
+      });
+      if (
+        !slot ||
+        slot.task.projectId !== projectId ||
+        slot.task.project.organizationId !== ctx.organization.id
+      ) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Slot not found" });
+      }
+
+      // If approverId is provided, verify the user is a member of this org.
+      if (patch.approverId) {
+        const member = await ctx.db.membership.findUnique({
+          where: {
+            userId_organizationId: {
+              userId: patch.approverId,
+              organizationId: ctx.organization.id,
+            },
+          },
+          select: { id: true },
+        });
+        if (!member) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Approver must be a member of this organization",
+          });
+        }
+      }
+
+      const data: Record<string, unknown> = {};
+      if (patch.name !== undefined) {
+        data.name = patch.name === null ? null : patch.name.trim() || null;
+      }
+      if (patch.dueDate !== undefined) {
+        data.dueDate = patch.dueDate === null ? null : new Date(patch.dueDate);
+      }
+      if (patch.approverId !== undefined) data.approverId = patch.approverId;
+
+      return ctx.db.taskRequirementSlot.update({
+        where: { id: slotId },
+        data,
+        include: {
+          approver: { select: { id: true, name: true, email: true, image: true } },
+        },
+      });
+    }),
 });
+
+function legacyCountForKind(
+  task: { requiredSubmittals: number | null; requiredInspections: number | null },
+  kind: SlotKind,
+): number {
+  if (kind === "submittal") return task.requiredSubmittals ?? 0;
+  return task.requiredInspections ?? 0;
+}


### PR DESCRIPTION
## Summary
- Adds `TaskRequirementSlot` (name, due date, approver) alongside the legacy `requiredSubmittals/Inspections` counts, kept in sync by a new `gantt.setSlotCount` mutation and lazily backfilled on first read.
- New right-side `SubmittalDrawer` lets admins/PMs manage per-slot metadata; the task popover gets a state-aware Manage chip (set up / in progress / in review / complete) driven by approval-aware `document.countByTask` (now `{ total, approved }`).
- Review Queue gains an Overdue tab + summary count fed by `approval.listOverdueSlots`, mapping slot index ↔ uploaded doc by position.
- Adds unit tests for the slot Zod schemas, the smart-default name library, and the folder-row state resolver.

## Test plan
- [ ] Open a task popover, set up submittals/inspections, edit names/due dates/approvers in the drawer, verify counts and overdue badge update
- [ ] Shrink slot count below filled count and confirm the warning dialog renders correctly
- [ ] Visit Review Queue → Overdue tab and confirm slots past their due date appear with their task name, approver, and due date
- [ ] `npm test` and `npx tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)