### PR TITLE
Move identity menu to header and add breadcrumb navigation

### DIFF
--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import Link from 'next/link';
+import { useParams, usePathname } from 'next/navigation';
+import { Box, Typography } from '@mui/material';
+import ProjectSwitcher from './ProjectSwitcher';
+import { projectNavItems } from './navItems';
+
+const PROJECT_PAGE_LABELS: Record<string, string> = Object.fromEntries(
+  projectNavItems.map((item) => [item.segment, item.label]),
+);
+
+function getTrailingLabel(segment: string | undefined): string | null {
+  if (!segment) return null;
+  return PROJECT_PAGE_LABELS[segment] ?? null;
+}
+
+export default function Breadcrumb() {
+  const params = useParams<{ orgSlug?: string; projectSlug?: string }>();
+  const pathname = usePathname();
+  const { orgSlug, projectSlug } = params;
+
+  // Determine the trailing page segment. For project routes, it's the segment after [projectSlug].
+  // For org-root, there is no trailing segment.
+  const segments = pathname.split('/').filter(Boolean);
+  const projectIdx = segments.indexOf('projects');
+  const trailingSegment =
+    projectIdx >= 0 && projectSlug ? segments[projectIdx + 2] : undefined;
+  const trailingLabel = getTrailingLabel(trailingSegment);
+
+  // Org root — show a single static "Dashboard" crumb.
+  if (!projectSlug) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
+        <Typography
+          sx={{
+            fontSize: '14.5px',
+            fontWeight: 600,
+            color: 'text.primary',
+            lineHeight: 1,
+            letterSpacing: '-0.005em',
+            px: 1,
+            py: 0.75,
+            userSelect: 'none',
+          }}
+        >
+          Dashboard
+        </Typography>
+      </Box>
+    );
+  }
+
+  // Inside a project — render: Projects / [Project chip] / [trailing static label?]
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.125, minWidth: 0 }}>
+      {/* "Projects" crumb — links back to the org root for now (will retarget to /projects in Phase 2) */}
+      <Box
+        component={Link}
+        href={`/${orgSlug}`}
+        sx={{
+          fontSize: '14.5px',
+          color: 'text.secondary',
+          textDecoration: 'none',
+          px: 1,
+          py: 0.75,
+          borderRadius: '6px',
+          lineHeight: 1,
+          transition: 'background-color 0.15s, color 0.15s',
+          '&:hover': {
+            bgcolor: 'action.hover',
+            color: 'text.primary',
+          },
+        }}
+      >
+        Projects
+      </Box>
+
+      <Separator />
+
+      {/* Active project chip — outlined button that opens the project switcher */}
+      <ProjectSwitcher />
+
+      {trailingLabel && (
+        <>
+          <Separator />
+          <Typography
+            sx={{
+              fontSize: '14.5px',
+              fontWeight: 600,
+              color: 'text.primary',
+              lineHeight: 1,
+              letterSpacing: '-0.005em',
+              px: 1,
+              py: 0.75,
+              userSelect: 'none',
+            }}
+          >
+            {trailingLabel}
+          </Typography>
+        </>
+      )}
+    </Box>
+  );
+}
+
+function Separator() {
+  return (
+    <Typography
+      component="span"
+      aria-hidden="true"
+      sx={{
+        color: 'text.disabled',
+        fontSize: '17px',
+        fontWeight: 300,
+        lineHeight: 1,
+        userSelect: 'none',
+      }}
+    >
+      /
+    </Typography>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { usePathname } from 'next/navigation';
-import { Bell, UserPlus, List } from '@phosphor-icons/react';
+import { Bell, UserPlus, List as ListIcon } from '@phosphor-icons/react';
 import { Box, Typography, IconButton, Divider } from '@mui/material';
 import { Button } from '@/components/ui/button';
 import {
@@ -16,17 +15,9 @@ import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
 import { useNotifications } from '@/hooks/useNotifications';
 import { useNavigationLoading } from '@/hooks/useNavigationLoading';
 import { useProjectSwitcher } from '@/hooks/useProjectSwitcher';
-import { api } from '@/trpc/react';
-import ProjectSwitcher from './ProjectSwitcher';
+import Breadcrumb from './Breadcrumb';
+import IdentityMenu from './IdentityMenu';
 import LocationWeather from './LocationWeather';
-
-const PAGE_TITLES: Record<string, string> = {
-  gantt: 'Timeline',
-  files: 'Tree',
-  'document-explorer': 'Document Explorer',
-  team: 'Team',
-  settings: 'Project Settings',
-};
 
 interface HeaderProps {
   onMenuOpen?: () => void;
@@ -34,164 +25,168 @@ interface HeaderProps {
 
 export default function Header({ onMenuOpen }: HeaderProps) {
   const [notifMenuOpen, setNotifMenuOpen] = useState(false);
-  const pathname = usePathname();
 
   useNavigationLoading();
   const { activeOrganizationId, orgSlug } = useOrgFromUrl();
   const { currentProject } = useProjectSwitcher(activeOrganizationId, orgSlug);
 
-  const lastSegment = pathname.split('/').pop() ?? '';
-  const pageTitle = PAGE_TITLES[lastSegment] ?? null;
   const { unreadCount, notificationsData, markAsRead, markAllAsRead } = useNotifications(
     activeOrganizationId,
-    notifMenuOpen
+    notifMenuOpen,
   );
 
   return (
     <Box
       component="header"
       sx={{
-        px: 3,
-        pt: 1.5,
-        pb: 1,
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 0.75,
+        height: 60,
         flexShrink: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 2,
+        px: { xs: 2, md: 2.5 },
+        bgcolor: 'background.paper',
+        borderBottom: '1px solid',
+        borderColor: 'divider',
       }}
     >
-      {/* Row 1: Navigation + Location/Weather + Notifications */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, width: '100%' }}>
+      {/* Left: mobile menu button + breadcrumb */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0, flex: 1 }}>
         {onMenuOpen && (
           <IconButton
             onClick={onMenuOpen}
             aria-label="Open menu"
-            sx={{ display: { xs: 'inline-flex', md: 'none' }, p: 0.5, '&:hover': { opacity: 0.7 } }}
-          >
-            <List size={20} weight="bold" />
-          </IconButton>
-        )}
-        {pageTitle && (
-          <>
-            <Typography sx={{ fontSize: 18, fontWeight: 700, color: 'text.primary', lineHeight: 1 }}>
-              {pageTitle}
-            </Typography>
-            <Typography sx={{ color: 'text.disabled', fontSize: 16, lineHeight: 1, userSelect: 'none' }}>·</Typography>
-          </>
-        )}
-        <ProjectSwitcher />
-
-        {/* Spacer */}
-        <Box sx={{ flex: 1 }} />
-
-        {/* Location/Weather pill — right side of Row 1 */}
-        {currentProject?.location && activeOrganizationId && (
-          <LocationWeather location={currentProject.location} organizationId={activeOrganizationId} />
-        )}
-
-        {/* Notifications Bell */}
-      <DropdownMenu open={notifMenuOpen} onOpenChange={setNotifMenuOpen}>
-        <DropdownMenuTrigger asChild>
-          <IconButton
-            aria-label="Notifications"
             sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '50%',
-              position: 'relative',
+              display: { xs: 'inline-flex', md: 'none' },
+              p: 0.75,
               color: 'text.secondary',
-              bgcolor: 'action.hover',
-              '&:hover': { bgcolor: 'divider' },
+              '&:hover': { color: 'text.primary' },
             }}
           >
-            <Bell size={18} weight="regular" />
-            {unreadCount > 0 && (
-              <Box
-                sx={{
-                  position: 'absolute',
-                  top: -2,
-                  right: -2,
-                  minWidth: 18,
-                  height: 18,
-                  bgcolor: 'primary.main',
-                  borderRadius: '50%',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontSize: 10,
-                  fontWeight: 700,
-                  color: 'white',
-                  px: 0.375,
-                  lineHeight: 1,
-                }}
-              >
-                {unreadCount > 9 ? '9+' : unreadCount}
-              </Box>
-            )}
+            <ListIcon size={20} weight="bold" />
           </IconButton>
-        </DropdownMenuTrigger>
-
-        <DropdownMenuContent align="end" className="w-80" style={{ maxHeight: 400, overflow: 'auto' }}>
-          <Box sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <Typography sx={{ fontSize: 14, fontWeight: 600 }}>Notifications</Typography>
-            {unreadCount > 0 && (
-              <Button
-                variant="text"
-                size="small"
-                onClick={() => markAllAsRead.mutate({ organizationId: activeOrganizationId })}
-                loading={markAllAsRead.isPending}
-                loadingPosition="start"
-                sx={{ fontSize: 12 }}
-              >
-                Mark all read
-              </Button>
-            )}
-          </Box>
-          <Divider />
-          {notificationsData?.notifications && notificationsData.notifications.length > 0 ? (
-            notificationsData.notifications.map((n) => (
-              <DropdownMenuItem
-                key={n.id}
-                onClick={() => {
-                  if (!n.read) markAsRead.mutate({ organizationId: activeOrganizationId, ids: [n.id] });
-                }}
-              >
-                <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'flex-start', width: '100%', p: 1.5 }}>
-                  <Box
-                    sx={{
-                      width: 32,
-                      height: 32,
-                      borderRadius: '50%',
-                      bgcolor: 'primary.main',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      flexShrink: 0,
-                    }}
-                  >
-                    <UserPlus size={16} weight="regular" color="white" />
-                  </Box>
-                  <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <Typography sx={{ fontSize: 13, mb: 0.5 }}>{n.message}</Typography>
-                    <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>
-                      {formatDistanceToNow(new Date(n.createdAt), { addSuffix: true })}
-                    </Typography>
-                  </Box>
-                  {!n.read && (
-                    <Box sx={{ width: 8, height: 8, bgcolor: 'primary.main', borderRadius: '50%', flexShrink: 0, mt: 0.5 }} />
-                  )}
-                </Box>
-              </DropdownMenuItem>
-            ))
-          ) : (
-            <Box sx={{ p: 4, textAlign: 'center' }}>
-              <Typography sx={{ fontSize: 13, color: 'text.secondary' }}>No notifications</Typography>
-            </Box>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
+        )}
+        <Breadcrumb />
       </Box>
 
+      {/* Right: weather (when applicable) + notifications + identity */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        {currentProject?.location && activeOrganizationId && (
+          <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
+            <LocationWeather
+              location={currentProject.location}
+              organizationId={activeOrganizationId}
+            />
+          </Box>
+        )}
+
+        {/* Notifications */}
+        <DropdownMenu open={notifMenuOpen} onOpenChange={setNotifMenuOpen}>
+          <DropdownMenuTrigger asChild>
+            <IconButton
+              aria-label="Notifications"
+              sx={{
+                width: 36,
+                height: 36,
+                borderRadius: '8px',
+                position: 'relative',
+                color: 'text.secondary',
+                '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
+              }}
+            >
+              <Bell size={18} weight="regular" />
+              {unreadCount > 0 && (
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    top: 6,
+                    right: 6,
+                    minWidth: 8,
+                    height: 8,
+                    bgcolor: 'error.main',
+                    borderRadius: '50%',
+                    border: '1.5px solid',
+                    borderColor: 'background.paper',
+                  }}
+                />
+              )}
+            </IconButton>
+          </DropdownMenuTrigger>
+
+          <DropdownMenuContent align="end" className="w-80" style={{ maxHeight: 400, overflow: 'auto' }}>
+            <Box sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <Typography sx={{ fontSize: 14, fontWeight: 600 }}>Notifications</Typography>
+              {unreadCount > 0 && (
+                <Button
+                  variant="text"
+                  size="small"
+                  onClick={() => markAllAsRead.mutate({ organizationId: activeOrganizationId })}
+                  loading={markAllAsRead.isPending}
+                  loadingPosition="start"
+                  sx={{ fontSize: 12 }}
+                >
+                  Mark all read
+                </Button>
+              )}
+            </Box>
+            <Divider />
+            {notificationsData?.notifications && notificationsData.notifications.length > 0 ? (
+              notificationsData.notifications.map((n) => (
+                <DropdownMenuItem
+                  key={n.id}
+                  onClick={() => {
+                    if (!n.read) markAsRead.mutate({ organizationId: activeOrganizationId, ids: [n.id] });
+                  }}
+                >
+                  <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'flex-start', width: '100%', p: 1.5 }}>
+                    <Box
+                      sx={{
+                        width: 32,
+                        height: 32,
+                        borderRadius: '50%',
+                        bgcolor: 'primary.main',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flexShrink: 0,
+                      }}
+                    >
+                      <UserPlus size={16} weight="regular" color="white" />
+                    </Box>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography sx={{ fontSize: 13, mb: 0.5 }}>{n.message}</Typography>
+                      <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>
+                        {formatDistanceToNow(new Date(n.createdAt), { addSuffix: true })}
+                      </Typography>
+                    </Box>
+                    {!n.read && (
+                      <Box sx={{ width: 8, height: 8, bgcolor: 'primary.main', borderRadius: '50%', flexShrink: 0, mt: 0.5 }} />
+                    )}
+                  </Box>
+                </DropdownMenuItem>
+              ))
+            ) : (
+              <Box sx={{ p: 4, textAlign: 'center' }}>
+                <Typography sx={{ fontSize: 13, color: 'text.secondary' }}>No notifications</Typography>
+              </Box>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Vertical divider between bell and identity */}
+        <Box
+          sx={{
+            width: '1px',
+            height: 22,
+            bgcolor: 'divider',
+            mx: 0.5,
+          }}
+        />
+
+        {/* Identity menu */}
+        <IdentityMenu />
+      </Box>
     </Box>
   );
 }

