### PR TITLE
Redesign Add Project flow with color theming and team step

### DIFF
--- a/claudedocs/components-guide.md
+++ b/claudedocs/components-guide.md
@@ -12,7 +12,7 @@ Conventions for adding, naming, and structuring components in `src/components/`.
 | `layout/` | App shell: Header, Sidebar, MobileDrawer, OrgSwitcher, ProjectSwitcher, UserMenu, PageHeader |
 | `providers/` | React context providers: ThemeRegistry, OrgProvider, ProjectProvider, LoadingProvider |
 | `dashboard/` | Dashboard feature components (StatsCards, ProjectsList, TeamActivity) |
-| `projects/` | Project CRUD dialogs and trees (AddProjectDialog, ProjectFormBody, ProjectsTree, ProjectDetailPanel) |
+| `projects/` | Project CRUD dialogs and trees (AddProjectDialog, ProjectFormBody, ProjectsTree, ProjectDetailPanel, SidebarRowPreview) |
 | `documents/` | Document feature components (DocumentList, UploadDialog, FileDropzone) |
 | `approvals/` | Submittal/inspection approval workflow (ApprovalToggle, ReviewQueueContent, ReviewCard) |
 | `team/` | Team/invite management (MembersList, InviteDialog, RoleSelect, PendingInvitesList) |
