### PR TITLE
Add template picker as first step in project creation flow

### DIFF
--- a/src/components/projects/AddProjectDialog.tsx
+++ b/src/components/projects/AddProjectDialog.tsx
@@ -9,13 +9,16 @@ import { useSession } from '@/lib/auth-client';
 import { api } from '@/trpc/react';
 import ProjectFormBody from '@/components/projects/ProjectFormBody';
 import AddProjectMembersStep from '@/components/projects/AddProjectMembersStep';
+import TemplatePickerStep, {
+  type ProjectTemplateOption,
+} from '@/components/projects/TemplatePickerStep';
 
 interface AddProjectDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-type Step = 'create' | 'members';
+type Step = 'template' | 'create' | 'members';
 
 interface CreatedProject {
   id: string;
@@ -32,7 +35,9 @@ export default function AddProjectDialog({
   const { showSnackbar } = useSnackbar();
   const currentUserId = session?.user?.id;
 
-  const [step, setStep] = useState<Step>('create');
+  const [step, setStep] = useState<Step>('template');
+  const [selectedTemplate, setSelectedTemplate] =
+    useState<ProjectTemplateOption>('BLANK');
   const [createdProject, setCreatedProject] = useState<CreatedProject | null>(
     null
   );
@@ -40,7 +45,8 @@ export default function AddProjectDialog({
   // Reset step state whenever dialog re-opens
   useEffect(() => {
     if (open) {
-      setStep('create');
+      setStep('template');
+      setSelectedTemplate('BLANK');
       setCreatedProject(null);
     }
   }, [open]);
@@ -97,7 +103,11 @@ export default function AddProjectDialog({
     handleClose();
   };
 
-  const showStepper = !!currentUserId && !confirmedNoOtherMembers;
+  // Members step only appears when the org has other members. Until the query
+  // resolves we assume it might appear (3-dot stepper). After it resolves we
+  // can confidently shrink to a 2-dot stepper for solo orgs.
+  const willHaveMembersStep = !!currentUserId && !confirmedNoOtherMembers;
+  const totalSteps = willHaveMembersStep ? 3 : 2;
 
   return (
     <Dialog
@@ -114,8 +124,15 @@ export default function AddProjectDialog({
         },
       }}
     >
-      {showStepper && (
-        <Stepper currentStep={step} />
+      <Stepper currentStep={step} totalSteps={totalSteps} />
+
+      {step === 'template' && (
+        <TemplatePickerStep
+          selected={selectedTemplate}
+          onSelect={setSelectedTemplate}
+          onContinue={() => setStep('create')}
+          onCancel={handleClose}
+        />
       )}
 
       {step === 'create' && (
@@ -124,7 +141,9 @@ export default function AddProjectDialog({
           organizationId={activeOrganizationId}
           title="New project"
           subtitle="Track schedule, documents and team in one place."
+          template={selectedTemplate}
           onCancel={handleClose}
+          onBack={() => setStep('template')}
           onSuccess={handleProjectCreated}
         />
       )}
@@ -143,9 +162,25 @@ export default function AddProjectDialog({
   );
 }
 
-function Stepper({ currentStep }: { currentStep: Step }) {
-  const step1Done = currentStep === 'members';
-  const step2Active = currentStep === 'members';
+function Stepper({
+  currentStep,
+  totalSteps,
+}: {
+  currentStep: Step;
+  totalSteps: 2 | 3;
+}) {
+  // template (1) → create (2) → members (3)
+  const currentIndex =
+    currentStep === 'template' ? 1 : currentStep === 'create' ? 2 : 3;
+
+  const dots: Array<{ index: number; state: 'done' | 'active' | 'pending' }> = [];
+  for (let i = 1; i <= totalSteps; i++) {
+    dots.push({
+      index: i,
+      state: i < currentIndex ? 'done' : i === currentIndex ? 'active' : 'pending',
+    });
+  }
+
   return (
     <Box
       sx={{
@@ -155,20 +190,32 @@ function Stepper({ currentStep }: { currentStep: Step }) {
         gap: 0.75,
         mb: 1.5,
       }}
-      aria-label={`Step ${step2Active ? 2 : 1} of 2`}
+      aria-label={`Step ${currentIndex} of ${totalSteps}`}
     >
-      <StepDot state={step1Done ? 'done' : 'active'}>
-        {step1Done ? <Check size={11} weight="bold" /> : '1'}
-      </StepDot>
-      <Box
-        sx={{
-          width: 14,
-          height: 2,
-          borderRadius: '1px',
-          bgcolor: step1Done ? 'primary.main' : 'divider',
-        }}
-      />
-      <StepDot state={step2Active ? 'active' : 'pending'}>2</StepDot>
+      {dots.map((dot, idx) => (
+        <Box
+          key={dot.index}
+          sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}
+        >
+          <StepDot state={dot.state}>
+            {dot.state === 'done' ? (
+              <Check size={11} weight="bold" />
+            ) : (
+              dot.index
+            )}
+          </StepDot>
+          {idx < dots.length - 1 && (
+            <Box
+              sx={{
+                width: 14,
+                height: 2,
+                borderRadius: '1px',
+                bgcolor: dot.state === 'done' ? 'primary.main' : 'divider',
+              }}
+            />
+          )}
+        </Box>
+      ))}
     </Box>
   );
 }

--- a/src/components/projects/ProjectFormBody.tsx
+++ b/src/components/projects/ProjectFormBody.tsx
@@ -3,8 +3,10 @@
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
+  ArrowLeft,
   ArrowRight,
   Image as ImageIcon,
+  ListBullets,
   Swatches,
   UploadSimple,
   X,
@@ -57,10 +59,19 @@ interface ProjectFormBodyProps {
   organizationId: string;
   title: string;
   subtitle: string;
+  template?: 'BLANK';
   onCancel?: () => void;
+  onBack?: () => void;
   onSuccess?: (project: { id: string; slug: string; name: string }) => void;
   replaceOnNavigate?: boolean;
 }
+
+const TEMPLATE_LABELS: Record<'BLANK', { name: string; hint: string }> = {
+  BLANK: {
+    name: 'Blank',
+    hint: 'Empty Gantt — build your own WBS task by task.',
+  },
+};
 
 function LocationAutocompleteField({
   value,
@@ -183,7 +194,9 @@ export default function ProjectFormBody({
   organizationId,
   title,
   subtitle,
+  template = 'BLANK',
   onCancel,
+  onBack,
   onSuccess,
   replaceOnNavigate,
 }: ProjectFormBodyProps) {
@@ -214,7 +227,7 @@ export default function ProjectFormBody({
       location: '',
       icon: 'building',
       color: 'slate',
-      template: 'BLANK',
+      template,
     },
   });
 
@@ -871,6 +884,57 @@ export default function ProjectFormBody({
           </Box>
         </Box>
 
+        {/* Template confirmation strip */}
+        <Box
+          sx={{
+            mt: 1.75,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.25,
+            p: '10px 12px',
+            borderRadius: '8px',
+            bgcolor: alpha(theme.palette.primary.main, 0.06),
+            border: `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
+          }}
+        >
+          <Box
+            sx={{
+              width: 26,
+              height: 26,
+              borderRadius: '6px',
+              bgcolor: alpha(theme.palette.primary.main, 0.12),
+              color: 'primary.main',
+              display: 'grid',
+              placeItems: 'center',
+              flexShrink: 0,
+            }}
+          >
+            <ListBullets size={14} weight="regular" />
+          </Box>
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Typography
+              sx={{
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                color: 'text.primary',
+                lineHeight: 1.2,
+              }}
+            >
+              {TEMPLATE_LABELS[template].name} template selected
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: '0.6875rem',
+                color: 'text.secondary',
+                mt: 0.25,
+                lineHeight: 1.3,
+              }}
+            >
+              {TEMPLATE_LABELS[template].hint}
+            </Typography>
+          </Box>
+        </Box>
+
         {/* Live sidebar preview — how the project appears in the nav */}
         <SidebarRowPreview
           name={watch('name')}
@@ -907,6 +971,27 @@ export default function ProjectFormBody({
           </Typography>
 
           <Box sx={{ display: 'flex', gap: 1, ml: 'auto', flexShrink: 0 }}>
+            {onBack && (
+              <Button
+                variant="text"
+                onClick={onBack}
+                startIcon={<ArrowLeft size={14} />}
+                sx={{
+                  color: 'text.secondary',
+                  fontWeight: 500,
+                  fontSize: '0.8125rem',
+                  px: 1.75,
+                  borderRadius: '8px',
+                  whiteSpace: 'nowrap',
+                  '&:hover': {
+                    bgcolor: alpha(theme.palette.divider, 0.18),
+                    color: 'text.primary',
+                  },
+                }}
+              >
+                Back
+              </Button>
+            )}
             {onCancel && (
               <Button
                 variant="text"

--- a/src/components/projects/TemplatePickerStep.tsx
+++ b/src/components/projects/TemplatePickerStep.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import {
+  Box,
+  Tooltip,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
+import {
+  ArrowRight,
+  Buildings,
+  Check,
+  HouseLine,
+  ListBullets,
+  Wrench,
+} from '@phosphor-icons/react';
+import type { ComponentType } from 'react';
+import { Button } from '@/components/ui/button';
+
+export type ProjectTemplateOption = 'BLANK';
+
+interface TemplateCard {
+  id: ProjectTemplateOption | 'RESIDENTIAL' | 'COMMERCIAL' | 'RENOVATION';
+  name: string;
+  meta: string;
+  bullets: [string, string];
+  Icon: ComponentType<{ size?: number; weight?: 'regular' | 'fill' | 'bold' }>;
+  available: boolean;
+}
+
+const TEMPLATES: TemplateCard[] = [
+  {
+    id: 'BLANK',
+    name: 'Blank',
+    meta: 'No tasks · default',
+    bullets: ['Empty Gantt chart', 'Build your own WBS'],
+    Icon: ListBullets,
+    available: true,
+  },
+  {
+    id: 'RESIDENTIAL',
+    name: 'Residential',
+    meta: 'Coming soon',
+    bullets: ['Site, foundation, framing', 'MEP, finishes, closeout'],
+    Icon: HouseLine,
+    available: false,
+  },
+  {
+    id: 'COMMERCIAL',
+    name: 'Commercial',
+    meta: 'Coming soon',
+    bullets: ['Permits, sitework, structure', 'Tenant fit-out, commissioning'],
+    Icon: Buildings,
+    available: false,
+  },
+  {
+    id: 'RENOVATION',
+    name: 'Renovation',
+    meta: 'Coming soon',
+    bullets: ['Demo, rough-in, finish', 'Punchlist & closeout'],
+    Icon: Wrench,
+    available: false,
+  },
+];
+
+interface TemplatePickerStepProps {
+  selected: ProjectTemplateOption;
+  onSelect: (template: ProjectTemplateOption) => void;
+  onContinue: () => void;
+  onCancel: () => void;
+}
+
+export default function TemplatePickerStep({
+  selected,
+  onSelect,
+  onContinue,
+  onCancel,
+}: TemplatePickerStepProps) {
+  const theme = useTheme();
+
+  return (
+    <Box>
+      <Box sx={{ mb: 2 }}>
+        <Typography
+          sx={{
+            fontSize: '1.0625rem',
+            fontWeight: 600,
+            color: 'text.primary',
+            letterSpacing: '-0.01em',
+            lineHeight: 1.25,
+          }}
+        >
+          Choose a template
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: '0.8125rem',
+            color: 'text.secondary',
+            mt: 0.25,
+            lineHeight: 1.4,
+          }}
+        >
+          Start with a structured WBS or a clean slate.
+        </Typography>
+      </Box>
+
+      <Box
+        role="radiogroup"
+        aria-label="Project template"
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gridAutoRows: 'minmax(0, 1fr)',
+          gap: 1,
+        }}
+      >
+        {TEMPLATES.map((tpl) => {
+          const isSelected = tpl.available && selected === tpl.id;
+          const card = (
+            <Box
+              component="button"
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              aria-disabled={!tpl.available}
+              disabled={!tpl.available}
+              onClick={() => {
+                if (tpl.available && tpl.id === 'BLANK') onSelect(tpl.id);
+              }}
+              sx={{
+                position: 'relative',
+                width: '100%',
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'flex-start',
+                gap: 1,
+                textAlign: 'left',
+                p: '12px 12px 11px',
+                borderRadius: '12px',
+                border: '1.5px solid',
+                borderColor: isSelected ? 'primary.main' : 'divider',
+                bgcolor: isSelected
+                  ? alpha(theme.palette.primary.main, 0.08)
+                  : 'background.paper',
+                color: 'text.primary',
+                cursor: tpl.available ? 'pointer' : 'not-allowed',
+                opacity: tpl.available ? 1 : 0.55,
+                fontFamily: 'inherit',
+                transition:
+                  'border-color 0.12s ease, background-color 0.12s ease',
+                '&:hover': tpl.available
+                  ? {
+                      borderColor: isSelected
+                        ? 'primary.main'
+                        : alpha(theme.palette.text.primary, 0.32),
+                      bgcolor: isSelected
+                        ? alpha(theme.palette.primary.main, 0.1)
+                        : 'action.hover',
+                    }
+                  : {},
+                '&:focus-visible': {
+                  outline: `2px solid ${theme.palette.primary.main}`,
+                  outlineOffset: 2,
+                },
+              }}
+            >
+              {isSelected && (
+                <Box
+                  aria-hidden
+                  sx={{
+                    position: 'absolute',
+                    top: 10,
+                    right: 10,
+                    width: 18,
+                    height: 18,
+                    borderRadius: '50%',
+                    bgcolor: 'primary.main',
+                    color: 'primary.contrastText',
+                    display: 'grid',
+                    placeItems: 'center',
+                  }}
+                >
+                  <Check size={11} weight="bold" />
+                </Box>
+              )}
+
+              <Box
+                sx={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: '8px',
+                  bgcolor: alpha(theme.palette.primary.main, 0.08),
+                  color: 'primary.main',
+                  display: 'grid',
+                  placeItems: 'center',
+                }}
+              >
+                <tpl.Icon size={16} weight="regular" />
+              </Box>
+
+              <Box sx={{ width: '100%' }}>
+                <Typography
+                  sx={{
+                    fontSize: '0.8125rem',
+                    fontWeight: 600,
+                    color: 'text.primary',
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {tpl.name}
+                </Typography>
+                <Typography
+                  sx={{
+                    fontSize: '0.6875rem',
+                    color: 'text.secondary',
+                    mt: 0.25,
+                    lineHeight: 1.3,
+                  }}
+                >
+                  {tpl.meta}
+                </Typography>
+              </Box>
+
+              <Box
+                component="ul"
+                sx={{
+                  m: 0,
+                  pl: '14px',
+                  fontSize: '0.6875rem',
+                  color: 'text.secondary',
+                  lineHeight: 1.4,
+                }}
+              >
+                {tpl.bullets.map((b) => (
+                  <li key={b}>{b}</li>
+                ))}
+              </Box>
+            </Box>
+          );
+
+          return tpl.available ? (
+            <Box key={tpl.id} sx={{ display: 'flex' }}>
+              {card}
+            </Box>
+          ) : (
+            <Tooltip
+              key={tpl.id}
+              title="Construction templates are coming soon"
+              arrow
+              placement="top"
+            >
+              <Box sx={{ display: 'flex' }}>{card}</Box>
+            </Tooltip>
+          );
+        })}
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          gap: 1,
+          mt: 2.25,
+          pt: 1.75,
+          borderTop: `1px solid ${theme.palette.divider}`,
+        }}
+      >
+        <Button
+          variant="text"
+          onClick={onCancel}
+          sx={{
+            color: 'text.secondary',
+            fontWeight: 500,
+            fontSize: '0.8125rem',
+            px: 2,
+            borderRadius: '8px',
+            '&:hover': {
+              bgcolor: alpha(theme.palette.divider, 0.18),
+              color: 'text.primary',
+            },
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={onContinue}
+          endIcon={<ArrowRight size={16} />}
+          sx={{
+            borderRadius: '8px',
+            fontWeight: 600,
+            fontSize: '0.8125rem',
+            px: 2.5,
+            py: 1,
+            textTransform: 'none',
+            boxShadow: `0 1px 2px ${alpha(theme.palette.primary.main, 0.25)}`,
+            '& .MuiButton-endIcon': {
+              transition: 'transform 0.15s ease',
+            },
+            '&:hover': {
+              boxShadow: `0 4px 12px ${alpha(theme.palette.primary.main, 0.3)}`,
+              '& .MuiButton-endIcon': { transform: 'translateX(3px)' },
+            },
+          }}
+        >
+          Continue
+        </Button>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- Inserts a new **Choose a template** step before the existing create form in `AddProjectDialog`, scaffolding the UX for future construction templates.
- **Blank** is the only functional option for now; **Residential**, **Commercial**, and **Renovation** render as disabled "Coming soon" cards so the dialog is visually complete without committing to template content yet.
- The stepper auto-sizes to 2 or 3 dots based on whether the conditional members step will appear, and `ProjectFormBody` gains optional `template` and `onBack` props plus a small "Blank template selected" confirmation strip.
- No schema, Prisma, or server changes — the `template` field on `project.create` was already plumbed end-to-end with a single `BLANK` enum, so this PR only adds UI.

## Test plan
- [ ] Open the Add Project dialog from the project switcher → confirm the new "Choose a template" screen appears first with 4 cards (Blank selected by default)
- [ ] Click **Continue** → form step shows the "Blank template selected" strip and a **Back** button that returns to the template picker
- [ ] Verify stepper shows 3 dots when org has other members, 2 dots when solo
- [ ] Hover the 3 disabled cards → "Construction templates are coming soon" tooltip appears
- [ ] Create a project end-to-end and confirm it lands on the Gantt page as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)