--- a/src/components/layout/IdentityMenu.tsx
+++ b/src/components/layout/IdentityMenu.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { GearSix, SignOut, Sun, Moon } from '@phosphor-icons/react';
+import { Box, Typography, Switch } from '@mui/material';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { authClient, signOut } from '@/lib/auth-client';
+import UserAvatar from '@/components/ui/UserAvatar';
+import { useLoading } from '@/components/providers/LoadingProvider';
+import { useThemeMode } from '@/components/providers/ThemeRegistry';
+import AccountSettingsModal from './AccountSettingsModal';
+
+export default function IdentityMenu() {
+  const router = useRouter();
+  const { showLoading, hideLoading } = useLoading();
+  const { mode: themeMode, toggleMode: toggleThemeMode } = useThemeMode();
+  const { data: session } = authClient.useSession();
+  const user = session?.user;
+
+  const [open, setOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const handleLogout = async () => {
+    setIsLoggingOut(true);
+    showLoading('Logging out...');
+    try {
+      await signOut({
+        fetchOptions: {
+          onSuccess: () => {
+            hideLoading();
+            setOpen(false);
+            router.push('/sign-in');
+            router.refresh();
+          },
+        },
+      });
+    } catch (error) {
+      console.error('Logout failed:', error);
+      setIsLoggingOut(false);
+      hideLoading();
+    }
+  };
+
+  return (
+    <>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger asChild>
+          <Box
+            component="button"
+            aria-label="Open account menu"
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.25,
+              pl: 0.5,
+              pr: 1.25,
+              py: 0.5,
+              border: 'none',
+              bgcolor: 'transparent',
+              color: 'text.primary',
+              cursor: 'pointer',
+              borderRadius: '9px',
+              transition: 'background-color 0.15s',
+              '&:hover': { bgcolor: 'action.hover' },
+            }}
+          >
+            {user && <UserAvatar user={user} size={32} borderRadius="8px" />}
+            <Box
+              sx={{
+                display: { xs: 'none', md: 'flex' },
+                flexDirection: 'column',
+                alignItems: 'flex-start',
+                minWidth: 0,
+                gap: '2px',
+                lineHeight: 1.2,
+              }}
+            >
+              <Typography
+                sx={{
+                  fontSize: '0.8125rem',
+                  fontWeight: 600,
+                  color: 'text.primary',
+                  lineHeight: 1.2,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  maxWidth: 160,
+                }}
+              >
+                {user?.name ?? 'User'}
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: '0.6875rem',
+                  color: 'text.secondary',
+                  lineHeight: 1.2,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  maxWidth: 160,
+                }}
+              >
+                {user?.email ?? ''}
+              </Typography>
+            </Box>
+          </Box>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent
+          align="end"
+          sideOffset={8}
+          slotProps={{
+            paper: {
+              sx: {
+                width: 260,
+                padding: 0,
+                overflow: 'hidden',
+                borderRadius: '12px',
+                mt: 0.5,
+              },
+            },
+          }}
+        >
+          {/* Profile Header */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, p: '14px' }}>
+            {user && <UserAvatar user={user} size={36} borderRadius="8px" />}
+            <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 }}>
+              <Typography
+                sx={{
+                  fontSize: '0.8125rem',
+                  fontWeight: 600,
+                  color: 'text.primary',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  lineHeight: 1.2,
+                }}
+              >
+                {user?.name ?? 'User'}
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: '0.6875rem',
+                  color: 'text.secondary',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  lineHeight: 1.2,
+                  mt: '2px',
+                }}
+              >
+                {user?.email ?? ''}
+              </Typography>
+            </Box>
+          </Box>
+
+          <Box sx={{ height: '1px', bgcolor: 'divider' }} />
+
+          {/* Menu Items */}
+          <Box sx={{ py: '4px', px: '6px' }}>
+            <Box
+              component="button"
+              onClick={() => {
+                setOpen(false);
+                setSettingsOpen(true);
+              }}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '10px',
+                width: '100%',
+                px: '10px',
+                py: '8px',
+                borderRadius: '8px',
+                border: 'none',
+                bgcolor: 'transparent',
+                color: 'text.primary',
+                cursor: 'pointer',
+                transition: 'background-color 0.15s',
+                '&:hover': { bgcolor: 'action.hover' },
+              }}
+            >
+              <GearSix size={14} />
+              <Typography sx={{ fontSize: '0.8125rem', color: 'inherit' }}>
+                Account Settings
+              </Typography>
+            </Box>
+
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '10px',
+                width: '100%',
+                px: '10px',
+                py: '6px',
+              }}
+            >
+              {themeMode === 'dark' ? (
+                <Sun size={14} color="var(--text-secondary)" />
+              ) : (
+                <Moon size={14} color="var(--text-secondary)" />
+              )}
+              <Typography sx={{ fontSize: '0.8125rem', color: 'text.primary', flex: 1 }}>
+                Dark mode
+              </Typography>
+              <Switch
+                checked={themeMode === 'dark'}
+                onChange={toggleThemeMode}
+                size="small"
+                sx={{
+                  '& .MuiSwitch-switchBase.Mui-checked': { color: 'primary.main' },
+                  '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+                    bgcolor: 'primary.main',
+                  },
+                }}
+              />
+            </Box>
+          </Box>
+
+          <Box sx={{ height: '1px', bgcolor: 'divider' }} />
+
+          {/* Log Out */}
+          <Box
+            component="button"
+            onClick={handleLogout}
+            disabled={isLoggingOut}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '10px',
+              width: '100%',
+              px: '14px',
+              py: '10px',
+              border: 'none',
+              bgcolor: 'transparent',
+              cursor: 'pointer',
+              color: 'error.main',
+              transition: 'background-color 0.15s',
+              '&:hover': { bgcolor: 'action.hover' },
+              '&:disabled': { opacity: 0.5, cursor: 'not-allowed' },
+            }}
+          >
+            <SignOut size={14} />
+            <Typography sx={{ fontSize: '0.8125rem', fontWeight: 500, color: 'inherit' }}>
+              Log out
+            </Typography>
+          </Box>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AccountSettingsModal open={settingsOpen} onOpenChange={setSettingsOpen} />
+    </>
+  );
+}