@@ -179,6 +179,19 @@ Client code uses these like any other URL (`<img src>`, `<iframe src>`, `<a href
 **Forms that upload and preview**: private URLs don't render in `<img>`, so forms that show a just-uploaded image before submit must use a local object URL for preview (`URL.createObjectURL(file)` + `revokeObjectURL` on unmount/replace) and keep the form state field for the raw URL that gets submitted. See `ProjectFormBody.tsx` and `manage/page.tsx` for the `previewUrl ?? imageUrl` display pattern. The tRPC update mutation also defensively treats an incoming proxy URL as a no-op (the form round-trips the unchanged proxy URL when the user edits other fields).
 
 User avatars (`user.image`) are the opposite: they live in the **public** avatars store and are rendered directly via the public CDN URL — no proxy involved.
+
+---
+
+## TextField / Input Styling
+
+All `TextField` components use the global `MuiOutlinedInput` theme override defined in `src/theme/theme.ts`. **Do not add custom `sx` to override border, focus ring, or background color on TextFields** — the theme handles this for both light and dark modes automatically.
+
+The global style gives every input:
+- `divider` border color at rest (soft, consistent with the design system)
+- `text.primary` border at 32% opacity on hover
+- `primary.main` border + 1.5px width + subtle focus ring on focus
+
+The only deliberate exception is `OtpInput.tsx` — its box-style digit appearance overrides the global styles via component-level `sx`, which takes precedence over `styleOverrides`. Do not replicate this pattern elsewhere.
 
 ---
 

--- a/prisma/migrations/20260506140000_add_project_color/migration.sql
+++ b/prisma/migrations/20260506140000_add_project_color/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN "color" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,6 +125,7 @@ model Project {
     location       String          @default("")
     slug           String
     icon           String          @default("building")
+    color          String?
     imageUrl       String?
     status         String          @default("active")
     organizationId String

--- a/src/__tests__/projects/add-project-members-step.test.tsx
+++ b/src/__tests__/projects/add-project-members-step.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import AddProjectMembersStep from "@/components/projects/AddProjectMembersStep";
+
+const mocks = vi.hoisted(() => ({
+  bulkAdd: vi.fn(),
+  bulkAddPending: false,
+  invalidate: vi.fn(),
+  members: [] as Array<{
+    id: string;
+    role: string;
+    user: { id: string; name: string | null; email: string; image: string | null };
+  }>,
+  membersLoading: false,
+}));
+
+vi.mock("@/trpc/react", () => ({
+  api: {
+    member: {
+      list: {
+        useQuery: () => ({
+          data: mocks.members,
+          isLoading: mocks.membersLoading,
+        }),
+      },
+    },
+    projectMember: {
+      bulkAdd: {
+        useMutation: (opts?: {
+          onSuccess?: (data: { added: number }) => void;
+          onError?: (error: { message?: string }) => void;
+        }) => ({
+          mutate: (input: unknown) => {
+            mocks.bulkAdd(input);
+            opts?.onSuccess?.({ added: 1 });
+          },
+          isPending: mocks.bulkAddPending,
+        }),
+      },
+    },
+    useUtils: () => ({
+      projectMember: {
+        list: { invalidate: mocks.invalidate },
+      },
+    }),
+  },
+}));
+
+vi.mock("@/hooks/useSnackbar", () => ({
+  useSnackbar: () => ({ showSnackbar: vi.fn() }),
+}));
+
+const baseProps = {
+  projectId: "proj-123",
+  projectName: "Westside Tower",
+  organizationId: "org-456",
+  currentUserId: "user-self",
+  onComplete: vi.fn(),
+  onSkip: vi.fn(),
+};
+
+const otherUser = (id: string, name: string, email: string) => ({
+  id: `m-${id}`,
+  role: "member",
+  user: { id, name, email, image: null },
+});
+
+describe("AddProjectMembersStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.bulkAdd.mockReset();
+    mocks.invalidate.mockReset();
+    mocks.bulkAddPending = false;
+    mocks.membersLoading = false;
+    mocks.members = [
+      otherUser("user-self", "Me Self", "me@buildco.com"),
+      otherUser("user-jordan", "Jordan Marquez", "jordan@buildco.com"),
+      otherUser("user-samira", "Samira Patel", "samira@buildco.com"),
+    ];
+  });
+
+  it("renders org members and excludes the current user", () => {
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    expect(screen.getByText("Jordan Marquez")).toBeInTheDocument();
+    expect(screen.getByText("Samira Patel")).toBeInTheDocument();
+    expect(screen.queryByText("Me Self")).not.toBeInTheDocument();
+  });
+
+  it("shows the project name in the subtitle", () => {
+    render(<AddProjectMembersStep {...baseProps} />);
+    expect(screen.getByText("Westside Tower")).toBeInTheDocument();
+  });
+
+  it("filters the list when typing in search", async () => {
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    const search = screen.getByPlaceholderText(/search teammates/i);
+    await user.type(search, "samira");
+
+    expect(screen.getByText("Samira Patel")).toBeInTheDocument();
+    expect(screen.queryByText("Jordan Marquez")).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state when search has no matches", async () => {
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    await user.type(screen.getByPlaceholderText(/search teammates/i), "zzz");
+    expect(screen.getByText(/no teammates match/i)).toBeInTheDocument();
+  });
+
+  it("disables Add to project until at least one teammate is selected", async () => {
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    const addButton = screen.getByRole("button", { name: /add to project/i });
+    expect(addButton).toBeDisabled();
+
+    await user.click(screen.getByText("Jordan Marquez"));
+    expect(addButton).not.toBeDisabled();
+  });
+
+  it("calls bulkAdd with selected members defaulting to 'member' role", async () => {
+    const onComplete = vi.fn();
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} onComplete={onComplete} />);
+
+    await user.click(screen.getByText("Jordan Marquez"));
+    await user.click(screen.getByRole("button", { name: /add to project/i }));
+
+    expect(mocks.bulkAdd).toHaveBeenCalledWith({
+      projectId: "proj-123",
+      members: [{ userId: "user-jordan", role: "member" }],
+    });
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it("calls onSkip without firing bulkAdd when Skip is clicked", async () => {
+    const onSkip = vi.fn();
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} onSkip={onSkip} />);
+
+    await user.click(screen.getByText("Jordan Marquez"));
+    await user.click(screen.getByRole("button", { name: /^skip$/i }));
+
+    expect(onSkip).toHaveBeenCalled();
+    expect(mocks.bulkAdd).not.toHaveBeenCalled();
+  });
+
+  it("shows empty state when there are no other org members", () => {
+    mocks.members = [otherUser("user-self", "Me Self", "me@buildco.com")];
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    expect(
+      screen.getByText(/no other teammates in your organization/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/projects/project-form-body-modal.test.tsx
+++ b/src/__tests__/projects/project-form-body-modal.test.tsx
@@ -27,6 +27,11 @@ vi.mock("@/trpc/react", () => ({
         }),
       },
     },
+    weather: {
+      getByLocation: {
+        useQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
+      },
+    },
     useUtils: vi.fn(() => ({
       project: {
         list: { invalidate: vi.fn() },
@@ -76,7 +81,7 @@ describe("ProjectFormBody — modal vs standalone behavior", () => {
     });
   });
 
-  it("calls onSuccess and does NOT navigate when in modal mode", async () => {
+  it("calls onSuccess with the created project and does NOT navigate in modal mode", async () => {
     const onSuccess = vi.fn();
     render(
       <ProjectFormBody
@@ -89,11 +94,14 @@ describe("ProjectFormBody — modal vs standalone behavior", () => {
       />
     );
 
-    // Simulate the mutation success callback
-    const mockProject = { name: "My Project", slug: "my-project" };
+    const mockProject = { id: "proj-123", name: "My Project", slug: "my-project" };
     onMutationSuccess?.(mockProject);
 
-    expect(onSuccess).toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledWith({
+      id: "proj-123",
+      slug: "my-project",
+      name: "My Project",
+    });
     expect(mockPush).not.toHaveBeenCalled();
     expect(mockReplace).not.toHaveBeenCalled();
   });
@@ -108,7 +116,7 @@ describe("ProjectFormBody — modal vs standalone behavior", () => {
       />
     );
 
-    const mockProject = { name: "My Project", slug: "my-project" };
+    const mockProject = { id: "proj-123", name: "My Project", slug: "my-project" };
     onMutationSuccess?.(mockProject);
 
     expect(mockPush).toHaveBeenCalledWith("/test-org/projects/my-project/gantt");
@@ -125,7 +133,7 @@ describe("ProjectFormBody — modal vs standalone behavior", () => {
       />
     );
 
-    const mockProject = { name: "My Project", slug: "my-project" };
+    const mockProject = { id: "proj-123", name: "My Project", slug: "my-project" };
     onMutationSuccess?.(mockProject);
 
     expect(mockReplace).toHaveBeenCalledWith("/test-org/projects/my-project/gantt");
@@ -146,8 +154,8 @@ describe("ProjectFormBody — modal vs standalone behavior", () => {
 
     expect(screen.getByText("New Project")).toBeInTheDocument();
     expect(screen.getByText("Set up a new construction project")).toBeInTheDocument();
-    expect(screen.getByText("Project Name")).toBeInTheDocument();
-    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^location$/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /create project/i })).toBeInTheDocument();
   });
 

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/settings/page.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/settings/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
-  Trash, Warning, MapPin, Swatches, CaretDown,
+  Trash, Warning, Swatches, CaretDown,
   Image as ImageIcon, UploadSimple, X, FloppyDisk,
 } from '@phosphor-icons/react';
 import { motion } from 'framer-motion';
@@ -13,7 +13,7 @@ import {
   Box, Typography, Paper, Popover, TextField,
   CircularProgress, IconButton, Tooltip,
 } from '@mui/material';
-import { useTheme, alpha, type Theme } from '@mui/material/styles';
+import { useTheme, alpha } from '@mui/material/styles';
 import Script from 'next/script';
 import { useRouter, useParams } from 'next/navigation';
 import { useDropzone } from 'react-dropzone';
@@ -35,31 +35,9 @@ const GOOGLE_PLACES_API_KEY = env.NEXT_PUBLIC_GOOGLE_PLACES_API_KEY;
 // Location fields (reused from ProjectFormBody patterns)
 // ---------------------------------------------------------------------------
 
-const fieldSxFactory = (theme: Theme) => ({
-  '& .MuiOutlinedInput-root': {
-    borderRadius: '8px',
-    fontSize: '0.9375rem',
-    bgcolor: alpha(theme.palette.divider, 0.08),
-    transition: 'all 0.15s ease',
-    '& fieldset': { borderColor: 'transparent' },
-    '&:hover fieldset': { borderColor: alpha(theme.palette.primary.main, 0.3) },
-    '&.Mui-focused fieldset': { borderColor: theme.palette.primary.main, borderWidth: '1.5px' },
-    '&.Mui-focused': {
-      bgcolor: 'background.paper',
-      boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
-    },
-  },
-  '& .MuiOutlinedInput-input': {
-    py: 1.5,
-    px: 1.75,
-    '&::placeholder': { color: alpha(theme.palette.text.secondary, 0.5), opacity: 1 },
-  },
-});
-
 function LocationAutocompleteField({
   value, onChange, error, helperText,
 }: { value: string; onChange: (v: string) => void; error?: boolean; helperText?: string }) {
-  const theme = useTheme();
   const {
     ready,
     suggestions: { data },
@@ -90,8 +68,8 @@ function LocationAutocompleteField({
       onInputChange={handleInputChange} onChange={handleSelect}
       disabled={!ready} filterOptions={(x) => x}
       renderInput={(params) => (
-        <TextField {...params} placeholder="e.g. 123 Main St, New York, NY"
-          error={error} helperText={helperText} fullWidth sx={fieldSxFactory(theme)} />
+        <TextField {...params} label="Location" placeholder="e.g. 123 Main St, New York, NY"
+          error={error} helperText={helperText} fullWidth />
       )}
       slotProps={{
         paper: {
@@ -109,11 +87,10 @@ function LocationAutocompleteField({
 function PlainLocationField({
   value, onChange, error, helperText,
 }: { value: string; onChange: (v: string) => void; error?: boolean; helperText?: string }) {
-  const theme = useTheme();
   return (
     <TextField value={value} onChange={(e) => onChange(e.target.value)}
-      placeholder="e.g. 123 Main St, New York, NY" error={error} helperText={helperText}
-      fullWidth autoComplete="off" sx={fieldSxFactory(theme)} />
+      label="Location" placeholder="e.g. 123 Main St, New York, NY" error={error} helperText={helperText}
+      fullWidth autoComplete="off" />
   );
 }
 
@@ -279,7 +256,6 @@ function ProjectSettingsForm({
 
   const useGooglePlaces = !!GOOGLE_PLACES_API_KEY && scriptLoaded;
   const hasChanges = isDirty || imageChanged;
-  const fieldSx = fieldSxFactory(theme);
 
   return (
     <>
@@ -484,33 +460,16 @@ function ProjectSettingsForm({
           )}
 
           {/* Project Name */}
-          <Typography component="label" htmlFor="settings-name-input"
-            sx={{
-              display: 'block', fontSize: '0.75rem', fontWeight: 600,
-              color: 'text.secondary', textTransform: 'uppercase',
-              letterSpacing: '0.05em', mb: 0.75,
-            }}>
-            Project Name
-          </Typography>
           <Controller name="name" control={control} render={({ field }) => (
             <TextField {...field} id="settings-name-input"
+              label="Project Name"
               placeholder="e.g. Downtown Tower Construction"
               error={!!errors.name} helperText={errors.name?.message}
-              fullWidth autoComplete="off" sx={fieldSx} />
+              fullWidth autoComplete="off" />
           )} />
 
           {/* Location */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 2.5, mb: 0.75 }}>
-            <MapPin size={13} style={{ color: theme.palette.text.secondary }} />
-            <Typography component="label"
-              sx={{
-                display: 'block', fontSize: '0.75rem', fontWeight: 600,
-                color: 'text.secondary', textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-              }}>
-              Location
-            </Typography>
-          </Box>
+          <Box sx={{ mt: 2 }}>
           <Controller name="location" control={control} render={({ field }) =>
             useGooglePlaces ? (
               <LocationAutocompleteField value={field.value ?? ''} onChange={field.onChange}
@@ -520,6 +479,7 @@ function ProjectSettingsForm({
                 error={!!errors.location} helperText={errors.location?.message} />
             )
           } />
+          </Box>
 
           {/* Save Button */}
           <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2.5 }}>

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -218,11 +218,6 @@ export default function ForgotPasswordPage() {
                         </InputAdornment>
                       ),
                     }}
-                    sx={{
-                      '& .MuiOutlinedInput-root': {
-                        bgcolor: 'input.background',
-                      },
-                    }}
                   />
                 </Box>
 

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -286,11 +286,6 @@ function ResetPasswordForm() {
                         </InputAdornment>
                       ),
                     }}
-                    sx={{
-                      '& .MuiOutlinedInput-root': {
-                        bgcolor: 'input.background',
-                      },
-                    }}
                   />
                 </Box>
 
@@ -326,11 +321,6 @@ function ResetPasswordForm() {
                           </IconButton>
                         </InputAdornment>
                       ),
-                    }}
-                    sx={{
-                      '& .MuiOutlinedInput-root': {
-                        bgcolor: 'input.background',
-                      },
                     }}
                   />
                 </Box>

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -411,9 +411,6 @@ function SignInForm() {
                         </InputAdornment>
                       ),
                     }}
-                    sx={{
-                      '& .MuiOutlinedInput-root': { bgcolor: 'input.background' },
-                    }}
                   />
                 </Box>
 
@@ -447,9 +444,6 @@ function SignInForm() {
                           </IconButton>
                         </InputAdornment>
                       ),
-                    }}
-                    sx={{
-                      '& .MuiOutlinedInput-root': { bgcolor: 'input.background' },
                     }}
                   />
                 </Box>

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -392,9 +392,6 @@ export default function SignUpPage() {
                         </InputAdornment>
                       ),
                     }}
-                    sx={{
-                      '& .MuiOutlinedInput-root': { bgcolor: 'input.background' },
-                    }}
                   />
                 </Box>
 
@@ -418,9 +415,6 @@ export default function SignUpPage() {
                           <Envelope size={18} weight="regular" />
                         </InputAdornment>
                       ),
-                    }}
-                    sx={{
-                      '& .MuiOutlinedInput-root': { bgcolor: 'input.background' },
                     }}
                   />
                 </Box>
@@ -456,9 +450,6 @@ export default function SignUpPage() {
                         </InputAdornment>
                       ),
                     }}
-                    sx={{
-                      '& .MuiOutlinedInput-root': { bgcolor: 'input.background' },
-                    }}
                   />
                 </Box>
 
@@ -481,9 +472,6 @@ export default function SignUpPage() {
                           <Key size={18} weight="regular" />
                         </InputAdornment>
                       ),
-                    }}
-                    sx={{
-                      '& .MuiOutlinedInput-root': { bgcolor: 'input.background' },
                     }}
                   />
                 </Box>

--- a/src/components/layout/ProjectSwitcher.tsx
+++ b/src/components/layout/ProjectSwitcher.tsx
@@ -67,6 +67,7 @@ export default function ProjectSwitcher() {
         <ProjectAvatar
           imageUrl={currentProject?.imageUrl}
           icon={currentProject?.icon}
+          colorId={currentProject?.imageUrl ? null : currentProject?.color}
           size={28}
           borderRadius="6px"
           color="var(--text-secondary)"
@@ -185,11 +186,8 @@ export default function ProjectSwitcher() {
                     width: 56,
                     flexShrink: 0,
                     display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    bgcolor: hasImage
-                      ? 'transparent'
-                      : alpha(theme.palette.divider, 0.06),
+                    alignItems: 'stretch',
+                    justifyContent: 'stretch',
                     overflow: 'hidden',
                   }}
                 >
@@ -207,9 +205,9 @@ export default function ProjectSwitcher() {
                   ) : (
                     <ProjectAvatar
                       icon={project.icon}
-                      size={22}
+                      colorId={project.color ?? 'slate'}
+                      size={56}
                       borderRadius={0}
-                      color={theme.palette.text.disabled}
                     />
                   )}
                 </Box>

--- a/src/components/projects/AddProjectDialog.tsx
+++ b/src/components/projects/AddProjectDialog.tsx
@@ -1,62 +1,215 @@
 'use client';
 
-import {
-  Box,
-  Dialog,
-  alpha,
-  useTheme,
-} from '@mui/material';
+import { useState, useEffect } from 'react';
+import { Dialog, alpha, Box, Typography } from '@mui/material';
+import { Check } from '@phosphor-icons/react';
+import { useSnackbar } from '@/hooks/useSnackbar';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
+import { useSession } from '@/lib/auth-client';
+import { api } from '@/trpc/react';
 import ProjectFormBody from '@/components/projects/ProjectFormBody';
+import AddProjectMembersStep from '@/components/projects/AddProjectMembersStep';
 
 interface AddProjectDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
+type Step = 'create' | 'members';
+
+interface CreatedProject {
+  id: string;
+  slug: string;
+  name: string;
+}
+
 export default function AddProjectDialog({
   open,
   onOpenChange,
 }: AddProjectDialogProps) {
-  const theme = useTheme();
   const { orgSlug, activeOrganizationId } = useOrgFromUrl();
+  const { data: session } = useSession();
+  const { showSnackbar } = useSnackbar();
+  const currentUserId = session?.user?.id;
+
+  const [step, setStep] = useState<Step>('create');
+  const [createdProject, setCreatedProject] = useState<CreatedProject | null>(
+    null
+  );
+
+  // Reset step state whenever dialog re-opens
+  useEffect(() => {
+    if (open) {
+      setStep('create');
+      setCreatedProject(null);
+    }
+  }, [open]);
+
+  // Pre-fetch org members so we can decide whether to skip step 2
+  const { data: orgMembers, isSuccess: orgMembersLoaded } =
+    api.member.list.useQuery(
+      { organizationId: activeOrganizationId },
+      { enabled: open && !!activeOrganizationId }
+    );
+
+  // Only treat the org as confirmed-empty after a successful query resolves.
+  // While the query is in-flight we err toward showing step 2 (which has its
+  // own empty state) so the members step is never silently skipped.
+  const confirmedNoOtherMembers =
+    orgMembersLoaded &&
+    !!currentUserId &&
+    orgMembers.filter((m) => m.user.id !== currentUserId).length === 0;
 
   const handleClose = () => {
     onOpenChange(false);
   };
 
+  const handleProjectCreated = (project: CreatedProject) => {
+    setCreatedProject(project);
+    if (currentUserId && !confirmedNoOtherMembers) {
+      setStep('members');
+    } else {
+      showSnackbar(
+        `"${project.name}" created — switch to it in the project dropdown`,
+        'success'
+      );
+      handleClose();
+    }
+  };
+
+  const handleMembersComplete = () => {
+    if (createdProject) {
+      showSnackbar(
+        `"${createdProject.name}" is ready`,
+        'success'
+      );
+    }
+    handleClose();
+  };
+
+  const handleMembersSkip = () => {
+    if (createdProject) {
+      showSnackbar(
+        `"${createdProject.name}" created — switch to it in the project dropdown`,
+        'success'
+      );
+    }
+    handleClose();
+  };
+
+  const showStepper = !!currentUserId && !confirmedNoOtherMembers;
+
   return (
     <Dialog
       open={open}
-      onClose={handleClose}
+      onClose={step === 'members' ? undefined : handleClose}
       maxWidth={false}
       PaperProps={{
         sx: {
-          width: 440,
+          width: 460,
           borderRadius: '16px',
           overflow: 'hidden',
+          p: 3,
           boxShadow: `0 24px 64px -16px ${alpha('#000', 0.2)}, 0 8px 20px -8px ${alpha('#000', 0.08)}`,
         },
       }}
     >
-      {/* Header accent bar */}
-      <Box
-        sx={{
-          height: 3,
-          background: `linear-gradient(90deg, ${theme.palette.primary.main}, ${alpha(theme.palette.primary.main, 0.3)})`,
-        }}
-      />
+      {showStepper && (
+        <Stepper currentStep={step} />
+      )}
 
-      <Box sx={{ p: 3.5 }}>
+      {step === 'create' && (
         <ProjectFormBody
           orgSlug={orgSlug}
           organizationId={activeOrganizationId}
-          title="New Project"
-          subtitle="Set up a new construction project"
+          title="New project"
+          subtitle="Track schedule, documents and team in one place."
           onCancel={handleClose}
-          onSuccess={handleClose}
+          onSuccess={handleProjectCreated}
         />
-      </Box>
+      )}
+
+      {step === 'members' && createdProject && currentUserId && (
+        <AddProjectMembersStep
+          projectId={createdProject.id}
+          projectName={createdProject.name}
+          organizationId={activeOrganizationId}
+          currentUserId={currentUserId}
+          onComplete={handleMembersComplete}
+          onSkip={handleMembersSkip}
+        />
+      )}
     </Dialog>
+  );
+}
+
+function Stepper({ currentStep }: { currentStep: Step }) {
+  const step1Done = currentStep === 'members';
+  const step2Active = currentStep === 'members';
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'flex-end',
+        gap: 0.75,
+        mb: 1.5,
+      }}
+      aria-label={`Step ${step2Active ? 2 : 1} of 2`}
+    >
+      <StepDot state={step1Done ? 'done' : 'active'}>
+        {step1Done ? <Check size={11} weight="bold" /> : '1'}
+      </StepDot>
+      <Box
+        sx={{
+          width: 14,
+          height: 2,
+          borderRadius: '1px',
+          bgcolor: step1Done ? 'primary.main' : 'divider',
+        }}
+      />
+      <StepDot state={step2Active ? 'active' : 'pending'}>2</StepDot>
+    </Box>
+  );
+}
+
+function StepDot({
+  state,
+  children,
+}: {
+  state: 'done' | 'active' | 'pending';
+  children: React.ReactNode;
+}) {
+  const isFilled = state === 'done' || state === 'active';
+  return (
+    <Box
+      sx={{
+        width: 18,
+        height: 18,
+        borderRadius: '50%',
+        bgcolor: isFilled ? 'primary.main' : 'action.disabledBackground',
+        color: isFilled ? 'primary.contrastText' : 'text.secondary',
+        display: 'grid',
+        placeItems: 'center',
+        flexShrink: 0,
+        boxShadow: state === 'active'
+          ? `0 0 0 3px ${alpha('#2B2D42', 0.08)}`
+          : 'none',
+      }}
+    >
+      {typeof children === 'string' ? (
+        <Typography
+          sx={{
+            fontSize: '0.625rem',
+            fontWeight: 600,
+            lineHeight: 1,
+          }}
+        >
+          {children}
+        </Typography>
+      ) : (
+        children
+      )}
+    </Box>
   );
 }

--- a/src/components/projects/AddProjectMembersStep.tsx
+++ b/src/components/projects/AddProjectMembersStep.tsx
@@ -1,0 +1,420 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  TextField,
+  Select,
+  MenuItem,
+  alpha,
+  useTheme,
+} from '@mui/material';
+import {
+  ArrowRight,
+  MagnifyingGlass,
+  Check,
+  Info,
+} from '@phosphor-icons/react';
+import { Button } from '@/components/ui/button';
+import { api } from '@/trpc/react';
+import { useSnackbar } from '@/hooks/useSnackbar';
+import type { AssignableRole } from '@/lib/validations/invitation';
+
+interface AddProjectMembersStepProps {
+  projectId: string;
+  projectName: string;
+  organizationId: string;
+  currentUserId: string;
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+const ROLE_OPTIONS: Array<{ value: AssignableRole; label: string }> = [
+  { value: 'project_manager', label: 'Project manager' },
+  { value: 'member', label: 'Member' },
+  { value: 'viewer', label: 'Viewer' },
+];
+
+function getInitials(name?: string | null, email?: string | null): string {
+  if (name) {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (parts.length >= 2) {
+      return ((parts[0]?.[0] ?? '') + (parts[1]?.[0] ?? '')).toUpperCase();
+    }
+    return parts[0]?.slice(0, 2).toUpperCase() ?? '?';
+  }
+  return email?.slice(0, 2).toUpperCase() ?? '?';
+}
+
+export default function AddProjectMembersStep({
+  projectId,
+  projectName,
+  organizationId,
+  currentUserId,
+  onComplete,
+  onSkip,
+}: AddProjectMembersStepProps) {
+  const theme = useTheme();
+  const { showSnackbar } = useSnackbar();
+  const utils = api.useUtils();
+
+  const [search, setSearch] = useState('');
+  const [selections, setSelections] = useState<Map<string, AssignableRole>>(
+    new Map()
+  );
+
+  const { data: members = [], isLoading } = api.member.list.useQuery({
+    organizationId,
+  });
+
+  const otherMembers = useMemo(
+    () => members.filter((m) => m.user.id !== currentUserId),
+    [members, currentUserId]
+  );
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return otherMembers;
+    return otherMembers.filter((m) => {
+      const name = m.user.name?.toLowerCase() ?? '';
+      const email = m.user.email?.toLowerCase() ?? '';
+      return name.includes(q) || email.includes(q);
+    });
+  }, [otherMembers, search]);
+
+  const toggleMember = (userId: string) => {
+    setSelections((prev) => {
+      const next = new Map(prev);
+      if (next.has(userId)) {
+        next.delete(userId);
+      } else {
+        next.set(userId, 'member');
+      }
+      return next;
+    });
+  };
+
+  const setRole = (userId: string, role: AssignableRole) => {
+    setSelections((prev) => {
+      if (!prev.has(userId)) return prev;
+      const next = new Map(prev);
+      next.set(userId, role);
+      return next;
+    });
+  };
+
+  const bulkAdd = api.projectMember.bulkAdd.useMutation({
+    onSuccess: ({ added }) => {
+      void utils.projectMember.list.invalidate({ projectId });
+      showSnackbar(
+        added === 1
+          ? '1 teammate added to project'
+          : `${added} teammates added to project`,
+        'success'
+      );
+      onComplete();
+    },
+    onError: (error) => {
+      showSnackbar(error.message || 'Failed to add teammates', 'error');
+    },
+  });
+
+  const handleAdd = () => {
+    const memberPayload = Array.from(selections.entries()).map(
+      ([userId, role]) => ({ userId, role })
+    );
+    bulkAdd.mutate({ projectId, members: memberPayload });
+  };
+
+  const selectedCount = selections.size;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box>
+        <Typography
+          sx={{
+            fontSize: '1.0625rem',
+            fontWeight: 600,
+            letterSpacing: '-0.005em',
+            color: 'text.primary',
+          }}
+        >
+          Add your team
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: '0.8125rem',
+            color: 'text.secondary',
+            mt: 0.5,
+            lineHeight: 1.45,
+          }}
+        >
+          Pick people from your organization to add to{' '}
+          <Box component="span" sx={{ fontWeight: 600, color: 'text.primary' }}>
+            {projectName}
+          </Box>
+          .
+        </Typography>
+      </Box>
+
+      <TextField
+        placeholder="Search teammates by name or email"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        fullWidth
+        size="small"
+        InputProps={{
+          startAdornment: (
+            <MagnifyingGlass
+              size={16}
+              style={{ marginRight: 8, opacity: 0.55, flexShrink: 0 }}
+            />
+          ),
+        }}
+      />
+
+      <Box
+        sx={{
+          maxHeight: 280,
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1px',
+          mx: -0.5,
+        }}
+      >
+        {isLoading ? (
+          <Typography
+            sx={{
+              fontSize: '0.8125rem',
+              color: 'text.secondary',
+              textAlign: 'center',
+              py: 3,
+            }}
+          >
+            Loading teammates…
+          </Typography>
+        ) : filtered.length === 0 ? (
+          <Typography
+            sx={{
+              fontSize: '0.8125rem',
+              color: 'text.secondary',
+              textAlign: 'center',
+              py: 3,
+            }}
+          >
+            {search
+              ? 'No teammates match your search'
+              : 'No other teammates in your organization yet'}
+          </Typography>
+        ) : (
+          filtered.map((m) => {
+            const isSelected = selections.has(m.user.id);
+            const role = selections.get(m.user.id) ?? 'member';
+            return (
+              <Box
+                key={m.user.id}
+                onClick={() => toggleMember(m.user.id)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleMember(m.user.id);
+                  }
+                }}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1.25,
+                  px: 1.25,
+                  py: 1,
+                  borderRadius: '8px',
+                  cursor: 'pointer',
+                  bgcolor: isSelected
+                    ? alpha(theme.palette.primary.main, 0.06)
+                    : 'transparent',
+                  '&:hover': {
+                    bgcolor: isSelected
+                      ? alpha(theme.palette.primary.main, 0.09)
+                      : 'action.hover',
+                  },
+                  transition: 'background-color 0.12s ease',
+                }}
+              >
+                <Box
+                  sx={{
+                    width: 16,
+                    height: 16,
+                    borderRadius: '4px',
+                    border: `1.5px solid ${isSelected ? theme.palette.primary.main : theme.palette.divider}`,
+                    bgcolor: isSelected ? 'primary.main' : 'transparent',
+                    color: 'primary.contrastText',
+                    display: 'grid',
+                    placeItems: 'center',
+                    flexShrink: 0,
+                    transition: 'all 0.12s ease',
+                  }}
+                  aria-hidden="true"
+                >
+                  {isSelected && <Check size={11} weight="bold" />}
+                </Box>
+
+                {m.user.image ? (
+                  <Box
+                    component="img"
+                    src={m.user.image}
+                    alt=""
+                    sx={{
+                      width: 28,
+                      height: 28,
+                      borderRadius: '50%',
+                      flexShrink: 0,
+                      objectFit: 'cover',
+                    }}
+                  />
+                ) : (
+                  <Box
+                    sx={{
+                      width: 28,
+                      height: 28,
+                      borderRadius: '50%',
+                      bgcolor: alpha(theme.palette.primary.main, 0.1),
+                      color: 'primary.main',
+                      display: 'grid',
+                      placeItems: 'center',
+                      fontSize: '0.6875rem',
+                      fontWeight: 600,
+                      flexShrink: 0,
+                    }}
+                  >
+                    {getInitials(m.user.name, m.user.email)}
+                  </Box>
+                )}
+
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography
+                    sx={{
+                      fontSize: '0.8125rem',
+                      fontWeight: 500,
+                      lineHeight: 1.2,
+                      color: 'text.primary',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {m.user.name ?? m.user.email}
+                  </Typography>
+                  {m.user.name && (
+                    <Typography
+                      sx={{
+                        fontSize: '0.6875rem',
+                        color: 'text.secondary',
+                        lineHeight: 1.3,
+                        mt: 0.125,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {m.user.email}
+                    </Typography>
+                  )}
+                </Box>
+
+                {isSelected && (
+                  <Select
+                    value={role}
+                    onChange={(e) =>
+                      setRole(m.user.id, e.target.value as AssignableRole)
+                    }
+                    onClick={(e) => e.stopPropagation()}
+                    size="small"
+                    sx={{
+                      minWidth: 130,
+                      fontSize: '0.75rem',
+                      flexShrink: 0,
+                      bgcolor: 'background.paper',
+                      '& .MuiSelect-select': { py: 0.5, fontSize: '0.75rem' },
+                    }}
+                  >
+                    {ROLE_OPTIONS.map((opt) => (
+                      <MenuItem
+                        key={opt.value}
+                        value={opt.value}
+                        sx={{ fontSize: '0.8125rem' }}
+                      >
+                        {opt.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                )}
+              </Box>
+            );
+          })
+        )}
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-end',
+          justifyContent: 'space-between',
+          gap: 1.5,
+          mt: 0.5,
+        }}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, minWidth: 0, flexShrink: 1 }}>
+          <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
+            <Box
+              component="span"
+              sx={{ fontWeight: 600, color: 'text.primary' }}
+            >
+              {selectedCount}
+            </Box>{' '}
+            selected
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Info size={11} style={{ opacity: 0.5, flexShrink: 0 }} />
+            <Typography
+              sx={{
+                fontSize: '0.6875rem',
+                color: 'text.disabled',
+                lineHeight: 1.3,
+              }}
+            >
+              Need to invite someone outside your org? Use the{' '}
+              <Box component="span" sx={{ fontWeight: 600 }}>
+                Team
+              </Box>{' '}
+              tab.
+            </Typography>
+          </Box>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 1, flexShrink: 0 }}>
+          <Button
+            onClick={onSkip}
+            variant="text"
+            size="small"
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            Skip
+          </Button>
+          <Button
+            onClick={handleAdd}
+            variant="contained"
+            size="small"
+            disabled={selectedCount === 0}
+            loading={bulkAdd.isPending}
+            endIcon={<ArrowRight size={14} weight="bold" />}
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            Add to project
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/projects/ProjectFormBody.tsx
+++ b/src/components/projects/ProjectFormBody.tsx
@@ -2,10 +2,18 @@
 
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowRight, CaretDown, MapPin, Image as ImageIcon, Swatches, UploadSimple, X } from '@phosphor-icons/react';
+import {
+  ArrowRight,
+  Image as ImageIcon,
+  Swatches,
+  UploadSimple,
+  X,
+  Plus,
+} from '@phosphor-icons/react';
 import { api } from '@/trpc/react';
 import { useRouter } from 'next/navigation';
 import Script from 'next/script';
+import { keyframes } from '@mui/system';
 import {
   Autocomplete as MuiAutocomplete,
   Box,
@@ -20,16 +28,18 @@ import {
 } from '@mui/material';
 import { Button } from '@/components/ui/button';
 import ProjectAvatar from '@/components/ui/ProjectAvatar';
+import SidebarRowPreview from '@/components/projects/SidebarRowPreview';
 import { useSnackbar } from '@/hooks/useSnackbar';
 import { useLoading } from '@/components/providers/LoadingProvider';
 import {
   createProjectSchema,
   type CreateProjectInput,
 } from '@/lib/validations/project';
+import { PROJECT_ICON_OPTIONS } from '@/lib/constants/projectIconComponents';
 import {
-  PROJECT_ICON_OPTIONS,
-  getProjectIcon,
-} from '@/lib/constants/projectIconComponents';
+  PROJECT_COLOR_OPTIONS,
+  type ProjectColor,
+} from '@/lib/constants/projectColors';
 import usePlacesAutocomplete, { getGeocode } from 'use-places-autocomplete';
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useDropzone } from 'react-dropzone';
@@ -37,13 +47,18 @@ import { env } from '@/env';
 
 const GOOGLE_PLACES_API_KEY = env.NEXT_PUBLIC_GOOGLE_PLACES_API_KEY;
 
+const overlayEnter = keyframes`
+  from { opacity: 0; transform: scale(0.985); }
+  to   { opacity: 1; transform: scale(1); }
+`;
+
 interface ProjectFormBodyProps {
   orgSlug: string;
   organizationId: string;
   title: string;
   subtitle: string;
   onCancel?: () => void;
-  onSuccess?: () => void;
+  onSuccess?: (project: { id: string; slug: string; name: string }) => void;
   replaceOnNavigate?: boolean;
 }
 
@@ -58,7 +73,6 @@ function LocationAutocompleteField({
   error?: boolean;
   helperText?: string;
 }) {
-  const theme = useTheme();
   const {
     ready,
     suggestions: { data },
@@ -93,7 +107,7 @@ function LocationAutocompleteField({
         try {
           await getGeocode({ address: newValue });
         } catch {
-          // Address selected from autocomplete, keep it even if geocode fails
+          // address selected from autocomplete; keep it even if geocode fails
         }
       } else {
         onChange('');
@@ -101,37 +115,6 @@ function LocationAutocompleteField({
     },
     [onChange, clearSuggestions]
   );
-
-  const fieldSx = {
-    '& .MuiOutlinedInput-root': {
-      borderRadius: '8px',
-      fontSize: '0.9375rem',
-      bgcolor: alpha(theme.palette.divider, 0.08),
-      transition: 'all 0.15s ease',
-      '& fieldset': {
-        borderColor: 'transparent',
-      },
-      '&:hover fieldset': {
-        borderColor: alpha(theme.palette.primary.main, 0.3),
-      },
-      '&.Mui-focused fieldset': {
-        borderColor: theme.palette.primary.main,
-        borderWidth: '1.5px',
-      },
-      '&.Mui-focused': {
-        bgcolor: 'background.paper',
-        boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
-      },
-    },
-    '& .MuiOutlinedInput-input': {
-      py: 1.5,
-      px: 1.75,
-      '&::placeholder': {
-        color: alpha(theme.palette.text.secondary, 0.5),
-        opacity: 1,
-      },
-    },
-  };
 
   return (
     <MuiAutocomplete
@@ -145,11 +128,11 @@ function LocationAutocompleteField({
       renderInput={(params) => (
         <TextField
           {...params}
-          placeholder="e.g. 123 Main St, New York, NY"
+          label="Location"
+          placeholder="123 Main St, New York, NY"
           error={error}
           helperText={helperText}
           fullWidth
-          sx={fieldSx}
         />
       )}
       slotProps={{
@@ -181,47 +164,16 @@ function PlainLocationField({
   error?: boolean;
   helperText?: string;
 }) {
-  const theme = useTheme();
-
   return (
     <TextField
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      placeholder="e.g. 123 Main St, New York, NY"
+      label="Location"
+      placeholder="123 Main St, New York, NY"
       error={error}
       helperText={helperText}
       fullWidth
       autoComplete="off"
-      sx={{
-        '& .MuiOutlinedInput-root': {
-          borderRadius: '8px',
-          fontSize: '0.9375rem',
-          bgcolor: alpha(theme.palette.divider, 0.08),
-          transition: 'all 0.15s ease',
-          '& fieldset': {
-            borderColor: 'transparent',
-          },
-          '&:hover fieldset': {
-            borderColor: alpha(theme.palette.primary.main, 0.3),
-          },
-          '&.Mui-focused fieldset': {
-            borderColor: theme.palette.primary.main,
-            borderWidth: '1.5px',
-          },
-          '&.Mui-focused': {
-            bgcolor: 'background.paper',
-            boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
-          },
-        },
-        '& .MuiOutlinedInput-input': {
-          py: 1.5,
-          px: 1.75,
-          '&::placeholder': {
-            color: alpha(theme.palette.text.secondary, 0.5),
-            opacity: 1,
-          },
-        },
-      }}
     />
   );
 }
@@ -244,7 +196,7 @@ export default function ProjectFormBody({
   const [pickerMode, setPickerMode] = useState<'icon' | 'photo'>('icon');
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
-  const [iconAnchorEl, setIconAnchorEl] = useState<HTMLElement | null>(null);
+  const [identityAnchor, setIdentityAnchor] = useState<HTMLElement | null>(null);
   const uploadedUrlRef = useRef<string | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
@@ -261,13 +213,13 @@ export default function ProjectFormBody({
       name: '',
       location: '',
       icon: 'building',
+      color: 'slate',
       template: 'BLANK',
     },
   });
 
   const selectedIcon = watch('icon') ?? 'building';
-  const SelectedIconComponent = getProjectIcon(selectedIcon);
-  const selectedIconLabel = PROJECT_ICON_OPTIONS.find(o => o.id === selectedIcon)?.label ?? 'Building';
+  const selectedColor = (watch('color') ?? 'slate') as ProjectColor;
   const imageUrl = watch('imageUrl');
   const displayImageUrl = previewUrl ?? imageUrl;
 
@@ -318,16 +270,17 @@ export default function ProjectFormBody({
     onSuccess: (newProject) => {
       void utils.project.list.invalidate();
       void utils.project.getActive.invalidate();
-      uploadedUrlRef.current = null; // Don't clean up — project owns it now
+      uploadedUrlRef.current = null; // project owns the image now
       handleReset();
 
       if (onSuccess) {
-        // Modal mode — show toast, let user switch manually via project dropdown
         hideLoading();
-        showSnackbar(`"${newProject.name}" created — switch to it in the project dropdown`, 'success');
-        onSuccess();
+        onSuccess({
+          id: newProject.id,
+          slug: newProject.slug,
+          name: newProject.name,
+        });
       } else {
-        // Standalone mode — navigate to the new project
         showSnackbar('Project created successfully', 'success');
         if (replaceOnNavigate) {
           router.replace(`/${orgSlug}/projects/${newProject.slug}/gantt`);
@@ -344,7 +297,6 @@ export default function ProjectFormBody({
 
   const onSubmit = (data: CreateProjectInput) => {
     if (!onSuccess) {
-      // Standalone mode — close and show loading overlay
       onCancel?.();
       showLoading('Creating your project...');
     }
@@ -390,7 +342,6 @@ export default function ProjectFormBody({
 
       const data = await res.json() as { imageUrl: string };
 
-      // Clean up previous upload if replacing
       if (uploadedUrlRef.current) {
         cleanupUploadedImage(uploadedUrlRef.current);
       }
@@ -401,6 +352,7 @@ export default function ProjectFormBody({
 
       uploadedUrlRef.current = data.imageUrl;
       setValue('imageUrl', data.imageUrl);
+      setPickerMode('photo');
     } catch (err) {
       setUploadError(err instanceof Error ? err.message : 'Upload failed — try again');
     } finally {
@@ -420,39 +372,41 @@ export default function ProjectFormBody({
     setUploadError(null);
   }, [setValue, cleanupUploadedImage]);
 
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+  const handleDropRejected = useCallback((rejections: import('react-dropzone').FileRejection[]) => {
+    const error = rejections[0]?.errors[0];
+    if (error?.code === 'file-too-large') {
+      setUploadError('File size exceeds 5MB limit');
+    } else if (error?.code === 'file-invalid-type') {
+      setUploadError('Only image files are allowed');
+    } else {
+      setUploadError('File not accepted');
+    }
+  }, []);
+
+  // ── Whole-modal dropzone: drop anywhere on the form to upload as cover. ─
+  const rootDropzone = useDropzone({
     onDrop: handlePhotoDrop,
     accept: { 'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.webp'] },
     maxFiles: 1,
     maxSize: 5 * 1024 * 1024,
     disabled: isUploading,
-    onDropRejected: (rejections) => {
-      const error = rejections[0]?.errors[0];
-      if (error?.code === 'file-too-large') {
-        setUploadError('File size exceeds 5MB limit');
-      } else if (error?.code === 'file-invalid-type') {
-        setUploadError('Only image files are allowed');
-      } else {
-        setUploadError('File not accepted');
-      }
-    },
+    noClick: true,
+    noKeyboard: true,
+    onDropRejected: handleDropRejected,
   });
 
-  const handleSwitchToIcon = useCallback(() => {
-    setPickerMode('icon');
-    setUploadError(null);
-    if (uploadedUrlRef.current) {
-      cleanupUploadedImage();
-      setValue('imageUrl', undefined);
-    }
-  }, [setValue, cleanupUploadedImage]);
-
-  const handleSwitchToPhoto = useCallback(() => {
-    setPickerMode('photo');
-    setUploadError(null);
-  }, []);
+  // Click-to-upload zone inside the popover (separate dropzone instance with click enabled).
+  const popoverDropzone = useDropzone({
+    onDrop: handlePhotoDrop,
+    accept: { 'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.webp'] },
+    maxFiles: 1,
+    maxSize: 5 * 1024 * 1024,
+    disabled: isUploading,
+    onDropRejected: handleDropRejected,
+  });
 
   const useGooglePlaces = !!GOOGLE_PLACES_API_KEY && scriptLoaded;
+  const closePopover = () => setIdentityAnchor(null);
 
   return (
     <>
@@ -464,236 +418,322 @@ export default function ProjectFormBody({
         />
       )}
 
-      {/* Header: Icon + Title */}
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 1.5 }}>
-        <Box
-          sx={{
-            width: 44,
-            height: 44,
-            borderRadius: '12px',
-            bgcolor: displayImageUrl ? 'transparent' : alpha(theme.palette.primary.main, 0.08),
-            border: displayImageUrl ? 'none' : `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            flexShrink: 0,
-            transition: 'all 0.15s ease',
-            overflow: 'hidden',
+      {/* Whole-modal dropzone wrapper. Drop anywhere → uploads + switches to photo. */}
+      <Box {...rootDropzone.getRootProps()} sx={{ position: 'relative', outline: 'none' }}>
+        <input {...rootDropzone.getInputProps()} />
+
+        {/* Drag overlay */}
+        {rootDropzone.isDragActive && (
+          <Box
+            aria-hidden
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              borderRadius: '12px',
+              border: `2px dashed ${theme.palette.primary.main}`,
+              bgcolor: alpha(theme.palette.primary.main, 0.06),
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: 'primary.main',
+              fontWeight: 600,
+              fontSize: '0.875rem',
+              pointerEvents: 'none',
+              zIndex: 5,
+              backdropFilter: 'blur(2px)',
+              animation: `${overlayEnter} 0.18s ease`,
+            }}
+          >
+            Drop image to use as cover
+          </Box>
+        )}
+
+        {/* Identity row */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.75, mb: 2.5 }}>
+          <Box
+            component="button"
+            type="button"
+            aria-label="Change project icon, color, or photo"
+            onClick={(e: React.MouseEvent<HTMLElement>) => setIdentityAnchor(e.currentTarget)}
+            sx={{
+              position: 'relative',
+              width: 56,
+              height: 56,
+              borderRadius: '14px',
+              border: 0,
+              p: 0,
+              cursor: 'pointer',
+              flexShrink: 0,
+              bgcolor: 'transparent',
+              transition: 'transform 0.12s ease, box-shadow 0.12s ease',
+              overflow: 'visible',
+              '&:hover': {
+                transform: 'translateY(-1px)',
+                boxShadow: `0 4px 10px ${alpha('#000', 0.08)}`,
+              },
+              '&:hover .identity-badge': {
+                transform: 'scale(1.2)',
+              },
+              '&:active': {
+                transform: 'scale(0.95)',
+              },
+              '&:focus-visible': {
+                outline: `2px solid ${theme.palette.primary.main}`,
+                outlineOffset: 2,
+              },
+            }}
+          >
+            <ProjectAvatar
+              imageUrl={displayImageUrl}
+              icon={selectedIcon}
+              colorId={displayImageUrl ? null : selectedColor}
+              size={56}
+              borderRadius="14px"
+            />
+            {/* + edit badge */}
+            <Box
+              aria-hidden
+              className="identity-badge"
+              sx={{
+                position: 'absolute',
+                bottom: -4,
+                right: -4,
+                width: 22,
+                height: 22,
+                borderRadius: '999px',
+                bgcolor: 'background.paper',
+                border: `1px solid ${theme.palette.divider}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: 'text.secondary',
+                boxShadow: `0 1px 2px ${alpha('#000', 0.06)}`,
+                transition: 'transform 0.15s ease',
+              }}
+            >
+              <Plus size={11} weight="bold" />
+            </Box>
+          </Box>
+
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Typography
+              sx={{
+                fontSize: '1.0625rem',
+                fontWeight: 600,
+                color: 'text.primary',
+                letterSpacing: '-0.01em',
+                lineHeight: 1.25,
+              }}
+            >
+              {title}
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: '0.8125rem',
+                color: 'text.secondary',
+                mt: 0.25,
+                lineHeight: 1.4,
+              }}
+            >
+              {subtitle}
+            </Typography>
+
+            {/* Color swatches — hidden when displaying a photo */}
+            {!displayImageUrl && (
+              <Controller
+                name="color"
+                control={control}
+                render={({ field }) => (
+                  <Box
+                    role="radiogroup"
+                    aria-label="Project color"
+                    sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 0.875 }}
+                  >
+                    {PROJECT_COLOR_OPTIONS.map((c) => {
+                      const isSelected = (field.value ?? 'slate') === c.id;
+                      return (
+                        <Tooltip key={c.id} title={c.label} arrow placement="top">
+                          <Box
+                            component="button"
+                            type="button"
+                            role="radio"
+                            aria-checked={isSelected}
+                            aria-label={c.label}
+                            onClick={() => field.onChange(c.id)}
+                            sx={{
+                              width: 16,
+                              height: 16,
+                              borderRadius: '999px',
+                              bgcolor: c.swatch,
+                              cursor: 'pointer',
+                              border: 0,
+                              p: 0,
+                              boxShadow: isSelected
+                                ? `0 0 0 2px ${theme.palette.background.paper}, 0 0 0 3.5px ${theme.palette.text.primary}`
+                                : `inset 0 0 0 1px ${alpha('#000', 0.08)}`,
+                              transition: 'transform 0.12s ease, box-shadow 0.18s ease',
+                              '&:hover': { transform: 'scale(1.15)' },
+                              '&:active': { transform: 'scale(0.85)' },
+                              '&:focus-visible': {
+                                outline: `2px solid ${theme.palette.primary.main}`,
+                                outlineOffset: 2,
+                              },
+                            }}
+                          />
+                        </Tooltip>
+                      );
+                    })}
+                  </Box>
+                )}
+              />
+            )}
+          </Box>
+        </Box>
+
+        {/* Identity popover (Icon/Photo tabs) */}
+        <Popover
+          open={!!identityAnchor}
+          anchorEl={identityAnchor}
+          onClose={closePopover}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+          slotProps={{
+            paper: {
+              sx: {
+                borderRadius: '12px',
+                mt: 1,
+                p: 1.25,
+                width: 320,
+                boxShadow: `0 12px 32px ${alpha('#000', 0.14)}`,
+              },
+            },
           }}
         >
-          <ProjectAvatar
-            imageUrl={displayImageUrl}
-            icon={selectedIcon}
-            size={displayImageUrl ? 44 : 22}
-            borderRadius="12px"
-            color={theme.palette.primary.main}
-          />
-        </Box>
-        <Box sx={{ pt: 0.25 }}>
-          <Typography
-            sx={{
-              fontSize: '1.125rem',
-              fontWeight: 700,
-              color: 'text.primary',
-              letterSpacing: '-0.01em',
-              lineHeight: 1.3,
-            }}
-          >
-            {title}
-          </Typography>
-          <Typography
-            sx={{
-              fontSize: '0.8125rem',
-              color: 'text.secondary',
-              mt: 0.25,
-              lineHeight: 1.4,
-            }}
-          >
-            {subtitle}
-          </Typography>
-        </Box>
-      </Box>
-
-      {/* Form */}
-      <Box sx={{ pt: 1 }}>
-        <form onSubmit={handleSubmit(onSubmit)} id="project-form">
-          {/* Picker Mode Toggle */}
+          {/* Tab header */}
           <Box
-            role="radiogroup"
-            aria-label="Project image type"
+            role="tablist"
             sx={{
-              display: 'inline-flex',
-              borderRadius: '8px',
-              bgcolor: alpha(theme.palette.divider, 0.08),
+              display: 'flex',
+              gap: 0.5,
+              bgcolor: alpha(theme.palette.divider, 0.12),
               p: '3px',
-              mb: 1.5,
+              borderRadius: '8px',
+              mb: 1.25,
             }}
           >
             <Box
               component="button"
               type="button"
-              role="radio"
-              aria-checked={pickerMode === 'icon'}
-              onClick={handleSwitchToIcon}
+              role="tab"
+              aria-selected={pickerMode === 'icon'}
+              onClick={() => setPickerMode('icon')}
               sx={{
-                display: 'flex',
+                flex: 1,
+                display: 'inline-flex',
                 alignItems: 'center',
+                justifyContent: 'center',
                 gap: 0.75,
-                px: 1.5,
                 py: 0.625,
                 borderRadius: '6px',
-                border: 'none',
+                border: 0,
                 cursor: 'pointer',
+                fontFamily: 'inherit',
                 fontSize: '0.75rem',
                 fontWeight: 600,
-                fontFamily: 'inherit',
-                letterSpacing: '0.02em',
-                transition: 'all 0.15s ease',
                 bgcolor: pickerMode === 'icon' ? 'background.paper' : 'transparent',
-                color: pickerMode === 'icon' ? theme.palette.primary.main : theme.palette.text.secondary,
+                color: pickerMode === 'icon' ? 'primary.main' : 'text.secondary',
                 boxShadow: pickerMode === 'icon' ? `0 1px 3px ${alpha('#000', 0.08)}` : 'none',
-                '&:hover': {
-                  color: pickerMode === 'icon' ? theme.palette.primary.main : theme.palette.text.primary,
-                },
               }}
             >
-              <Swatches size={14} weight={pickerMode === 'icon' ? 'fill' : 'regular'} />
+              <Swatches size={13} weight={pickerMode === 'icon' ? 'fill' : 'regular'} />
               Icon
             </Box>
             <Box
               component="button"
               type="button"
-              role="radio"
-              aria-checked={pickerMode === 'photo'}
-              onClick={handleSwitchToPhoto}
+              role="tab"
+              aria-selected={pickerMode === 'photo'}
+              onClick={() => setPickerMode('photo')}
               sx={{
-                display: 'flex',
+                flex: 1,
+                display: 'inline-flex',
                 alignItems: 'center',
+                justifyContent: 'center',
                 gap: 0.75,
-                px: 1.5,
                 py: 0.625,
                 borderRadius: '6px',
-                border: 'none',
+                border: 0,
                 cursor: 'pointer',
+                fontFamily: 'inherit',
                 fontSize: '0.75rem',
                 fontWeight: 600,
-                fontFamily: 'inherit',
-                letterSpacing: '0.02em',
-                transition: 'all 0.15s ease',
                 bgcolor: pickerMode === 'photo' ? 'background.paper' : 'transparent',
-                color: pickerMode === 'photo' ? theme.palette.primary.main : theme.palette.text.secondary,
+                color: pickerMode === 'photo' ? 'primary.main' : 'text.secondary',
                 boxShadow: pickerMode === 'photo' ? `0 1px 3px ${alpha('#000', 0.08)}` : 'none',
-                '&:hover': {
-                  color: pickerMode === 'photo' ? theme.palette.primary.main : theme.palette.text.primary,
-                },
               }}
             >
-              <ImageIcon size={14} weight={pickerMode === 'photo' ? 'fill' : 'regular'} />
+              <ImageIcon size={13} weight={pickerMode === 'photo' ? 'fill' : 'regular'} />
               Photo
             </Box>
           </Box>
 
-          {/* Icon Picker (dropdown) */}
+          {/* Icon tab body */}
           {pickerMode === 'icon' && (
             <Controller
               name="icon"
               control={control}
               render={({ field }) => (
-                <>
-                  <Box
-                    component="button"
-                    type="button"
-                    onClick={(e: React.MouseEvent<HTMLElement>) => setIconAnchorEl(e.currentTarget)}
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 1,
-                      px: 1.5,
-                      py: 1,
-                      mb: 2.5,
-                      borderRadius: '8px',
-                      border: '1.5px solid',
-                      borderColor: alpha(theme.palette.divider, 0.3),
-                      bgcolor: alpha(theme.palette.divider, 0.06),
-                      cursor: 'pointer',
-                      fontFamily: 'inherit',
-                      fontSize: '0.8125rem',
-                      fontWeight: 500,
-                      color: 'text.primary',
-                      transition: 'all 0.15s ease',
-                      '&:hover': {
-                        borderColor: alpha(theme.palette.primary.main, 0.4),
-                        bgcolor: alpha(theme.palette.divider, 0.1),
-                      },
-                    }}
-                  >
-                    <SelectedIconComponent size={18} weight="fill" />
-                    {selectedIconLabel}
-                    <CaretDown size={12} style={{ marginLeft: 'auto', color: theme.palette.text.secondary }} />
-                  </Box>
-                  <Popover
-                    open={!!iconAnchorEl}
-                    anchorEl={iconAnchorEl}
-                    onClose={() => setIconAnchorEl(null)}
-                    anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-                    transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                    slotProps={{
-                      paper: {
-                        sx: {
-                          borderRadius: '10px',
-                          mt: 0.5,
-                          p: 1,
-                          boxShadow: `0 8px 24px ${alpha('#000', 0.12)}`,
-                        },
-                      },
-                    }}
-                  >
-                    <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 0.5 }}>
-                      {PROJECT_ICON_OPTIONS.map(({ id, label, Icon }) => {
-                        const isSelected = (field.value ?? 'building') === id;
-                        return (
-                          <Tooltip key={id} title={label} arrow placement="top">
-                            <Box
-                              component="button"
-                              type="button"
-                              onClick={() => { field.onChange(id); setIconAnchorEl(null); }}
-                              sx={{
-                                width: 36,
-                                height: 36,
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                borderRadius: '8px',
-                                border: '1.5px solid',
-                                borderColor: isSelected ? theme.palette.primary.main : 'transparent',
-                                bgcolor: isSelected ? alpha(theme.palette.primary.main, 0.08) : 'transparent',
-                                color: isSelected ? theme.palette.primary.main : theme.palette.text.secondary,
-                                cursor: 'pointer',
-                                transition: 'all 0.15s ease',
-                                p: 0,
-                                '&:hover': {
-                                  bgcolor: isSelected
-                                    ? alpha(theme.palette.primary.main, 0.12)
-                                    : alpha(theme.palette.divider, 0.12),
-                                  color: isSelected ? theme.palette.primary.main : theme.palette.text.primary,
-                                },
-                              }}
-                            >
-                              <Icon size={18} weight={isSelected ? 'fill' : 'regular'} />
-                            </Box>
-                          </Tooltip>
-                        );
-                      })}
-                    </Box>
-                  </Popover>
-                </>
+                <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 0.5 }}>
+                  {PROJECT_ICON_OPTIONS.map(({ id, label, Icon }) => {
+                    const isSelected = (field.value ?? 'building') === id;
+                    return (
+                      <Tooltip key={id} title={label} arrow placement="top">
+                        <Box
+                          component="button"
+                          type="button"
+                          onClick={() => field.onChange(id)}
+                          sx={{
+                            width: 36,
+                            height: 36,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            borderRadius: '8px',
+                            border: '1.5px solid',
+                            borderColor: isSelected ? theme.palette.primary.main : 'transparent',
+                            bgcolor: isSelected
+                              ? alpha(theme.palette.primary.main, 0.08)
+                              : 'transparent',
+                            color: isSelected
+                              ? theme.palette.primary.main
+                              : theme.palette.text.secondary,
+                            cursor: 'pointer',
+                            transition: 'all 0.15s ease',
+                            p: 0,
+                            '&:hover': {
+                              bgcolor: isSelected
+                                ? alpha(theme.palette.primary.main, 0.12)
+                                : alpha(theme.palette.divider, 0.18),
+                              color: isSelected
+                                ? theme.palette.primary.main
+                                : theme.palette.text.primary,
+                            },
+                            '&:active': { transform: 'scale(0.88)' },
+                          }}
+                        >
+                          <Icon size={18} weight={isSelected ? 'fill' : 'regular'} />
+                        </Box>
+                      </Tooltip>
+                    );
+                  })}
+                </Box>
               )}
             />
           )}
 
-          {/* Photo Picker */}
+          {/* Photo tab body */}
           {pickerMode === 'photo' && (
-            <Box sx={{ mb: 2.5 }}>
+            <Box>
               {displayImageUrl ? (
                 <Box
                   sx={{
@@ -733,7 +773,7 @@ export default function ProjectFormBody({
                 </Box>
               ) : (
                 <Box
-                  {...getRootProps()}
+                  {...popoverDropzone.getRootProps()}
                   aria-label="Upload project photo"
                   aria-busy={isUploading}
                   sx={{
@@ -746,19 +786,19 @@ export default function ProjectFormBody({
                     border: '1.5px dashed',
                     borderColor: uploadError
                       ? theme.palette.error.main
-                      : isDragActive
+                      : popoverDropzone.isDragActive
                         ? theme.palette.primary.main
-                        : alpha(theme.palette.divider, 0.4),
+                        : alpha(theme.palette.divider, 0.5),
                     borderRadius: '10px',
                     cursor: isUploading ? 'not-allowed' : 'pointer',
-                    bgcolor: isDragActive
+                    bgcolor: popoverDropzone.isDragActive
                       ? alpha(theme.palette.primary.main, 0.04)
                       : 'transparent',
                     opacity: isUploading ? 0.6 : 1,
                     transition: 'all 0.15s ease',
                     '&:hover': {
                       borderColor: isUploading
-                        ? alpha(theme.palette.divider, 0.4)
+                        ? alpha(theme.palette.divider, 0.5)
                         : alpha(theme.palette.primary.main, 0.4),
                       bgcolor: isUploading
                         ? 'transparent'
@@ -766,67 +806,36 @@ export default function ProjectFormBody({
                     },
                   }}
                 >
-                  <input {...getInputProps()} />
+                  <input {...popoverDropzone.getInputProps()} />
                   {isUploading ? (
                     <CircularProgress size={20} />
                   ) : (
-                    <UploadSimple
-                      size={20}
-                      style={{ color: theme.palette.text.disabled }}
-                    />
+                    <UploadSimple size={20} style={{ color: theme.palette.text.disabled }} />
                   )}
-                  <Typography
-                    sx={{
-                      fontSize: '0.8125rem',
-                      color: 'text.secondary',
-                    }}
-                  >
+                  <Typography sx={{ fontSize: '0.8125rem', color: 'text.secondary' }}>
                     {isUploading
                       ? 'Uploading...'
-                      : isDragActive
+                      : popoverDropzone.isDragActive
                         ? 'Drop image here'
-                        : 'Drag & drop or click to upload'}
+                        : 'Click to upload or drop here'}
                   </Typography>
-                  <Typography
-                    sx={{
-                      fontSize: '0.6875rem',
-                      color: 'text.secondary',
-                    }}
-                  >
+                  <Typography sx={{ fontSize: '0.6875rem', color: 'text.secondary' }}>
                     PNG, JPG, WebP up to 5MB
                   </Typography>
                 </Box>
               )}
               {uploadError && (
-                <Typography
-                  sx={{
-                    fontSize: '0.75rem',
-                    color: 'error.main',
-                    mt: 0.75,
-                  }}
-                >
+                <Typography sx={{ fontSize: '0.75rem', color: 'error.main', mt: 0.75 }}>
                   {uploadError}
                 </Typography>
               )}
             </Box>
           )}
+        </Popover>
 
-          {/* Project Name */}
-          <Typography
-            component="label"
-            htmlFor="project-name-input"
-            sx={{
-              display: 'block',
-              fontSize: '0.75rem',
-              fontWeight: 600,
-              color: 'text.secondary',
-              textTransform: 'uppercase',
-              letterSpacing: '0.05em',
-              mb: 0.75,
-            }}
-          >
-            Project Name
-          </Typography>
+        {/* Form fields */}
+        <Box component="form" onSubmit={handleSubmit(onSubmit)} id="project-form">
+          {/* Name */}
           <Controller
             name="name"
             control={control}
@@ -834,63 +843,19 @@ export default function ProjectFormBody({
               <TextField
                 {...field}
                 id="project-name-input"
-                placeholder="e.g. Downtown Tower Construction"
+                label="Name"
+                placeholder="Downtown Tower Construction"
                 error={!!errors.name}
                 helperText={errors.name?.message}
                 fullWidth
                 autoFocus
                 autoComplete="off"
-                sx={{
-                  '& .MuiOutlinedInput-root': {
-                    borderRadius: '8px',
-                    fontSize: '0.9375rem',
-                    bgcolor: alpha(theme.palette.divider, 0.08),
-                    transition: 'all 0.15s ease',
-                    '& fieldset': {
-                      borderColor: 'transparent',
-                    },
-                    '&:hover fieldset': {
-                      borderColor: alpha(theme.palette.primary.main, 0.3),
-                    },
-                    '&.Mui-focused fieldset': {
-                      borderColor: theme.palette.primary.main,
-                      borderWidth: '1.5px',
-                    },
-                    '&.Mui-focused': {
-                      bgcolor: 'background.paper',
-                      boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
-                    },
-                  },
-                  '& .MuiOutlinedInput-input': {
-                    py: 1.5,
-                    px: 1.75,
-                    '&::placeholder': {
-                      color: alpha(theme.palette.text.secondary, 0.5),
-                      opacity: 1,
-                    },
-                  },
-                }}
               />
             )}
           />
 
           {/* Location */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 2.5, mb: 0.75 }}>
-            <MapPin size={13} style={{ color: theme.palette.text.secondary }} />
-            <Typography
-              component="label"
-              sx={{
-                display: 'block',
-                fontSize: '0.75rem',
-                fontWeight: 600,
-                color: 'text.secondary',
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-              }}
-            >
-              Location
-            </Typography>
-          </Box>
+          <Box sx={{ mt: 2 }}>
           <Controller
             name="location"
             control={control}
@@ -912,65 +877,100 @@ export default function ProjectFormBody({
               )
             }
           />
-        </form>
-      </Box>
+          </Box>
+        </Box>
 
-      {/* Actions */}
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'flex-end',
-          gap: 1,
-          pt: 2.5,
-        }}
-      >
-        {onCancel && (
-          <Button
-            variant="text"
-            onClick={handleCancel}
-            sx={{
-              color: 'text.secondary',
-              fontWeight: 500,
-              fontSize: '0.8125rem',
-              px: 2,
-              borderRadius: '8px',
-              '&:hover': {
-                bgcolor: alpha(theme.palette.divider, 0.12),
-                color: 'text.primary',
-              },
-            }}
-          >
-            Cancel
-          </Button>
-        )}
-        <Button
-          type="submit"
-          form="project-form"
-          variant="contained"
-          loading={createProject.isPending}
-          disabled={isUploading}
-          onClick={handleSubmit(onSubmit)}
-          endIcon={<ArrowRight size={16} />}
+        {/* Live sidebar preview — how the project appears in the nav */}
+        <SidebarRowPreview
+          name={watch('name')}
+          icon={selectedIcon}
+          colorId={selectedColor}
+          imageUrl={displayImageUrl ?? undefined}
+          location={watch('location') ?? undefined}
+          organizationId={organizationId}
+        />
+
+        {/* Actions row */}
+        <Box
           sx={{
-            borderRadius: '8px',
-            fontWeight: 600,
-            fontSize: '0.8125rem',
-            px: 2.5,
-            py: 1,
-            textTransform: 'none',
-            boxShadow: `0 1px 3px ${alpha(theme.palette.primary.main, 0.3)}`,
-            ...(!onCancel && {
-              width: '100%',
-              py: 1.5,
-              fontSize: '0.9375rem',
-            }),
-            '&:hover': {
-              boxShadow: `0 4px 12px ${alpha(theme.palette.primary.main, 0.35)}`,
-            },
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 1,
+            mt: 2.25,
+            pt: 1.75,
+            borderTop: `1px solid ${theme.palette.divider}`,
           }}
         >
-          Create Project
-        </Button>
+          <Typography
+            sx={{
+              fontSize: '0.6875rem',
+              color: 'text.secondary',
+              display: { xs: 'none', sm: 'block' },
+              opacity: 0.85,
+              flexShrink: 1,
+              minWidth: 0,
+            }}
+          >
+            Drop an image anywhere to use as cover
+          </Typography>
+
+          <Box sx={{ display: 'flex', gap: 1, ml: 'auto', flexShrink: 0 }}>
+            {onCancel && (
+              <Button
+                variant="text"
+                onClick={handleCancel}
+                sx={{
+                  color: 'text.secondary',
+                  fontWeight: 500,
+                  fontSize: '0.8125rem',
+                  px: 2,
+                  borderRadius: '8px',
+                  whiteSpace: 'nowrap',
+                  '&:hover': {
+                    bgcolor: alpha(theme.palette.divider, 0.18),
+                    color: 'text.primary',
+                  },
+                }}
+              >
+                Cancel
+              </Button>
+            )}
+            <Button
+              type="submit"
+              form="project-form"
+              variant="contained"
+              loading={createProject.isPending}
+              disabled={isUploading}
+              onClick={handleSubmit(onSubmit)}
+              endIcon={<ArrowRight size={16} />}
+              sx={{
+                borderRadius: '8px',
+                fontWeight: 600,
+                fontSize: '0.8125rem',
+                px: 2.5,
+                py: 1,
+                textTransform: 'none',
+                whiteSpace: 'nowrap',
+                boxShadow: `0 1px 2px ${alpha(theme.palette.primary.main, 0.25)}`,
+                ...(!onCancel && {
+                  width: '100%',
+                  py: 1.5,
+                  fontSize: '0.9375rem',
+                }),
+                '& .MuiButton-endIcon': {
+                  transition: 'transform 0.15s ease',
+                },
+                '&:hover': {
+                  boxShadow: `0 4px 12px ${alpha(theme.palette.primary.main, 0.3)}`,
+                  '& .MuiButton-endIcon': { transform: 'translateX(3px)' },
+                },
+              }}
+            >
+              Create project
+            </Button>
+          </Box>
+        </Box>
       </Box>
     </>
   );

--- a/src/components/projects/SidebarRowPreview.tsx
+++ b/src/components/projects/SidebarRowPreview.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, useTheme, alpha } from '@mui/material';
+import {
+  MapPin,
+  Clock,
+  Sun,
+  Moon,
+  Cloud,
+  CloudRain,
+  CloudSnow,
+  CloudLightning,
+  CloudFog,
+  type Icon,
+} from '@phosphor-icons/react';
+import ProjectAvatar from '@/components/ui/ProjectAvatar';
+import { api } from '@/trpc/react';
+
+interface SidebarRowPreviewProps {
+  name?: string;
+  icon?: string;
+  colorId?: string;
+  imageUrl?: string;
+  location?: string;
+  organizationId?: string;
+}
+
+function getLocalTime(timezoneOffset: number): string {
+  const now = new Date();
+  const utcMs = now.getTime() + now.getTimezoneOffset() * 60_000;
+  const localDate = new Date(utcMs + timezoneOffset * 1000);
+  return localDate.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+}
+
+function getWeatherIcon(icon: string): { Icon: Icon; label: string } {
+  const code = icon.slice(0, 2);
+  switch (code) {
+    case '01': return icon.endsWith('n') ? { Icon: Moon, label: 'Clear' } : { Icon: Sun, label: 'Clear' };
+    case '02': return { Icon: Cloud, label: 'Partly cloudy' };
+    case '03': return { Icon: Cloud, label: 'Cloudy' };
+    case '04': return { Icon: Cloud, label: 'Overcast' };
+    case '09': return { Icon: CloudRain, label: 'Drizzle' };
+    case '10': return { Icon: CloudRain, label: 'Rain' };
+    case '11': return { Icon: CloudLightning, label: 'Thunderstorm' };
+    case '13': return { Icon: CloudSnow, label: 'Snow' };
+    case '50': return { Icon: CloudFog, label: 'Fog' };
+    default:   return { Icon: Cloud, label: 'Cloudy' };
+  }
+}
+
+function getWeatherTint(icon: string): string {
+  const code = icon.slice(0, 2);
+  switch (code) {
+    case '01': return 'rgba(251, 191, 36, 0.08)';
+    case '02': return 'rgba(251, 191, 36, 0.05)';
+    case '03':
+    case '04': return 'rgba(141, 153, 174, 0.1)';
+    case '09':
+    case '10': return 'rgba(37, 99, 235, 0.06)';
+    case '11': return 'rgba(107, 114, 128, 0.1)';
+    case '13': return 'rgba(141, 153, 174, 0.08)';
+    case '50': return 'rgba(141, 153, 174, 0.06)';
+    default:   return 'rgba(141, 153, 174, 0.08)';
+  }
+}
+
+const chipSx = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 0.625,
+  px: 1.25,
+  py: 0.5,
+  borderRadius: 'var(--radius-pill)',
+  bgcolor: 'action.hover',
+} as const;
+
+const labelSx = {
+  fontSize: '0.6875rem',
+  fontWeight: 500,
+  color: 'text.secondary',
+  lineHeight: 1,
+  whiteSpace: 'nowrap',
+} as const;
+
+export default function SidebarRowPreview({
+  name,
+  icon,
+  colorId,
+  imageUrl,
+  location,
+  organizationId,
+}: SidebarRowPreviewProps) {
+  const theme = useTheme();
+  const displayName = name?.trim() || 'Untitled project';
+
+  // Debounce location before querying so we don't fire on every keystroke
+  const [debouncedLocation, setDebouncedLocation] = useState('');
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedLocation(location?.trim() ?? ''), 800);
+    return () => clearTimeout(t);
+  }, [location]);
+
+  const { data: weather } = api.weather.getByLocation.useQuery(
+    { location: debouncedLocation, organizationId: organizationId ?? '' },
+    {
+      staleTime: 5 * 60 * 1000,
+      enabled: debouncedLocation.length > 3 && !!organizationId,
+    },
+  );
+
+  const [localTime, setLocalTime] = useState<string | null>(null);
+  useEffect(() => {
+    if (weather?.timezoneOffset == null) { setLocalTime(null); return; }
+    setLocalTime(getLocalTime(weather.timezoneOffset));
+    const interval = setInterval(() => setLocalTime(getLocalTime(weather.timezoneOffset)), 60_000);
+    return () => clearInterval(interval);
+  }, [weather?.timezoneOffset]);
+
+  const weatherInfo = weather ? getWeatherIcon(weather.icon) : null;
+  const shortLocation = debouncedLocation.length > 28
+    ? debouncedLocation.slice(0, 26) + '…'
+    : debouncedLocation;
+
+  return (
+    <Box sx={{ mt: 2.5 }}>
+      <Typography
+        sx={{
+          fontSize: '0.625rem',
+          fontWeight: 600,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          color: 'text.secondary',
+          mb: 0.75,
+        }}
+      >
+        Preview
+      </Typography>
+
+      {/* Mock sidebar frame */}
+      <Box
+        aria-hidden
+        sx={{
+          bgcolor: theme.palette.mode === 'dark' ? 'sidebar.background' : 'background.default',
+          border: `1px solid ${theme.palette.divider}`,
+          borderRadius: '10px',
+          p: 0.75,
+        }}
+      >
+        {/* Active project row */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.25,
+            px: 1.25,
+            py: 0.875,
+            borderRadius: '8px',
+            bgcolor: alpha(theme.palette.text.primary, 0.05),
+            position: 'relative',
+          }}
+        >
+          {/* Active accent bar */}
+          <Box
+            aria-hidden
+            sx={{
+              position: 'absolute',
+              left: 0,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              width: '2.5px',
+              height: 16,
+              borderRadius: '0 2px 2px 0',
+              bgcolor: 'sidebar.indicator',
+            }}
+          />
+          <ProjectAvatar
+            imageUrl={imageUrl ?? null}
+            icon={icon}
+            colorId={imageUrl ? null : colorId}
+            size={22}
+            borderRadius="6px"
+          />
+          <Typography
+            sx={{
+              fontSize: '0.8125rem',
+              fontWeight: 550,
+              letterSpacing: '-0.005em',
+              color: name?.trim() ? 'text.primary' : 'text.secondary',
+              fontStyle: name?.trim() ? 'normal' : 'italic',
+              lineHeight: 1,
+              flex: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {displayName}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Weather / time pills — appear once location is typed */}
+      {!!debouncedLocation && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.75,
+            flexWrap: 'wrap',
+            mt: 1,
+            '@keyframes fadeUp': {
+              from: { opacity: 0, transform: 'translateY(4px)' },
+              to: { opacity: 1, transform: 'translateY(0)' },
+            },
+            animation: 'fadeUp 0.22s ease',
+          }}
+        >
+          {/* Location chip */}
+          <Box sx={chipSx}>
+            <MapPin size={11} weight="bold" style={{ flexShrink: 0, opacity: 0.55 }} />
+            <Typography sx={labelSx}>{shortLocation}</Typography>
+          </Box>
+
+          {/* Weather chip */}
+          {weather && weatherInfo && (
+            <Box
+              sx={{
+                ...chipSx,
+                bgcolor: getWeatherTint(weather.icon),
+                '@keyframes fadeIn': { from: { opacity: 0 }, to: { opacity: 1 } },
+                animation: 'fadeIn 0.3s ease',
+              }}
+            >
+              <weatherInfo.Icon size={11} weight="bold" style={{ flexShrink: 0, opacity: 0.65 }} />
+              <Typography
+                sx={{
+                  ...labelSx,
+                  fontWeight: 600,
+                  fontVariantNumeric: 'tabular-nums',
+                  letterSpacing: '-0.01em',
+                }}
+              >
+                {weather.temp}°F
+              </Typography>
+              <Typography
+                sx={{
+                  ...labelSx,
+                  fontSize: '0.625rem',
+                  fontWeight: 400,
+                }}
+              >
+                {weatherInfo.label}
+              </Typography>
+            </Box>
+          )}
+
+          {/* Time chip */}
+          {localTime && (
+            <Box
+              sx={{
+                ...chipSx,
+                '@keyframes fadeIn': { from: { opacity: 0 }, to: { opacity: 1 } },
+                animation: 'fadeIn 0.3s ease',
+              }}
+            >
+              <Clock size={11} weight="bold" style={{ flexShrink: 0, opacity: 0.5 }} />
+              <Typography sx={{ ...labelSx, fontVariantNumeric: 'tabular-nums' }}>
+                {localTime}
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/components/ui/ProjectAvatar.tsx
+++ b/src/components/ui/ProjectAvatar.tsx
@@ -1,25 +1,31 @@
 'use client';
 
 import { useState } from 'react';
-import { Box } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 import { getProjectIcon } from '@/lib/constants/projectIconComponents';
+import { resolveColorTint } from '@/lib/constants/projectColors';
 
 interface ProjectAvatarProps {
   imageUrl?: string | null;
   icon?: string;
+  /** Optional color id from VALID_PROJECT_COLORS. When set (and no image), the icon renders inside a tinted square. */
+  colorId?: string | null;
   size: number;
   borderRadius?: number | string;
+  /** Override the icon foreground color. Ignored when colorId is set. */
   color?: string;
 }
 
 export default function ProjectAvatar({
   imageUrl,
   icon,
+  colorId,
   size,
   borderRadius = 3,
   color,
 }: ProjectAvatarProps) {
   const [imgError, setImgError] = useState(false);
+  const theme = useTheme();
 
   if (imageUrl && !imgError) {
     return (
@@ -40,5 +46,28 @@ export default function ProjectAvatar({
   }
 
   const Icon = getProjectIcon(icon);
+
+  if (colorId) {
+    const tint = resolveColorTint(colorId, theme.palette.mode);
+    return (
+      <Box
+        sx={{
+          width: size,
+          height: size,
+          borderRadius,
+          bgcolor: tint.bg,
+          color: tint.fg,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+          transition: 'background-color 0.2s ease, color 0.2s ease',
+        }}
+      >
+        <Icon size={Math.round(size * 0.55)} />
+      </Box>
+    );
+  }
+
   return <Icon size={size} style={{ color, flexShrink: 0 }} />;
 }

--- a/src/lib/constants/projectColors.ts
+++ b/src/lib/constants/projectColors.ts
@@ -1,0 +1,102 @@
+export const VALID_PROJECT_COLORS = [
+  'slate',
+  'emerald',
+  'blue',
+  'amber',
+  'rose',
+  'violet',
+] as const;
+
+export type ProjectColor = (typeof VALID_PROJECT_COLORS)[number];
+
+export interface ProjectColorTokens {
+  id: ProjectColor;
+  label: string;
+  /** Solid swatch color used in the picker dot. */
+  swatch: string;
+  /** Foreground (icon/text) color used on tinted background — light mode. */
+  tintLight: string;
+  /** Tinted background — light mode. */
+  tintBgLight: string;
+  /** Foreground — dark mode. */
+  tintDark: string;
+  /** Tinted background — dark mode. */
+  tintBgDark: string;
+}
+
+export const PROJECT_COLOR_OPTIONS: ProjectColorTokens[] = [
+  {
+    id: 'slate',
+    label: 'Slate',
+    swatch: '#2B2D42',
+    tintLight: '#2B2D42',
+    tintBgLight: 'rgba(43,45,66,0.08)',
+    tintDark: '#cbd5e1',
+    tintBgDark: 'rgba(203,213,225,0.10)',
+  },
+  {
+    id: 'emerald',
+    label: 'Emerald',
+    swatch: '#047857',
+    tintLight: '#047857',
+    tintBgLight: '#D1FAE5',
+    tintDark: '#34d399',
+    tintBgDark: 'rgba(52,211,153,0.14)',
+  },
+  {
+    id: 'blue',
+    label: 'Blue',
+    swatch: '#1d4ed8',
+    tintLight: '#1d4ed8',
+    tintBgLight: '#DBEAFE',
+    tintDark: '#60a5fa',
+    tintBgDark: 'rgba(96,165,250,0.16)',
+  },
+  {
+    id: 'amber',
+    label: 'Amber',
+    swatch: '#b45309',
+    tintLight: '#b45309',
+    tintBgLight: '#FEF3C7',
+    tintDark: '#fbbf24',
+    tintBgDark: 'rgba(251,191,36,0.14)',
+  },
+  {
+    id: 'rose',
+    label: 'Rose',
+    swatch: '#be123c',
+    tintLight: '#be123c',
+    tintBgLight: '#FFE4E6',
+    tintDark: '#fb7185',
+    tintBgDark: 'rgba(251,113,133,0.14)',
+  },
+  {
+    id: 'violet',
+    label: 'Violet',
+    swatch: '#6d28d9',
+    tintLight: '#6d28d9',
+    tintBgLight: '#EDE9FE',
+    tintDark: '#a78bfa',
+    tintBgDark: 'rgba(167,139,250,0.16)',
+  },
+];
+
+const COLOR_MAP: Record<string, ProjectColorTokens> = Object.fromEntries(
+  PROJECT_COLOR_OPTIONS.map((c) => [c.id, c])
+);
+
+export function getProjectColor(colorId?: string | null): ProjectColorTokens {
+  if (!colorId) return COLOR_MAP.slate!;
+  return COLOR_MAP[colorId] ?? COLOR_MAP.slate!;
+}
+
+/** Returns the right tint pair for the current theme mode. */
+export function resolveColorTint(
+  colorId: string | null | undefined,
+  mode: 'light' | 'dark',
+): { fg: string; bg: string } {
+  const c = getProjectColor(colorId);
+  return mode === 'dark'
+    ? { fg: c.tintDark, bg: c.tintBgDark }
+    : { fg: c.tintLight, bg: c.tintBgLight };
+}

--- a/src/lib/validations/project.ts
+++ b/src/lib/validations/project.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
 import { VALID_PROJECT_ICONS } from "@/lib/constants/projectIcons";
+import { VALID_PROJECT_COLORS } from "@/lib/constants/projectColors";
 
 export const createProjectSchema = z.object({
   name: z.string().min(1, "Project name is required").max(100).trim(),
   location: z.string().min(1, "Location is required").max(200).trim(),
   icon: z.enum(VALID_PROJECT_ICONS).default("building").optional(),
+  color: z.enum(VALID_PROJECT_COLORS).optional(),
   imageUrl: z.string().url().optional(),
   template: z.enum(["BLANK"]).default("BLANK").optional(),
 });
@@ -12,7 +14,7 @@ export const createProjectSchema = z.object({
 export type CreateProjectInput = z.infer<typeof createProjectSchema>;
 
 export const updateProjectSchema = createProjectSchema
-  .pick({ name: true, location: true, icon: true, imageUrl: true })
+  .pick({ name: true, location: true, icon: true, color: true, imageUrl: true })
   .partial()
   .extend({ location: z.string().max(200).trim().optional() })
   .strict();

--- a/src/lib/validations/projectMember.ts
+++ b/src/lib/validations/projectMember.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { ASSIGNABLE_ROLES } from "./invitation";
+
+export const bulkAddProjectMembersSchema = z.object({
+  members: z
+    .array(
+      z.object({
+        userId: z.string(),
+        role: z.enum(ASSIGNABLE_ROLES, {
+          errorMap: () => ({ message: "Please select a valid role" }),
+        }),
+      })
+    )
+    .min(1, "Select at least one teammate"),
+});
+
+export type BulkAddProjectMembersInput = z.infer<
+  typeof bulkAddProjectMembersSchema
+>;

--- a/src/server/api/routers/projectMember.ts
+++ b/src/server/api/routers/projectMember.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, projectProcedure } from "@/server/api/trpc";
-import { canRemoveMembers, canAssignRole } from "@/lib/permissions";
+import {
+  canInviteMembers,
+  canRemoveMembers,
+  canAssignRole,
+} from "@/lib/permissions";
+import { bulkAddProjectMembersSchema } from "@/lib/validations/projectMember";
 
 export const projectMemberRouter = createTRPCRouter({
   list: projectProcedure.query(async ({ ctx, input }) => {
@@ -71,5 +76,53 @@ export const projectMemberRouter = createTRPCRouter({
       });
 
       return { success: true };
+    }),
+
+  bulkAdd: projectProcedure
+    .input(bulkAddProjectMembersSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!canInviteMembers(ctx.projectMember.role)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have permission to add members to this project",
+        });
+      }
+
+      for (const member of input.members) {
+        if (!canAssignRole(ctx.projectMember.role, member.role)) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Cannot assign a role equal to or above your own",
+          });
+        }
+      }
+
+      const userIds = input.members.map((m) => m.userId);
+      const memberships = await ctx.db.membership.findMany({
+        where: {
+          organizationId: ctx.organization.id,
+          userId: { in: userIds },
+        },
+        select: { userId: true },
+      });
+      const validUserIds = new Set(memberships.map((m) => m.userId));
+      const invalidIds = userIds.filter((id) => !validUserIds.has(id));
+      if (invalidIds.length > 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "One or more users are not members of this organization",
+        });
+      }
+
+      const result = await ctx.db.projectMember.createMany({
+        data: input.members.map((m) => ({
+          userId: m.userId,
+          projectId: ctx.project.id,
+          role: m.role,
+        })),
+        skipDuplicates: true,
+      });
+
+      return { added: result.count };
     }),
 });

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,4 +1,4 @@
-import { createTheme, type Theme } from '@mui/material/styles';
+import { createTheme, alpha, type Theme } from '@mui/material/styles';
 
 // Light theme — matches construction.pen $--variable tokens (3rd iteration)
 export const lightTheme: Theme = createTheme({
@@ -105,6 +105,27 @@ export const lightTheme: Theme = createTheme({
           '&.MuiButton-sizeLarge .MuiButton-startIcon svg, &.MuiButton-sizeLarge .MuiButton-endIcon svg': { width: 18, height: 18 },
           '&.MuiButton-sizeSmall .MuiButton-startIcon svg, &.MuiButton-sizeSmall .MuiButton-endIcon svg': { width: 14, height: 14 },
         },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          transition: 'box-shadow 0.15s ease',
+          '& .MuiOutlinedInput-notchedOutline': {
+            borderColor: theme.palette.divider,
+            transition: 'border-color 0.15s ease',
+          },
+          '&:hover:not(.Mui-disabled) .MuiOutlinedInput-notchedOutline': {
+            borderColor: alpha(theme.palette.text.primary, 0.32),
+          },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: theme.palette.primary.main,
+            borderWidth: '1.5px',
+          },
+          '&.Mui-focused': {
+            boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
+          },
+        }),
       },
     },
   },
@@ -368,6 +389,27 @@ export const darkTheme: Theme = createTheme({
           '&.MuiButton-sizeLarge .MuiButton-startIcon svg, &.MuiButton-sizeLarge .MuiButton-endIcon svg': { width: 18, height: 18 },
           '&.MuiButton-sizeSmall .MuiButton-startIcon svg, &.MuiButton-sizeSmall .MuiButton-endIcon svg': { width: 14, height: 14 },
         },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          transition: 'box-shadow 0.15s ease',
+          '& .MuiOutlinedInput-notchedOutline': {
+            borderColor: theme.palette.divider,
+            transition: 'border-color 0.15s ease',
+          },
+          '&:hover:not(.Mui-disabled) .MuiOutlinedInput-notchedOutline': {
+            borderColor: alpha(theme.palette.text.primary, 0.32),
+          },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: theme.palette.primary.main,
+            borderWidth: '1.5px',
+          },
+          '&.Mui-focused': {
+            boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.08)}`,
+          },
+        }),
       },
     },
   },

