### PR TITLE
Prevent schema drift via CI + backfill missing WaitlistEntry migration

### DIFF
--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -1,0 +1,113 @@
+name: Schema Drift
+
+# Two checks that together prevent the drift hazards described in
+# claudedocs/environment-setup.md ("Database workflow"):
+#
+#   1. migration-required: if a PR edits prisma/schema.prisma, it must also add
+#      a new file under prisma/migrations/. Catches "edited schema, forgot to
+#      run prisma migrate dev" — the most common workflow mistake.
+#
+#   2. migrations-apply-cleanly: every migration in the repo applies cleanly to
+#      a fresh Postgres instance. Catches broken raw SQL, bad ordering, missing
+#      extensions, and similar migration-file bugs.
+#
+# What this does NOT do: a full `prisma migrate diff` between the migrated DB
+# and schema.prisma. That comparison reports false positives for raw-SQL features
+# Prisma's schema language can't express (GENERATED columns, DB-level defaults
+# on @updatedAt fields, custom indexes/functions). Catching those at PR review
+# time is left to humans.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'prisma/schema.prisma'
+      - 'prisma/migrations/**'
+      - '.github/workflows/schema-drift.yml'
+  push:
+    branches: [main, preview]
+    paths:
+      - 'prisma/schema.prisma'
+      - 'prisma/migrations/**'
+
+jobs:
+  migration-required:
+    name: Schema change has a migration
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for new migration when schema.prisma changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          schema_changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- prisma/schema.prisma | wc -l)
+          new_migration_dirs=$(git diff --name-only --diff-filter=A "$BASE_SHA" "$HEAD_SHA" -- 'prisma/migrations/*/migration.sql' | wc -l)
+
+          if [ "$schema_changed" -gt 0 ] && [ "$new_migration_dirs" -eq 0 ]; then
+            echo "::error::prisma/schema.prisma changed but no new migration was added."
+            echo ""
+            echo "Run: npx prisma migrate dev --name <descriptive_name>"
+            echo "Then commit the resulting prisma/migrations/<timestamp>_<name>/migration.sql file."
+            echo ""
+            echo "Never use 'prisma db push' — it skips raw SQL and causes silent drift."
+            echo "See claudedocs/environment-setup.md → 'Database workflow' for details."
+            exit 1
+          fi
+
+          echo "schema.prisma changes: $schema_changed file(s)"
+          echo "New migration files: $new_migration_dirs"
+          echo "OK"
+
+  migrations-apply-cleanly:
+    name: Migrations apply to fresh DB
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: migrate_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Enable pgvector and pg_trgm extensions
+        run: |
+          psql -h localhost -U postgres -d migrate_test -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          psql -h localhost -U postgres -d migrate_test -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+        env:
+          PGPASSWORD: postgres
+
+      - name: Apply all migrations to a fresh DB
+        run: npx prisma migrate deploy
+        env:
+          POSTGRES_PRISMA_URL: postgresql://postgres:postgres@localhost:5432/migrate_test
+          POSTGRES_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/migrate_test

--- a/prisma/migrations/20260508120000_add_waitlist_entry/migration.sql
+++ b/prisma/migrations/20260508120000_add_waitlist_entry/migration.sql
@@ -1,0 +1,23 @@
+-- Backfills the WaitlistEntry table that was added to schema.prisma in PR #40
+-- without an accompanying migration. The /api/waitlist route has been calling
+-- into a non-existent table since then.
+--
+-- IF NOT EXISTS is intentional: some shared local dev databases may already
+-- have this table from a stray `prisma db push` run, while production and
+-- preview Neon DBs do not. The defensive form lets this migration apply
+-- cleanly to either state without per-workspace `prisma migrate resolve` toil.
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "WaitlistEntry" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WaitlistEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "WaitlistEntry_email_key" ON "WaitlistEntry"("email");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "WaitlistEntry_email_idx" ON "WaitlistEntry"("email");


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/schema-drift.yml` with two checks: a git-diff guard that fails any PR which edits `prisma/schema.prisma` without adding a new migration file, and a job that runs `prisma migrate deploy` against fresh Postgres + pgvector to catch broken migration SQL.
- Backfills the missing `WaitlistEntry` migration from PR #40, which added the model and `/api/waitlist` route to schema but never created the table — meaning the route has been broken in production since merge.
- The migration uses `CREATE TABLE IF NOT EXISTS` defensively so it applies cleanly to fresh DBs (production/preview Neon) and to any local workspace where a stray `prisma db push` already created the table.

## Test plan
- [x] Verified locally: migration applies cleanly to a fresh DB, to my actual local DB, and to a DB that already has the table from `db push` (with pre-existing data preserved)
- [x] Verified the new workflow's `migration-required` check passes on this PR
- [ ] Verify the GitHub Action runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)