--- a/src/components/layout/ProjectSwitcher.tsx
+++ b/src/components/layout/ProjectSwitcher.tsx
@@ -49,32 +49,63 @@ export default function ProjectSwitcher() {
     setSearch('');
   };
 
+  const hasProject = !!(projectSlug && currentProject);
+
   return (
     <>
       <ButtonBase
         onClick={(e) => setAnchorEl(e.currentTarget)}
         sx={{
-          display: 'flex',
+          display: 'inline-flex',
           alignItems: 'center',
-          gap: '6px',
-          px: 1,
-          py: 0.5,
+          gap: 1,
+          pl: 0.75,
+          pr: 1,
+          py: 0.875,
+          bgcolor: 'background.paper',
+          border: '1px solid',
+          borderColor: 'divider',
           borderRadius: '8px',
-          transition: 'background-color 0.15s',
-          '&:hover': { bgcolor: 'action.selected' },
+          boxShadow: '0 1px 2px rgba(0,0,0,0.03)',
+          transition: 'background-color 0.15s, border-color 0.15s, box-shadow 0.15s',
+          color: 'text.primary',
+          fontSize: '14.5px',
+          fontWeight: 600,
+          letterSpacing: '-0.005em',
+          lineHeight: 1,
+          minWidth: 0,
+          maxWidth: 320,
+          '&:hover': {
+            bgcolor: 'action.hover',
+            borderColor: (theme) => theme.palette.mode === 'dark' ? alpha(theme.palette.divider, 0.8) : '#d4d4d4',
+            boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
+          },
         }}
       >
         <ProjectAvatar
           imageUrl={currentProject?.imageUrl}
           icon={currentProject?.icon}
-          size={28}
-          borderRadius="6px"
+          size={22}
+          borderRadius="5px"
           color="var(--text-secondary)"
         />
-        <Typography sx={{ fontSize: 14, fontWeight: 500, color: 'text.secondary', lineHeight: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 160 }}>
-          {projectSlug && currentProject ? currentProject.name : 'Select project'}
+        <Typography
+          component="span"
+          sx={{
+            fontSize: '14.5px',
+            fontWeight: 600,
+            letterSpacing: '-0.005em',
+            color: hasProject ? 'text.primary' : 'text.secondary',
+            lineHeight: 1,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            minWidth: 0,
+          }}
+        >
+          {hasProject ? currentProject.name : 'Select project'}
         </Typography>
-        <CaretUpDown size={12} style={{ flexShrink: 0, color: 'var(--text-secondary)' }} />
+        <CaretUpDown size={14} style={{ flexShrink: 0, color: 'var(--text-secondary)' }} />
       </ButtonBase>
 
       <Menu

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -3,27 +3,15 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { usePathname, useParams } from 'next/navigation';
-import { useRouter } from 'next/navigation';
-import { ChartBar, FolderSimple, FileMagnifyingGlass, GearSix, UsersThree, SealCheck, CaretRight, CaretLineLeft, CaretLineRight, SignOut, Sun, Moon, type Icon } from '@phosphor-icons/react';
-import { Box, Typography, Tooltip, Switch } from '@mui/material';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { ChartBar, FolderSimple, FileMagnifyingGlass, GearSix, UsersThree, SealCheck, CaretRight, CaretLineLeft, CaretLineRight, type Icon } from '@phosphor-icons/react';
+import { Box, Typography, Tooltip } from '@mui/material';
 import { projectNavItems, getProjectNavHref, SIDEBAR_SECTIONS } from './navItems';
 import OrgSwitcher from './OrgSwitcher';
 
 import { api } from '@/trpc/react';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
 import { useProjectSwitcher } from '@/hooks/useProjectSwitcher';
-import { authClient, signOut } from '@/lib/auth-client';
-import UserAvatar from '@/components/ui/UserAvatar';
 import { LogoIcon } from '@/components/ui/Logo';
-import LoadingSpinner from '@/components/ui/loading-spinner';
-import { useLoading } from '@/components/providers/LoadingProvider';
-import { useThemeMode } from '@/components/providers/ThemeRegistry';
-import AccountSettingsModal from './AccountSettingsModal';
 
 const SIDEBAR_WIDTH = 240;
 const SIDEBAR_COLLAPSED_WIDTH = 64;
@@ -37,10 +25,6 @@ const iconMap: Record<string, Icon> = {
   UsersThree,
 };
 
-const profileMenuItems = [
-  { icon: GearSix, label: 'Account Settings' },
-];
-
 interface SidebarProps {
   collapsed: boolean;
   onToggleCollapse: () => void;
@@ -50,12 +34,6 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
   const pathname = usePathname();
   const params = useParams<{ orgSlug?: string; projectSlug?: string }>();
   const { orgSlug, projectSlug } = params;
-  const router = useRouter();
-
-  const { data: session } = authClient.useSession();
-  const user = session?.user;
-  const { showLoading, hideLoading } = useLoading();
-  const { mode: themeMode, toggleMode: toggleThemeMode } = useThemeMode();
 
   const { activeOrganizationId } = useOrgFromUrl();
   const { currentProject } = useProjectSwitcher(activeOrganizationId, orgSlug ?? '');
@@ -66,9 +44,6 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
   );
   const memberCount = projectMembers.length;
 
-  const [profileOpen, setProfileOpen] = useState(false);
-  const [isLoggingOut, setIsLoggingOut] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
   const [isMac, setIsMac] = useState(false);
 
   // Pulse badge when memberCount changes (triggers once on initial query load, then on any update)
@@ -84,27 +59,6 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
   useEffect(() => {
     setIsMac(/Mac/.test(navigator.userAgent));
   }, []);
-
-  const handleLogout = async () => {
-    setIsLoggingOut(true);
-    showLoading('Logging out...');
-    try {
-      await signOut({
-        fetchOptions: {
-          onSuccess: () => {
-            hideLoading();
-            setProfileOpen(false);
-            router.push('/sign-in');
-            router.refresh();
-          },
-        },
-      });
-    } catch (error) {
-      console.error('Logout failed:', error);
-      setIsLoggingOut(false);
-      hideLoading();
-    }
-  };
 
   return (
     <Box
@@ -130,31 +84,65 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
           alignItems: 'center',
           justifyContent: collapsed ? 'center' : 'flex-start',
           gap: 1,
-          height: 48,
+          height: 60,
           px: collapsed ? 0 : 1.75,
           borderBottom: '1px solid',
           borderColor: 'divider',
           color: 'text.primary',
           userSelect: 'none',
           overflow: 'hidden',
+          flexShrink: 0,
         }}
         aria-label="BuildTrack Pro"
       >
         <LogoIcon size={20} />
         {!collapsed && (
-          <Typography
-            sx={{
-              fontSize: '0.875rem',
-              fontWeight: 600,
-              lineHeight: 1,
-              letterSpacing: '-0.01em',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            BuildTrack Pro
-          </Typography>
+          <>
+            <Typography
+              sx={{
+                fontSize: '0.875rem',
+                fontWeight: 600,
+                lineHeight: 1,
+                letterSpacing: '-0.01em',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                flex: 1,
+              }}
+            >
+              BuildTrack Pro
+            </Typography>
+            <Tooltip
+              title={`Collapse sidebar (${isMac ? '⌘' : 'Ctrl+'}B)`}
+              placement="bottom"
+            >
+              <Box
+                component="button"
+                onClick={onToggleCollapse}
+                aria-label="Collapse sidebar"
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 28,
+                  height: 28,
+                  flexShrink: 0,
+                  borderRadius: '6px',
+                  border: 'none',
+                  bgcolor: 'transparent',
+                  color: 'text.secondary',
+                  cursor: 'pointer',
+                  transition: 'background-color 0.15s, color 0.15s',
+                  '&:hover': {
+                    bgcolor: 'sidebar.hoverBg',
+                    color: 'text.primary',
+                  },
+                }}
+              >
+                <CaretLineLeft size={14} weight="bold" />
+              </Box>
+            </Tooltip>
+          </>
         )}
       </Box>
 