--- a/tests/team/no-project-prompt.spec.ts
+++ b/tests/team/no-project-prompt.spec.ts
@@ -30,8 +30,10 @@ test.describe("No project prompt (inline)", () => {
     await page.getByRole("button", { name: "Create Project" }).click();
 
     // AddProjectDialog should open
-    await expect(page.getByText("New Project")).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("Set up a new construction project")).toBeVisible();
+    await expect(page.getByText("New project")).toBeVisible({ timeout: 5000 });
+    await expect(
+      page.getByText("Track schedule, documents and team in one place.")
+    ).toBeVisible();
   });
 
   test("no redirect to /new-project when org has no projects", async ({


### PR DESCRIPTION
## Summary
- Replaces the single-screen Add Project dialog with a 2-step flow: project identity (name, color, icon/photo, location with live sidebar preview) followed by an optional bulk-add teammates step backed by a new `projectMember.bulkAdd` tRPC procedure.
- Adds a `Project.color` field (slate / emerald / blue / amber / rose / violet) with a tinted-icon `ProjectAvatar` system used across the create form, project switcher, and sidebar preview.
- Centralizes outlined-input styling in the MUI theme so the auth pages and project settings drop their per-field `sx` overrides; documents the rule in `components-guide.md`.

## Test plan
- [ ] `npm run typecheck`
- [ ] `npx vitest run src/__tests__/projects/`
- [ ] Create a project from the org dropdown — confirm step 2 appears when the org has other members and is skipped when solo
- [ ] Switch color swatches and verify the avatar tint flips correctly in light + dark mode
- [ ] Drop an image anywhere on the create dialog and confirm it uploads as the cover

🤖 Generated with [Claude Code](https://claude.com/claude-code)