@@ -477,203 +465,6 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
           </Tooltip>
         </Box>
       </Box>
-
-      {/* User Profile */}
-      <DropdownMenu open={profileOpen} onOpenChange={setProfileOpen}>
-        <DropdownMenuTrigger asChild>
-          <Box
-            component="button"
-            sx={{
-              borderTop: '1px solid',
-              borderColor: 'divider',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: collapsed ? 'center' : 'flex-start',
-              gap: collapsed ? 0 : 1.25,
-              px: collapsed ? 0 : 1.75,
-              py: 1.5,
-              width: '100%',
-              bgcolor: 'transparent',
-              border: 'none',
-              cursor: 'pointer',
-              color: 'text.secondary',
-              transition: 'all 0.15s ease',
-              '&:hover': {
-                bgcolor: 'sidebar.hoverBg',
-              },
-            }}
-          >
-            {user && (
-              <UserAvatar user={user} size={32} borderRadius="8px" />
-            )}
-
-            {!collapsed && (
-              <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1, gap: '2px' }}>
-                <Typography
-                  sx={{
-                    fontSize: '0.8125rem',
-                    fontWeight: 550,
-                    color: 'text.primary',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    lineHeight: 1.2,
-                    textAlign: 'left',
-                  }}
-                >
-                  {user?.name ?? 'User'}
-                </Typography>
-                <Typography
-                  sx={{
-                    fontSize: '0.6875rem',
-                    color: 'text.secondary',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    lineHeight: 1.2,
-                    textAlign: 'left',
-                  }}
-                >
-                  {user?.email ?? ''}
-                </Typography>
-              </Box>
-            )}
-          </Box>
-        </DropdownMenuTrigger>
-
-        <DropdownMenuContent
-          align="start"
-          sideOffset={8}
-          anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
-          transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-          style={{ width: 240, padding: 0, overflow: 'hidden', borderRadius: 12 }}
-        >
-          {/* Profile Header */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, p: '14px' }}>
-            {user && <UserAvatar user={user} size={36} borderRadius="8px" />}
-            <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 }}>
-              <Typography
-                sx={{
-                  fontSize: '0.8125rem',
-                  fontWeight: 600,
-                  color: 'text.primary',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  lineHeight: 1.2,
-                }}
-              >
-                {user?.name ?? 'User'}
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: '0.6875rem',
-                  color: 'text.secondary',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  lineHeight: 1.2,
-                  mt: '2px',
-                }}
-              >
-                {user?.email ?? ''}
-              </Typography>
-            </Box>
-          </Box>
-
-          <Box sx={{ height: '1px', bgcolor: 'divider' }} />
-
-          {/* Menu Items */}
-          <Box sx={{ py: '4px', px: '6px' }}>
-            {profileMenuItems.map((item) => (
-              <Box
-                key={item.label}
-                component="button"
-                onClick={() => {
-                  setProfileOpen(false);
-                  setSettingsOpen(true);
-                }}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '10px',
-                  width: '100%',
-                  px: '10px',
-                  py: '8px',
-                  borderRadius: '8px',
-                  border: 'none',
-                  bgcolor: 'transparent',
-                  color: 'text.primary',
-                  cursor: 'pointer',
-                  transition: 'background-color 0.15s',
-                  '&:hover': { bgcolor: 'action.hover' },
-                }}
-              >
-                <item.icon size={14} />
-                <Typography sx={{ fontSize: '0.8125rem', color: 'inherit' }}>
-                  {item.label}
-                </Typography>
-              </Box>
-            ))}
-
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '10px',
-                width: '100%',
-                px: '10px',
-                py: '6px',
-              }}
-            >
-              {themeMode === 'dark' ? <Sun size={14} color="var(--text-secondary)" /> : <Moon size={14} color="var(--text-secondary)" />}
-              <Typography sx={{ fontSize: '0.8125rem', color: 'text.primary', flex: 1 }}>
-                Dark mode
-              </Typography>
-              <Switch
-                checked={themeMode === 'dark'}
-                onChange={toggleThemeMode}
-                size="small"
-                sx={{
-                  '& .MuiSwitch-switchBase.Mui-checked': { color: 'primary.main' },
-                  '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': { bgcolor: 'primary.main' },
-                }}
-              />
-            </Box>
-          </Box>
-
-          <Box sx={{ height: '1px', bgcolor: 'divider' }} />
-
-          {/* Log Out */}
-          <Box
-            component="button"
-            onClick={handleLogout}
-            disabled={isLoggingOut}
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '10px',
-              width: '100%',
-              px: '14px',
-              py: '10px',
-              border: 'none',
-              bgcolor: 'transparent',
-              cursor: 'pointer',
-              color: 'error.main',
-              transition: 'background-color 0.15s',
-              '&:hover': { bgcolor: 'action.hover' },
-              '&:disabled': { opacity: 0.5, cursor: 'not-allowed' },
-            }}
-          >
-            <SignOut size={14} />
-            <Typography sx={{ fontSize: '0.8125rem', fontWeight: 500, color: 'inherit' }}>
-              Log out
-            </Typography>
-          </Box>
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      <AccountSettingsModal open={settingsOpen} onOpenChange={setSettingsOpen} />
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- Extract the user/identity menu out of the sidebar footer into a new `IdentityMenu` component anchored at the right of the header (avatar + name/email trigger, account settings, dark-mode toggle, log out).
- Replace the header's page-title + inline project switcher with a new `Breadcrumb` (`Projects / [Project chip] / [Page]`); page labels are now derived from `projectNavItems` so `Review Queue` is covered too.
- Restyle the header into a single 60px row with a notification dot indicator, vertical divider, and identity menu; sidebar gains a collapse affordance in the brand row alongside the existing bottom toggle.

## Test plan
- [ ] Verify breadcrumb renders correctly on org root (Dashboard) and on each project subpage (gantt, files, document-explorer, reviews, team, settings).
- [ ] Open the identity menu, toggle dark mode, open Account Settings, and log out.
- [ ] Confirm notification dropdown still opens, marks read, and shows the new dot indicator.
- [ ] Check sidebar collapse from both the brand-row button and the bottom toggle (incl. ⌘/Ctrl+B shortcut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)