### PR TITLE
Bind documents to slots via Document.slotId FK with unique constraint

### DIFF
--- a/prisma/migrations/20260522013529_add_document_slot_fk/migration.sql
+++ b/prisma/migrations/20260522013529_add_document_slot_fk/migration.sql
@@ -1,0 +1,109 @@
+-- Phase 3 — Slot ↔ Document FK binding
+--
+-- Replaces positional slot↔doc pairing (slot N matched upload N) with an
+-- explicit FK on Document.slotId. After this migration:
+--   - Documents in submittal/inspection folders may point to a specific slot.
+--   - Backfill preserves the visible pairings the UI showed before: for each
+--     (task, kind), the i-th oldest document (by createdAt) binds to slot
+--     index i.
+--   - Tasks whose requiredSubmittals/requiredInspections were set but whose
+--     slot rows were never lazily backfilled by gantt.listSlots get their
+--     missing rows created here so the doc↔slot join can find them.
+--   - ON DELETE SET NULL on the FK means deleting a slot does NOT delete its
+--     bound document — the doc just becomes unbound (slotId = NULL), same as
+--     an excess upload with no slot.
+
+-- 1) Schema: add nullable slotId, FK to TaskRequirementSlot, and index.
+ALTER TABLE "Document" ADD COLUMN "slotId" TEXT;
+
+ALTER TABLE "Document"
+    ADD CONSTRAINT "Document_slotId_fkey"
+    FOREIGN KEY ("slotId") REFERENCES "TaskRequirementSlot"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "Document_slotId_idx" ON "Document"("slotId");
+
+-- 2) Pre-create any slot rows implied by the legacy count columns but not
+--    yet materialized. Phase 1 introduced TaskRequirementSlot and populated
+--    rows lazily on first read via gantt.listSlots; tasks no one has opened
+--    the popover/drawer for since then only have count integers.
+INSERT INTO "TaskRequirementSlot" ("id", "taskId", "kind", "index", "name", "createdAt", "updatedAt")
+SELECT
+    gen_random_uuid()::text,
+    t.id,
+    'submittal',
+    gs.idx,
+    NULL,
+    NOW(),
+    NOW()
+FROM "GanttTask" t
+CROSS JOIN LATERAL generate_series(0, t."requiredSubmittals" - 1) AS gs(idx)
+WHERE t."requiredSubmittals" IS NOT NULL
+  AND t."requiredSubmittals" > 0
+  AND NOT EXISTS (
+    SELECT 1 FROM "TaskRequirementSlot" trs
+    WHERE trs."taskId" = t.id AND trs.kind = 'submittal'
+  );
+
+INSERT INTO "TaskRequirementSlot" ("id", "taskId", "kind", "index", "name", "createdAt", "updatedAt")
+SELECT
+    gen_random_uuid()::text,
+    t.id,
+    'inspection',
+    gs.idx,
+    NULL,
+    NOW(),
+    NOW()
+FROM "GanttTask" t
+CROSS JOIN LATERAL generate_series(0, t."requiredInspections" - 1) AS gs(idx)
+WHERE t."requiredInspections" IS NOT NULL
+  AND t."requiredInspections" > 0
+  AND NOT EXISTS (
+    SELECT 1 FROM "TaskRequirementSlot" trs
+    WHERE trs."taskId" = t.id AND trs.kind = 'inspection'
+  );
+
+-- 3) Positional backfill: pair existing docs to slots by upload order. Kind
+--    is derived from folder family (matches the drawer's view, which is the
+--    inclusive one). For each (task, kind), the i-th oldest doc binds to
+--    slot at index i. Excess docs (more docs than slots) stay unbound.
+WITH classified_docs AS (
+    SELECT
+        d.id AS doc_id,
+        d."taskId",
+        d."createdAt",
+        CASE
+            WHEN d."folderId" IN ('submittals', 'submittals-product', 'submittals-shop', 'submittals-certs')
+                THEN 'submittal'
+            WHEN d."folderId" IN ('inspections', 'inspections-structural', 'inspections-mep', 'inspections-safety')
+                THEN 'inspection'
+        END AS kind
+    FROM "Document" d
+    WHERE d."taskId" IS NOT NULL
+      AND d."folderId" IN (
+        'submittals', 'submittals-product', 'submittals-shop', 'submittals-certs',
+        'inspections', 'inspections-structural', 'inspections-mep', 'inspections-safety'
+      )
+),
+ranked_docs AS (
+    SELECT
+        doc_id,
+        "taskId",
+        kind,
+        ROW_NUMBER() OVER (
+            PARTITION BY "taskId", kind
+            ORDER BY "createdAt" ASC, doc_id ASC
+        ) - 1 AS pos
+    FROM classified_docs
+)
+UPDATE "Document"
+SET "slotId" = pairs.slot_id
+FROM (
+    SELECT rd.doc_id, trs.id AS slot_id
+    FROM ranked_docs rd
+    JOIN "TaskRequirementSlot" trs
+      ON trs."taskId" = rd."taskId"
+     AND trs.kind = rd.kind
+     AND trs.index = rd.pos
+) pairs
+WHERE "Document".id = pairs.doc_id;

--- a/prisma/migrations/20260522030000_unique_document_slot_id/migration.sql
+++ b/prisma/migrations/20260522030000_unique_document_slot_id/migration.sql
@@ -1,0 +1,30 @@
+-- Phase 3 hardening — enforce one-document-per-slot at the DB layer.
+--
+-- The Document.slotId FK introduced in 20260522013529 had no uniqueness
+-- guarantee, so two concurrent uploads could race past resolveSlotForUpload
+-- (auto-link reads "first empty slot", or stale UI passes the same explicit
+-- slotId twice) and both land with the same slotId. gantt.listSlots uses
+-- take: 1, so the second doc would silently disappear from the UI even
+-- though it still exists in blob storage.
+--
+-- Safety: if any duplicate bindings slipped in during the window between
+-- the FK migration and this one, keep the oldest doc bound to each slot
+-- and unbind the rest before adding the constraint.
+
+WITH ranked AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY "slotId"
+            ORDER BY "createdAt" ASC, id ASC
+        ) AS rn
+    FROM "Document"
+    WHERE "slotId" IS NOT NULL
+)
+UPDATE "Document"
+SET "slotId" = NULL
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+CREATE UNIQUE INDEX "Document_slotId_unique"
+ON "Document" ("slotId")
+WHERE "slotId" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -167,6 +167,7 @@ model Document {
     searchVector   Unsupported("tsvector")?
     taskId         String?
     folderId       String?
+    slotId         String?
     projectId      String
     uploadedById   String
     approvalStatus String                         @default("unapproved")
@@ -174,14 +175,16 @@ model Document {
     approvedAt     DateTime?
     createdAt      DateTime                       @default(now())
 
-    project       Project    @relation(fields: [projectId], references: [id], onDelete: Cascade)
-    uploadedBy    User       @relation(fields: [uploadedById], references: [id], onDelete: Cascade)
-    approvedBy    User?      @relation("ApprovedByUser", fields: [approvedById], references: [id], onDelete: SetNull)
-    coverForTasks GanttTask[] @relation("TaskCoverDocument")
+    project       Project              @relation(fields: [projectId], references: [id], onDelete: Cascade)
+    uploadedBy    User                 @relation(fields: [uploadedById], references: [id], onDelete: Cascade)
+    approvedBy    User?                @relation("ApprovedByUser", fields: [approvedById], references: [id], onDelete: SetNull)
+    slot          TaskRequirementSlot? @relation(fields: [slotId], references: [id], onDelete: SetNull)
+    coverForTasks GanttTask[]          @relation("TaskCoverDocument")
 
     @@index([projectId, taskId, folderId])
     @@index([projectId])
     @@index([projectId, approvalStatus])
+    @@index([slotId])
 }
 
 model Membership {
@@ -312,8 +315,9 @@ model TaskRequirementSlot {
     createdAt   DateTime  @default(now())
     updatedAt   DateTime  @updatedAt
 
-    task     GanttTask @relation(fields: [taskId], references: [id], onDelete: Cascade)
-    approver User?     @relation("SlotApprover", fields: [approverId], references: [id], onDelete: SetNull)
+    task      GanttTask  @relation(fields: [taskId], references: [id], onDelete: Cascade)
+    approver  User?      @relation("SlotApprover", fields: [approverId], references: [id], onDelete: SetNull)
+    documents Document[]
 
     @@unique([taskId, kind, index])
     @@index([taskId, kind])

--- a/src/__tests__/server/approval-overdue-fk.test.ts
+++ b/src/__tests__/server/approval-overdue-fk.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment node
+//
+// Phase 3 — Slot ↔ Document FK binding.
+//
+// Before Phase 3, overdue logic was positional: for each (task, kind), count
+// docs in the folder family; slots at index >= that count were considered
+// unfilled, and any past-due unfilled slot was overdue. After Phase 3, a
+// slot is "filled" only if Document.slotId points at it — independent of
+// upload order or how many docs landed in the folder.
+//
+// These tests pin that the Prisma query expresses the new "no bound
+// document" semantics, not the old positional count.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/server/api/trpc", () => {
+  const buildChain = () => {
+    const chain: Record<string, unknown> = {
+      input: (schema: unknown) => {
+        chain._schema = schema;
+        return chain;
+      },
+      query: (handler: unknown) => ({ _handler: handler, _schema: chain._schema }),
+      mutation: (handler: unknown) => ({ _handler: handler, _schema: chain._schema }),
+    };
+    return chain;
+  };
+  return {
+    createTRPCRouter: (routes: Record<string, unknown>) => routes,
+    protectedProcedure: buildChain(),
+    publicProcedure: buildChain(),
+    projectProcedure: buildChain(),
+    orgProcedure: buildChain(),
+  };
+});
+
+type Handler = (args: { ctx: ReturnType<typeof makeCtx>; input: unknown }) => Promise<unknown>;
+
+const ORG_ID = "org-1";
+const PROJECT_ID = "proj-1";
+
+function makeCtx() {
+  const projectFindFirst = vi.fn().mockResolvedValue({ id: PROJECT_ID });
+  const slotFindMany = vi.fn().mockResolvedValue([]);
+  const slotCount = vi.fn().mockResolvedValue(0);
+  const documentGroupBy = vi.fn().mockResolvedValue([]);
+  return {
+    db: {
+      project: { findFirst: projectFindFirst },
+      taskRequirementSlot: { findMany: slotFindMany, count: slotCount },
+      document: { groupBy: documentGroupBy },
+    },
+    session: { user: { id: "user-1", name: "U", email: "u@x" } },
+    organization: { id: ORG_ID },
+    membership: { role: "owner" as const },
+    _spies: { slotFindMany, slotCount, documentGroupBy },
+  };
+}
+
+describe("approval router — overdue uses Document.slotId FK", () => {
+  let router: Record<string, { _handler: Handler } | undefined>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/server/api/routers/approval");
+    router = mod.approvalRouter as unknown as Record<string, { _handler: Handler } | undefined>;
+  });
+
+  it("listOverdueSlots queries slots with no bound document (FK), not by positional doc count", async () => {
+    const ctx = makeCtx();
+
+    await router.listOverdueSlots!._handler({
+      ctx,
+      input: { projectId: PROJECT_ID },
+    });
+
+    expect(ctx._spies.slotFindMany).toHaveBeenCalledTimes(1);
+    const args = ctx._spies.slotFindMany.mock.calls[0]![0] as {
+      where: {
+        dueDate: { not: null; lt: Date };
+        task: { projectId: string };
+        documents: { none: object };
+      };
+    };
+    expect(args.where.documents).toEqual({ none: {} });
+    expect(args.where.task).toEqual({ projectId: PROJECT_ID });
+    expect(args.where.dueDate.lt).toBeInstanceOf(Date);
+
+    // The legacy positional implementation grouped Document by (taskId, folderId)
+    // to figure out which slots were filled. That groupBy must not happen any more.
+    expect(ctx._spies.documentGroupBy).not.toHaveBeenCalled();
+  });
+
+  it("summary's overdue count is driven by the FK-based slot count (no positional groupBy)", async () => {
+    const ctx = makeCtx();
+    ctx._spies.slotCount.mockResolvedValue(4);
+
+    const result = await router.summary!._handler({
+      ctx,
+      input: { projectId: PROJECT_ID },
+    }) as { overdue: number };
+
+    expect(result.overdue).toBe(4);
+
+    const countArgs = ctx._spies.slotCount.mock.calls[0]![0] as {
+      where: {
+        dueDate: { not: null; lt: Date };
+        task: { projectId: string };
+        documents: { none: object };
+      };
+    };
+    expect(countArgs.where.documents).toEqual({ none: {} });
+    expect(ctx._spies.documentGroupBy).toHaveBeenCalledTimes(1);
+    // groupBy is still used for the pending/approved totals, but its where
+    // clause must not be filtering by the legacy positional shape.
+    const groupArgs = ctx._spies.documentGroupBy.mock.calls[0]![0] as {
+      by: string[];
+      where: Record<string, unknown>;
+    };
+    expect(groupArgs.by).toEqual(["approvalStatus"]);
+  });
+});

--- a/src/__tests__/server/upload-slot-resolve.test.ts
+++ b/src/__tests__/server/upload-slot-resolve.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment node
+//
+// Phase 3 — Slot ↔ Document FK binding.
+//
+// resolveSlotForUpload is the gatekeeper that converts a client-side intent
+// ("upload to this folder, optionally to this slot") into a Document.slotId.
+// These tests pin the two modes:
+//
+//   - Explicit pin (per-slot upload button): caller passes slotId. We
+//     validate task and kind match before honoring it.
+//   - Auto-link (generic folder dropzone): no slotId. We bind to the
+//     lowest-index slot of the matching kind that has no bound document.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { resolveSlotForUpload } from "@/server/api/helpers/uploadSlot";
+
+const TASK_ID = "task-1";
+const OTHER_TASK_ID = "task-2";
+const SLOT_ID = "slot-A";
+
+type Slot = { id: string; taskId: string; kind: string };
+
+function makeDb(opts: {
+  findUniqueResult?: Slot | null;
+  findFirstResult?: { id: string } | null;
+} = {}) {
+  const findUnique = vi.fn().mockResolvedValue(opts.findUniqueResult ?? null);
+  const findFirst = vi.fn().mockResolvedValue(opts.findFirstResult ?? null);
+  return {
+    db: {
+      taskRequirementSlot: { findUnique, findFirst },
+    },
+    findUnique,
+    findFirst,
+  };
+}
+
+describe("resolveSlotForUpload — explicit slotId", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the slot id when it belongs to the task and matches the kind", async () => {
+    const { db } = makeDb({
+      findUniqueResult: { id: SLOT_ID, taskId: TASK_ID, kind: "submittal" },
+    });
+
+    const result = await resolveSlotForUpload(db, {
+      taskId: TASK_ID,
+      slotKind: "submittal",
+      explicitSlotId: SLOT_ID,
+    });
+
+    expect(result).toEqual({ ok: true, slotId: SLOT_ID });
+  });
+
+  it("rejects when the slot belongs to a different task", async () => {
+    const { db } = makeDb({
+      findUniqueResult: { id: SLOT_ID, taskId: OTHER_TASK_ID, kind: "submittal" },
+    });
+
+    const result = await resolveSlotForUpload(db, {
+      taskId: TASK_ID,
+      slotKind: "submittal",
+      explicitSlotId: SLOT_ID,
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects when the slot's kind doesn't match the upload's folder kind", async () => {
+    // User dragged a doc into the Submittals folder but passed an inspection slot's id.
+    const { db } = makeDb({
+      findUniqueResult: { id: SLOT_ID, taskId: TASK_ID, kind: "inspection" },
+    });
+
+    const result = await resolveSlotForUpload(db, {
+      taskId: TASK_ID,
+      slotKind: "submittal",
+      explicitSlotId: SLOT_ID,
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects when the slot id refers to a non-existent slot", async () => {
+    const { db } = makeDb({ findUniqueResult: null });
+
+    const result = await resolveSlotForUpload(db, {
+      taskId: TASK_ID,
+      slotKind: "submittal",
+      explicitSlotId: "nope",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("does not run the auto-link query when an explicit slot id is provided", async () => {
+    const { db, findFirst } = makeDb({
+      findUniqueResult: { id: SLOT_ID, taskId: TASK_ID, kind: "submittal" },
+    });
+
+    await resolveSlotForUpload(db, {
+      taskId: TASK_ID,
+      slotKind: "submittal",
+      explicitSlotId: SLOT_ID,
+    });
+
+    // findFirst is now used both for the occupancy check (explicit path)
+    // and the lowest-index lookup (auto-link path). The auto-link call is
+    // identified by `orderBy.index === "asc"`. The explicit path must not
+    // issue that call.
+    const autoLinkCalls = findFirst.mock.calls.filter(([args]) => {
+      return (args as { orderBy?: { index?: string } }).orderBy?.index === "asc";
+    });
+    expect(autoLinkCalls).toHaveLength(0);
+  });
+
+  it("rejects when the explicit slot already has a bound document", async () => {
+    // Stale UI: another upload bound to this slot between the popover
+    // rendering it as empty and the user clicking. Pre-checking avoids
+    // burning a blob upload + AI analysis on a doomed create (which the
+    // partial unique index would otherwise reject at the DB layer).
+    const { db } = makeDb({
+      findUniqueResult: { id: SLOT_ID, taskId: TASK_ID, kind: "submittal" },
+      findFirstResult: { id: "existing-doc" },
+    });
+
+    const result = await resolveSlotForUpload(db, {
+      taskId: TASK_ID,
+      slotKind: "submittal",
+      explicitSlotId: SLOT_ID,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/already/i);
+    }
+  });
+});
+
+describe("resolveSlotForUpload — auto-link", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the first empty slot's id when one exists", async () => {
+    const { db } = makeDb({ findFirstResult: { id: "slot-empty-3" } });
+
+    const result = await resolveSlotForUpload(db, {
+      taskId: TASK_ID,
+      slotKind: "submittal",
+      explicitSlotId: null,
+    });
+
+    expect(result).toEqual({ ok: true, slotId: "slot-empty-3" });
+  });
+
+  it("returns slotId=null when every slot of this kind is already bound", async () => {
+    // Overflow upload: no slot to auto-link to. The doc still gets created,
+    // it just lands unbound. Surface this as ok with slotId=null so the
+    // route doesn't fail the upload.
+    const { db } = makeDb({ findFirstResult: null });
+
+    const result = await resolveSlotForUpload(db, {
+      taskId: TASK_ID,
+      slotKind: "submittal",
+      explicitSlotId: null,
+    });
+
+    expect(result).toEqual({ ok: true, slotId: null });
+  });
+
+  it("queries by ascending slot index — the visible UI order — and scopes to slots with no document", async () => {
+    // The popover and drawer render slots ordered by index. Auto-link must
+    // bind to the first empty slot the user sees, not a random one.
+    const { db, findFirst } = makeDb({ findFirstResult: { id: "slot-empty-0" } });
+
+    await resolveSlotForUpload(db, {
+      taskId: TASK_ID,
+      slotKind: "submittal",
+      explicitSlotId: null,
+    });
+
+    const args = findFirst.mock.calls[0]![0] as {
+      where: { taskId: string; kind: string; documents: { none: object } };
+      orderBy: { index: string };
+    };
+    expect(args.where.taskId).toBe(TASK_ID);
+    expect(args.where.kind).toBe("submittal");
+    expect(args.where.documents).toEqual({ none: {} });
+    expect(args.orderBy.index).toBe("asc");
+  });
+});

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { put } from "@vercel/blob";
+import { Prisma } from "../../../../generated/prisma";
 import { db } from "@/server/db";
 import { auth } from "@/lib/auth";
 import { analyzeDocument } from "@/server/services/tagging";
 import { embedDocuments, toVectorSql } from "@/server/services/embeddings";
 import { env } from "@/env";
 import { documentProxyUrl } from "@/lib/blobProxy";
+import { slotKindForFolder } from "@/lib/folders";
+import { resolveSlotForUpload } from "@/server/api/helpers/uploadSlot";
 
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
@@ -57,9 +60,11 @@ export async function POST(req: NextRequest) {
     const projectId = formData.get("projectId") as string | null;
     const rawTaskId = formData.get("taskId") as string | null;
     const rawFolderId = formData.get("folderId") as string | null;
+    const rawSlotId = formData.get("slotId") as string | null;
     // Empty string and missing both mean "unassigned"
     const taskId = rawTaskId && rawTaskId.length > 0 ? rawTaskId : null;
     const folderId = rawFolderId && rawFolderId.length > 0 ? rawFolderId : null;
+    const slotIdFromForm = rawSlotId && rawSlotId.length > 0 ? rawSlotId : null;
     const title = (formData.get("title") as string | null)?.trim() || null;
     const notes = (formData.get("notes") as string | null)?.trim() ?? "";
 
@@ -119,6 +124,24 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Slot binding (Phase 3): if the upload targets a trackable folder, bind
+    // it to a specific TaskRequirementSlot. Honors an explicit slotId from
+    // the per-slot upload button; otherwise auto-links to the first empty
+    // slot of the matching kind. Overflow uploads land unbound.
+    const slotKind = slotKindForFolder(folderId);
+    let slotId: string | null = null;
+    if (taskId && slotKind) {
+      const resolved = await resolveSlotForUpload(db, {
+        taskId,
+        slotKind,
+        explicitSlotId: slotIdFromForm,
+      });
+      if (!resolved.ok) {
+        return NextResponse.json({ error: resolved.error }, { status: 400 });
+      }
+      slotId = resolved.slotId;
+    }
+
     const fileBuffer = Buffer.from(await file.arrayBuffer());
 
     // Unassigned uploads land in a project-level "_unassigned" path; assigned uploads use task/folder.
@@ -136,30 +159,72 @@ export async function POST(req: NextRequest) {
     const analysis = await analyzeDocument(fileBuffer, file.type, file.name);
 
     // Create document record with tags and description
-    const document = await db.document.create({
-      data: {
-        name: title || file.name,
-        blobUrl: blob.url,
-        mimeType: file.type,
-        size: file.size,
-        tags: analysis.tags,
-        description: analysis.description,
-        notes,
-        taskId,
-        folderId,
-        projectId,
-        uploadedById: session.user.id,
-      },
-      include: {
-        uploadedBy: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
+    const createDocumentForSlot = (boundSlotId: string | null) =>
+      db.document.create({
+        data: {
+          name: title || file.name,
+          blobUrl: blob.url,
+          mimeType: file.type,
+          size: file.size,
+          tags: analysis.tags,
+          description: analysis.description,
+          notes,
+          taskId,
+          folderId,
+          slotId: boundSlotId,
+          projectId,
+          uploadedById: session.user.id,
+        },
+        include: {
+          uploadedBy: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+            },
           },
         },
-      },
-    });
+      });
+
+    // The partial unique index on Document.slotId rejects a second binding
+    // to the same slot. If we hit it, the explicit-pin case is a real
+    // conflict (UI was stale), but the auto-link case is recoverable —
+    // re-resolve once to grab the next empty slot.
+    let document;
+    try {
+      document = await createDocumentForSlot(slotId);
+    } catch (err) {
+      const target =
+        err instanceof Prisma.PrismaClientKnownRequestError ? err.meta?.target : undefined;
+      const isSlotIdConflict =
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === "P2002" &&
+        ((Array.isArray(target) && target.includes("slotId")) ||
+          target === "Document_slotId_unique");
+
+      if (!isSlotIdConflict) throw err;
+
+      if (slotIdFromForm) {
+        return NextResponse.json(
+          { error: "Slot was filled by a concurrent upload — please retry" },
+          { status: 409 },
+        );
+      }
+
+      // Auto-link race: another upload won the slot we picked. Re-resolve
+      // without an explicit slot and retry once. If every slot is now full,
+      // resolveSlotForUpload returns slotId=null and the doc lands unbound.
+      const retry = await resolveSlotForUpload(db, {
+        taskId: taskId!,
+        slotKind: slotKind!,
+        explicitSlotId: null,
+      });
+      if (!retry.ok) {
+        return NextResponse.json({ error: retry.error }, { status: 400 });
+      }
+      slotId = retry.slotId;
+      document = await createDocumentForSlot(slotId);
+    }
 
     // Generate and store embedding for semantic search (non-blocking — don't fail upload if this fails)
     // Embed filename + description + tags for richer semantic matching

--- a/src/components/bryntum/components/SubmittalDrawer.tsx
+++ b/src/components/bryntum/components/SubmittalDrawer.tsx
@@ -66,10 +66,14 @@ interface SubmittalDrawerProps {
   taskId: string;
   taskName: string;
   initialKind?: SlotKind;
-  /** Documents already uploaded under this task — used to mark slots as filled in order. */
+  /** Documents already uploaded under this task — used for the tab badge counts. */
   docsByKind: Record<SlotKind, DocumentItem[]>;
-  /** Open the upload dialog for a given folder. Reuses the existing UploadDialog flow. */
-  onUploadToFolder: (folderId: 'submittals' | 'inspections') => void;
+  /**
+   * Open the upload dialog for a given folder. Pass a `slotId` to bind the
+   * upload to a specific slot; omit it to let the server auto-link to the
+   * first empty slot.
+   */
+  onUploadToFolder: (folderId: 'submittals' | 'inspections', slotId?: string) => void;
 }
 
 export default function SubmittalDrawer({
@@ -123,8 +127,7 @@ export default function SubmittalDrawer({
         projectId={projectId}
         taskId={taskId}
         kind={activeKind}
-        docs={docsByKind[activeKind]}
-        onUploadToFolder={() => onUploadToFolder(KIND_META[activeKind].folderId)}
+        onUploadToFolder={(slotId) => onUploadToFolder(KIND_META[activeKind].folderId, slotId)}
       />
     </Drawer>
   );
@@ -293,15 +296,13 @@ function DrawerContent({
   projectId,
   taskId,
   kind,
-  docs,
   onUploadToFolder,
 }: {
   organizationId: string;
   projectId: string;
   taskId: string;
   kind: SlotKind;
-  docs: DocumentItem[];
-  onUploadToFolder: () => void;
+  onUploadToFolder: (slotId?: string) => void;
 }) {
   const meta = KIND_META[kind];
   const utils = api.useUtils();
@@ -336,13 +337,19 @@ function DrawerContent({
   // Decrement-with-data confirm state.
   const [confirmRemove, setConfirmRemove] = useState<null | { trailingFilled: number; nextCount: number }>(null);
 
-  const filledCount = Math.min(docs.length, slots.length);
+  // "Filled" now means a slot has a bound document via Document.slotId — no
+  // more docs[i]↔slot[i] positional pairing.
+  const filledCount = slots.reduce((n, s) => n + (s.document ? 1 : 0), 0);
 
   const handleStepCount = (next: number) => {
     if (next < 0 || next > 50) return;
     if (next < slots.length) {
-      // Removing slots — warn if any of the trailing slots map to an uploaded file.
-      const trailingFilled = Math.max(0, filledCount - next);
+      // Removing trailing slots — warn if any are bound. The FK is ON DELETE
+      // SET NULL, so the documents survive (just become unbound); the warning
+      // is about the user's intent, not data loss.
+      const trailingFilled = slots
+        .slice(next)
+        .reduce((n, s) => n + (s.document ? 1 : 0), 0);
       if (trailingFilled > 0) {
         setConfirmRemove({ trailingFilled, nextCount: next });
         return;
@@ -427,12 +434,12 @@ function DrawerContent({
           <EmptyState kind={kind} onSeed={(count) => setCountMutation.mutate({ organizationId, projectId, taskId, kind, count })} />
         ) : (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            {slots.map((slot, i) => (
+            {slots.map((slot) => (
               <SlotCard
                 key={slot.id}
                 slot={slot}
                 kind={kind}
-                doc={docs[i] ?? null}
+                doc={slot.document}
                 members={members}
                 onRename={(name) =>
                   updateSlotMutation.mutate({ organizationId, projectId, slotId: slot.id, name })
@@ -443,7 +450,7 @@ function DrawerContent({
                 onSetApprover={(approverId) =>
                   updateSlotMutation.mutate({ organizationId, projectId, slotId: slot.id, approverId })
                 }
-                onUpload={onUploadToFolder}
+                onUpload={() => onUploadToFolder(slot.id)}
               />
             ))}
           </Box>
@@ -545,13 +552,15 @@ function SlotSummary({
   slots,
   filledCount,
 }: {
-  slots: { dueDate: Date | null }[];
+  slots: { dueDate: Date | null; document: { id: string } | null }[];
   filledCount: number;
 }) {
   const today = startOfDay(new Date());
-  const overdue = slots
-    .slice(filledCount) // only count *unfilled* slots as overdue
-    .filter((s) => s.dueDate && isBefore(new Date(s.dueDate), today)).length;
+  // FK semantics: a slot is overdue when its dueDate has passed and it has
+  // no bound document. Position no longer determines filled-ness.
+  const overdue = slots.filter(
+    (s) => !s.document && s.dueDate && isBefore(new Date(s.dueDate), today),
+  ).length;
   const pending = slots.length - filledCount;
   const parts: React.ReactNode[] = [];
   if (filledCount > 0) {
@@ -598,6 +607,14 @@ type SlotData = {
   approver: { id: string; name: string | null; email: string; image: string | null } | null;
 };
 
+// SlotCard only renders the bound document's name + upload date in the
+// footer, so we type doc minimally to accept whatever listSlots returns.
+type SlotBoundDoc = {
+  id: string;
+  name: string;
+  createdAt: Date | string | null;
+};
+
 type Member = {
   user: { id: string; name: string | null; email: string; image: string | null };
 };
@@ -614,7 +631,7 @@ function SlotCard({
 }: {
   slot: SlotData;
   kind: SlotKind;
-  doc: DocumentItem | null;
+  doc: SlotBoundDoc | null;
   members: Member[];
   onRename: (name: string | null) => void;
   onSetDueDate: (dueDate: string | null) => void;

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -48,9 +48,16 @@ export function TaskDetailsPopover({
   const canManageSlots = canApproveDocuments(memberRole);
 
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
-  const [uploadFolder, setUploadFolder] = useState<{ id: string; name: string } | null>(null);
+  const [uploadTarget, setUploadTarget] = useState<{ folder: { id: string; name: string }; slotId?: string } | null>(null);
   const [rightPanel, setRightPanel] = useState<RightPanel>(null);
   const [drawerKind, setDrawerKind] = useState<SlotKind | null>(null);
+
+  const openUploadDialog = useCallback(
+    (folder: { id: string; name: string }, slotId?: string) => {
+      setUploadTarget({ folder, slotId });
+    },
+    [],
+  );
 
   // ── Drag state ──
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
@@ -158,7 +165,13 @@ export function TaskDetailsPopover({
     void utils.document.countByTask.invalidate({ organizationId, projectId, taskId: taskId! });
     void utils.document.listByTask.invalidate({ organizationId, projectId, taskId: taskId! });
     void utils.document.listByFolder.invalidate({ organizationId, projectId, taskId: taskId! });
-    setUploadFolder(null);
+    // listSlots now embeds the bound document; refresh both kinds so the slot
+    // row that just received an upload re-renders as filled.
+    void utils.gantt.listSlots.invalidate({ organizationId, projectId, taskId: taskId! });
+    void utils.gantt.requirementStats.invalidate({ projectId });
+    void utils.approval.summary.invalidate({ projectId });
+    void utils.approval.listOverdueSlots.invalidate({ projectId });
+    setUploadTarget(null);
   }, [organizationId, projectId, taskId, utils]);
 
   const handleClose = () => {
@@ -408,7 +421,7 @@ export function TaskDetailsPopover({
                       onToggle={() => toggleFolder(folder.id)}
                       count={count}
                       docs={folderDocs}
-                      onUpload={setUploadFolder}
+                      onUpload={openUploadDialog}
                       onSelectDoc={openPreview}
                       selectedDocId={selectedDocId}
                       // Tracking props
@@ -464,16 +477,17 @@ export function TaskDetailsPopover({
       </Popover>
 
       {/* Upload dialog */}
-      {uploadFolder && taskId && (
+      {uploadTarget && taskId && (
         <UploadDialog
           open
           onOpenChange={(isOpen) => {
-            if (!isOpen) setUploadFolder(null);
+            if (!isOpen) setUploadTarget(null);
           }}
           projectId={projectId}
           taskId={taskId}
-          folderId={uploadFolder.id}
-          folderName={uploadFolder.name}
+          folderId={uploadTarget.folder.id}
+          folderName={uploadTarget.folder.name}
+          slotId={uploadTarget.slotId}
           onUploadComplete={handleUploadComplete}
         />
       )}
@@ -496,9 +510,9 @@ export function TaskDetailsPopover({
               expandFolderIds('inspections').includes(d.folderId),
             ),
           }}
-          onUploadToFolder={(folderId) => {
+          onUploadToFolder={(folderId, slotId) => {
             const folder = folderData.find((f) => f.id === folderId);
-            if (folder) setUploadFolder({ id: folder.id, name: folder.name });
+            if (folder) openUploadDialog({ id: folder.id, name: folder.name }, slotId);
           }}
         />
       )}

--- a/src/components/bryntum/components/task-popover/BaseFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/BaseFolderContent.tsx
@@ -15,7 +15,7 @@ function BaseFolderContentInner({
   if (docs.length === 0) {
     return (
       <Box
-        onClick={onUpload}
+        onClick={() => onUpload()}
         sx={{
           ml: '36px',
           mr: 0.75,

--- a/src/components/bryntum/components/task-popover/FolderRow.tsx
+++ b/src/components/bryntum/components/task-popover/FolderRow.tsx
@@ -43,7 +43,7 @@ interface FolderRowProps {
   onToggle: () => void;
   count: number;
   docs: DocumentItem[];
-  onUpload: (folder: { id: string; name: string }) => void;
+  onUpload: (folder: { id: string; name: string }, slotId?: string) => void;
   onSelectDoc: (doc: PreviewDoc) => void;
   selectedDocId: string | null;
   // Tracking props (only used for trackable folders)
@@ -95,7 +95,7 @@ function FolderRowInner({
     docs,
     onSelectDoc,
     selectedDocId,
-    onUpload: () => onUpload({ id: folder.id, name: folder.name }),
+    onUpload: (slotId?: string) => onUpload({ id: folder.id, name: folder.name }, slotId),
     folderName: folder.name,
     projectId,
     taskId,

--- a/src/components/bryntum/components/task-popover/PhotosFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/PhotosFolderContent.tsx
@@ -42,7 +42,7 @@ function PhotosFolderContentInner({
   const AddPhotoTile = (
     <Box
       component="button"
-      onClick={onUpload}
+      onClick={() => onUpload()}
       aria-label="Add photo"
       sx={{
         height: 70,

--- a/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
@@ -15,7 +15,6 @@ interface TrackableFolderContentProps extends FolderContentProps {
 }
 
 function TrackableFolderContentInner({
-  docs,
   onSelectDoc,
   selectedDocId,
   onUpload,
@@ -33,12 +32,14 @@ function TrackableFolderContentInner({
   const canShowApproval =
     !!organizationId && typeof memberRole === 'string';
 
-  // Slot metadata (names) — shares the React Query cache with SubmittalDrawer.
+  // Slots now carry their bound document (Document.slotId FK). The first
+  // element of slot.documents is the doc; null means the slot is empty.
   const slotsQuery = api.gantt.listSlots.useQuery(
     { organizationId: organizationId!, projectId: projectId!, taskId: taskId!, kind: kind! },
     { enabled: !!kind && !!taskId && !!projectId && !!organizationId && (required ?? 0) > 0 },
   );
-  const slotMeta = slotsQuery.data ?? [];
+  const slots = slotsQuery.data ?? [];
+
   // No requirement set — empty state (no dropzones until a requirement is configured)
   if (required === null || required === 0) {
     return (
@@ -64,17 +65,13 @@ function TrackableFolderContentInner({
     );
   }
 
-  // Requirement is set — render N slots
   const singularName = folderName.replace(/s$/i, '');
-  const slots = Array.from({ length: required }, (_, i) => {
-    const doc = docs[i] ?? null;
-    return { index: i, doc };
-  });
 
   return (
     <Box sx={{ pl: '20px', display: 'flex', flexDirection: 'column', gap: '4px', py: 0.75 }}>
-      {slots.map(({ index, doc }) => {
-        const slotNum = index + 1;
+      {slots.map((slot) => {
+        const slotNum = slot.index + 1;
+        const doc = slot.document;
         const isFilled = !!doc;
         const isSelected = isFilled && selectedDocId === doc.id;
 
@@ -87,7 +84,7 @@ function TrackableFolderContentInner({
             size: doc.size,
             createdAt: doc.createdAt,
             uploadedBy: doc.uploadedBy ?? null,
-            folderId: doc.folderId,
+            folderId: doc.folderId ?? '',
             approvalStatus: doc.approvalStatus,
             approvedAt: doc.approvedAt,
             approvedBy: doc.approvedBy,
@@ -96,7 +93,7 @@ function TrackableFolderContentInner({
 
           return (
             <Box
-              key={doc.id}
+              key={slot.id}
               onClick={() => onSelectDoc(preview)}
               sx={{
                 display: 'flex',
@@ -171,11 +168,11 @@ function TrackableFolderContentInner({
           );
         }
 
-        // Empty slot — mini dropzone
+        // Empty slot — clicking pins the upload to this specific slot via slotId.
         return (
           <Box
-            key={`empty-${index}`}
-            onClick={onUpload}
+            key={slot.id}
+            onClick={() => onUpload(slot.id)}
             sx={{
               display: 'flex',
               alignItems: 'center',
@@ -224,7 +221,7 @@ function TrackableFolderContentInner({
                 minWidth: 0,
               }}
             >
-              {slotMeta[index]?.name?.trim() || `${singularName} ${slotNum}`}
+              {slot.name?.trim() || `${singularName} ${slotNum}`}
             </Typography>
           </Box>
         );

--- a/src/components/bryntum/components/task-popover/types.ts
+++ b/src/components/bryntum/components/task-popover/types.ts
@@ -36,7 +36,12 @@ export interface FolderContentProps {
   docs: DocumentItem[];
   onSelectDoc: (doc: PreviewDoc) => void;
   selectedDocId: string | null;
-  onUpload: () => void;
+  /**
+   * Open the upload dialog for this folder. Pass a `slotId` to bind the
+   * upload to a specific slot (per-slot upload button on a trackable folder);
+   * omit it to let the server auto-link to the first empty slot.
+   */
+  onUpload: (slotId?: string) => void;
   folderName: string;
   // Optional pin context — only consumed by the Photos folder
   projectId?: string;

--- a/src/components/documents/UploadDialog.tsx
+++ b/src/components/documents/UploadDialog.tsx
@@ -25,6 +25,12 @@ interface UploadDialogProps {
   taskId: string;
   folderId: string;
   folderName: string;
+  /**
+   * Pin this upload to a specific TaskRequirementSlot. When set, the server
+   * binds Document.slotId to this slot instead of auto-linking to the first
+   * empty slot of the matching kind.
+   */
+  slotId?: string;
   onUploadComplete: () => void;
 }
 
@@ -35,6 +41,7 @@ export default function UploadDialog({
   taskId,
   folderId,
   folderName,
+  slotId,
   onUploadComplete,
 }: UploadDialogProps) {
   const [file, setFile] = useState<File | null>(null);
@@ -126,6 +133,7 @@ export default function UploadDialog({
       formData.append('projectId', projectId);
       formData.append('taskId', taskId);
       formData.append('folderId', folderId);
+      if (slotId) formData.append('slotId', slotId);
       if (title.trim()) formData.append('title', title.trim());
       if (notes.trim()) formData.append('notes', notes.trim());
 

--- a/src/lib/folders.ts
+++ b/src/lib/folders.ts
@@ -93,3 +93,19 @@ export function isApprovableFolder(folderId: string | null | undefined): boolean
 }
 
 export const APPROVABLE_FOLDER_ID_LIST: string[] = Array.from(APPROVABLE_FOLDER_IDS);
+
+const SUBMITTAL_FOLDER_IDS = new Set(expandFolderIds("submittals"));
+const INSPECTION_FOLDER_IDS = new Set(expandFolderIds("inspections"));
+
+/**
+ * Maps a folder to the slot kind a document there should bind to.
+ * Returns null for non-trackable folders (RFI, change orders, photos).
+ */
+export function slotKindForFolder(
+  folderId: string | null | undefined,
+): "submittal" | "inspection" | null {
+  if (!folderId) return null;
+  if (SUBMITTAL_FOLDER_IDS.has(folderId)) return "submittal";
+  if (INSPECTION_FOLDER_IDS.has(folderId)) return "inspection";
+  return null;
+}

--- a/src/server/api/helpers/uploadSlot.ts
+++ b/src/server/api/helpers/uploadSlot.ts
@@ -1,0 +1,79 @@
+import type { SlotKind } from "@/lib/validations/gantt";
+
+export type ResolveSlotResult =
+  | { ok: true; slotId: string | null }
+  | { ok: false; error: string };
+
+// Structural type narrow enough to accept the real PrismaClient AND a
+// vitest mock with just these two methods. Avoids importing the full
+// generated delegate type into tests.
+type SlotResolverDb = {
+  taskRequirementSlot: {
+    findUnique: (args: {
+      where: { id: string };
+      select: { id: true; taskId: true; kind: true };
+    }) => Promise<{ id: string; taskId: string; kind: string } | null>;
+    findFirst: (args: {
+      where: {
+        id?: string;
+        taskId?: string;
+        kind?: SlotKind;
+        documents?: { none?: Record<string, never>; some?: Record<string, never> };
+      };
+      orderBy?: { index: "asc" };
+      select: { id: true };
+    }) => Promise<{ id: string } | null>;
+  };
+};
+
+/**
+ * Determines the TaskRequirementSlot a new upload should bind to via
+ * Document.slotId, given an optional explicit slotId from the client.
+ *
+ * - If the caller passed an `explicitSlotId` (per-slot upload button): verify
+ *   the slot exists, belongs to this task, and matches the kind implied by
+ *   the upload's folder. Mismatches return an error so the upload aborts.
+ * - Otherwise (generic folder dropzone): auto-link to the lowest-index slot
+ *   that has no bound document yet.
+ * - If every slot of this kind is already full, the upload lands unbound
+ *   (slotId = null). The doc still exists in the folder — it just doesn't
+ *   satisfy any slot's requirement.
+ */
+export async function resolveSlotForUpload(
+  db: SlotResolverDb,
+  args: { taskId: string; slotKind: SlotKind; explicitSlotId: string | null },
+): Promise<ResolveSlotResult> {
+  const { taskId, slotKind, explicitSlotId } = args;
+
+  if (explicitSlotId) {
+    const slot = await db.taskRequirementSlot.findUnique({
+      where: { id: explicitSlotId },
+      select: { id: true, taskId: true, kind: true },
+    });
+    if (!slot || slot.taskId !== taskId || slot.kind !== slotKind) {
+      return { ok: false, error: "Invalid slot for this task and folder" };
+    }
+    // Reject if the slot is already bound. The partial unique index on
+    // Document.slotId catches this at the DB layer too, but pre-checking
+    // here avoids burning a blob upload + AI analysis on a doomed create.
+    const occupied = await db.taskRequirementSlot.findFirst({
+      where: { id: slot.id, documents: { some: {} } },
+      select: { id: true },
+    });
+    if (occupied) {
+      return { ok: false, error: "Slot already has a document" };
+    }
+    return { ok: true, slotId: slot.id };
+  }
+
+  const empty = await db.taskRequirementSlot.findFirst({
+    where: {
+      taskId,
+      kind: slotKind,
+      documents: { none: {} },
+    },
+    orderBy: { index: "asc" },
+    select: { id: true },
+  });
+  return { ok: true, slotId: empty?.id ?? null };
+}

--- a/src/server/api/routers/approval.ts
+++ b/src/server/api/routers/approval.ts
@@ -100,9 +100,9 @@ export const approvalRouter = createTRPCRouter({
     }),
 
   /**
-   * Slots whose dueDate has passed and don't yet have an upload mapped to them.
-   * Maps a slot to "filled" by index: if N docs exist under the kind's folder
-   * for that task, slots 0..N-1 are filled. Mirrors the per-task popover logic.
+   * Slots whose dueDate has passed and have no document bound to them via
+   * Document.slotId. Phase 3 replaced positional "slots 0..N-1 are filled by
+   * docs 0..N-1" with this explicit FK check.
    */
   listOverdueSlots: orgProcedure
     .input(z.object({ projectId: z.string() }))
@@ -116,10 +116,11 @@ export const approvalRouter = createTRPCRouter({
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 
-      const candidates = await ctx.db.taskRequirementSlot.findMany({
+      const overdue = await ctx.db.taskRequirementSlot.findMany({
         where: {
           dueDate: { not: null, lt: today },
           task: { projectId: input.projectId },
+          documents: { none: {} },
         },
         orderBy: { dueDate: "asc" },
         include: {
@@ -128,49 +129,16 @@ export const approvalRouter = createTRPCRouter({
         },
       });
 
-      if (candidates.length === 0) return [];
-
-      const taskIds = Array.from(new Set(candidates.map((c) => c.task.id)));
-      const submittalIds = expandFolderIds("submittals");
-      const inspectionIds = expandFolderIds("inspections");
-
-      const grouped = await ctx.db.document.groupBy({
-        by: ["taskId", "folderId"],
-        where: {
-          projectId: input.projectId,
-          taskId: { in: taskIds },
-          folderId: { in: [...submittalIds, ...inspectionIds] },
-        },
-        _count: { _all: true },
-      });
-
-      // count[taskId][kind] = number of docs uploaded under that folder family
-      const counts = new Map<string, { submittal: number; inspection: number }>();
-      for (const row of grouped) {
-        // The where clause constrains taskId/folderId to non-null IN-lists, so guards are belt-and-suspenders.
-        if (!row.taskId || !row.folderId) continue;
-        const bucket = counts.get(row.taskId) ?? { submittal: 0, inspection: 0 };
-        if (submittalIds.includes(row.folderId)) bucket.submittal += row._count._all;
-        if (inspectionIds.includes(row.folderId)) bucket.inspection += row._count._all;
-        counts.set(row.taskId, bucket);
-      }
-
-      return candidates
-        .filter((slot) => {
-          const c = counts.get(slot.task.id) ?? { submittal: 0, inspection: 0 };
-          const filledForKind = slot.kind === "submittal" ? c.submittal : c.inspection;
-          return slot.index >= filledForKind;
-        })
-        .map((slot) => ({
-          id: slot.id,
-          taskId: slot.task.id,
-          taskName: slot.task.name,
-          kind: slot.kind as SlotKind,
-          index: slot.index,
-          name: slot.name,
-          dueDate: slot.dueDate!,
-          approver: slot.approver,
-        }));
+      return overdue.map((slot) => ({
+        id: slot.id,
+        taskId: slot.task.id,
+        taskName: slot.task.name,
+        kind: slot.kind as SlotKind,
+        index: slot.index,
+        name: slot.name,
+        dueDate: slot.dueDate!,
+        approver: slot.approver,
+      }));
     }),
 
   /**
@@ -264,48 +232,19 @@ export const approvalRouter = createTRPCRouter({
 });
 
 /**
- * Returns the number of slots whose dueDate has passed and which don't yet
- * have an upload covering them. Used by `summary` for the overdue badge.
+ * Returns the number of slots whose dueDate has passed and have no
+ * document bound to them via Document.slotId. Used by `summary` for the
+ * overdue badge in the sidebar.
  */
 async function countOverdueSlots(db: PrismaClient, projectId: string): Promise<number> {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  const candidates = await db.taskRequirementSlot.findMany({
+  return db.taskRequirementSlot.count({
     where: {
       dueDate: { not: null, lt: today },
       task: { projectId },
+      documents: { none: {} },
     },
-    select: { id: true, taskId: true, kind: true, index: true },
   });
-  if (candidates.length === 0) return 0;
-
-  const taskIds = Array.from(new Set(candidates.map((c) => c.taskId)));
-  const submittalIds = expandFolderIds("submittals");
-  const inspectionIds = expandFolderIds("inspections");
-
-  const grouped = await db.document.groupBy({
-    by: ["taskId", "folderId"],
-    where: {
-      projectId,
-      taskId: { in: taskIds },
-      folderId: { in: [...submittalIds, ...inspectionIds] },
-    },
-    _count: { _all: true },
-  });
-
-  const counts = new Map<string, { submittal: number; inspection: number }>();
-  for (const row of grouped) {
-    if (!row.taskId || !row.folderId) continue;
-    const bucket = counts.get(row.taskId) ?? { submittal: 0, inspection: 0 };
-    if (submittalIds.includes(row.folderId)) bucket.submittal += row._count._all;
-    if (inspectionIds.includes(row.folderId)) bucket.inspection += row._count._all;
-    counts.set(row.taskId, bucket);
-  }
-
-  return candidates.filter((slot) => {
-    const c = counts.get(slot.taskId) ?? { submittal: 0, inspection: 0 };
-    const filledForKind = slot.kind === "submittal" ? c.submittal : c.inspection;
-    return slot.index >= filledForKind;
-  }).length;
 }

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/validations/gantt";
 import { nextSuggestedSlotName } from "@/lib/constants/slotNameLibrary";
 import { APPROVABLE_FOLDER_ID_LIST } from "@/lib/folders";
+import { documentProxyUrl } from "@/lib/blobProxy";
 import { buildTaskTree, mapDependencyToGantt, mapResourceToGantt, mapAssignmentToGantt, mapTimeRangeToGantt } from "@/server/api/helpers/ganttTree";
 import { syncTasks, syncDependencies, syncResources, syncAssignments, syncTimeRanges } from "@/server/api/helpers/ganttSync";
 
@@ -356,7 +357,9 @@ export const ganttRouter = createTRPCRouter({
 
   /**
    * Project-wide requirement stats for the toolbar progress card.
-   * Returns total required and total uploaded across all tasks.
+   * Returns total required and total uploaded across all tasks. Uses the
+   * Document.slotId FK to count satisfied slots; uploads that aren't bound
+   * to a slot (overflow, or dropped outside a slot button) don't count.
    */
   requirementStats: orgProcedure
     .input(z.object({ projectId: z.string() }))
@@ -371,8 +374,7 @@ export const ganttRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Project not found or access denied" });
       }
 
-      // Get the latest task end date and all tasks with requirements in parallel
-      const [latestEndDate, tasksWithReqs] = await Promise.all([
+      const [latestEndDate, tasksWithReqs, filledSlots] = await Promise.all([
         ctx.db.ganttTask.aggregate({
           where: { projectId, endDate: { not: null } },
           _max: { endDate: true },
@@ -391,63 +393,25 @@ export const ganttRouter = createTRPCRouter({
             requiredInspections: true,
           },
         }),
+        ctx.db.taskRequirementSlot.count({
+          where: {
+            task: { projectId },
+            documents: { some: {} },
+          },
+        }),
       ]);
 
-      if (tasksWithReqs.length === 0) {
-        return { totalRequired: 0, totalUploaded: 0, latestEndDate: latestEndDate._max.endDate ?? null };
-      }
-
-      // Sum all required counts
       let totalRequired = 0;
       for (const t of tasksWithReqs) {
         totalRequired += t.requiredSubmittals ?? 0;
         totalRequired += t.requiredInspections ?? 0;
       }
 
-      // Count documents in submittal/inspection folders for these tasks
-      const taskIds = tasksWithReqs.map((t) => t.id);
-      const docCounts = await ctx.db.document.groupBy({
-        by: ["taskId", "folderId"],
-        where: {
-          projectId,
-          taskId: { in: taskIds },
-          folderId: {
-            startsWith: "submittals",
-          },
-        },
-        _count: { id: true },
-      });
-
-      const inspectionDocs = await ctx.db.document.groupBy({
-        by: ["taskId", "folderId"],
-        where: {
-          projectId,
-          taskId: { in: taskIds },
-          folderId: {
-            startsWith: "inspections",
-          },
-        },
-        _count: { id: true },
-      });
-
-      // Sum uploaded per task, capped by their requirement
-      let totalUploaded = 0;
-      for (const t of tasksWithReqs) {
-        if (t.requiredSubmittals != null) {
-          const uploaded = docCounts
-            .filter((d) => d.taskId === t.id)
-            .reduce((sum, d) => sum + d._count.id, 0);
-          totalUploaded += Math.min(uploaded, t.requiredSubmittals);
-        }
-        if (t.requiredInspections != null) {
-          const uploaded = inspectionDocs
-            .filter((d) => d.taskId === t.id)
-            .reduce((sum, d) => sum + d._count.id, 0);
-          totalUploaded += Math.min(uploaded, t.requiredInspections);
-        }
-      }
-
-      return { totalRequired, totalUploaded, latestEndDate: latestEndDate._max.endDate ?? null };
+      return {
+        totalRequired,
+        totalUploaded: filledSlots,
+        latestEndDate: latestEndDate._max.endDate ?? null,
+      };
     }),
 
   // ─── Per-slot tracking (Tier 2/3) ──────────────────────────────────────
@@ -469,36 +433,66 @@ export const ganttRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Task not found" });
       }
 
+      const slotInclude = {
+        approver: { select: { id: true, name: true, email: true, image: true } },
+        documents: {
+          orderBy: { createdAt: "asc" },
+          take: 1,
+          select: {
+            id: true,
+            name: true,
+            blobUrl: true,
+            mimeType: true,
+            size: true,
+            folderId: true,
+            createdAt: true,
+            approvalStatus: true,
+            approvedAt: true,
+            approvedBy: { select: { id: true, name: true, email: true } },
+            uploadedBy: { select: { id: true, name: true, email: true } },
+          },
+        },
+      } as const;
+
       const existing = await ctx.db.taskRequirementSlot.findMany({
         where: { taskId, kind },
         orderBy: { index: "asc" },
-        include: {
-          approver: { select: { id: true, name: true, email: true, image: true } },
-        },
+        include: slotInclude,
       });
 
       const legacyCount = legacyCountForKind(task, kind);
 
       // Lazy backfill: legacy count > 0 but no slot rows yet → create N anonymous slots.
-      if (existing.length === 0 && legacyCount > 0) {
-        await ctx.db.taskRequirementSlot.createMany({
-          data: Array.from({ length: legacyCount }, (_, i) => ({
-            taskId,
-            kind,
-            index: i,
-          })),
-          skipDuplicates: true,
-        });
-        return ctx.db.taskRequirementSlot.findMany({
-          where: { taskId, kind },
-          orderBy: { index: "asc" },
-          include: {
-            approver: { select: { id: true, name: true, email: true, image: true } },
-          },
-        });
-      }
+      const slots =
+        existing.length === 0 && legacyCount > 0
+          ? await (async () => {
+              await ctx.db.taskRequirementSlot.createMany({
+                data: Array.from({ length: legacyCount }, (_, i) => ({
+                  taskId,
+                  kind,
+                  index: i,
+                })),
+                skipDuplicates: true,
+              });
+              return ctx.db.taskRequirementSlot.findMany({
+                where: { taskId, kind },
+                orderBy: { index: "asc" },
+                include: slotInclude,
+              });
+            })()
+          : existing;
 
-      return existing;
+      // Flatten: collapse `documents[0]` into a single `document` field with a
+      // proxied blob URL the client can render. The partial unique index on
+      // Document.slotId enforces at-most-one bound document per slot, so
+      // `take: 1` is precisely the bound document.
+      return slots.map(({ documents, ...slot }) => {
+        const doc = documents[0] ?? null;
+        return {
+          ...slot,
+          document: doc ? { ...doc, blobUrl: documentProxyUrl(doc.id) } : null,
+        };
+      });
     }),
 
   setSlotCount: orgProcedure


### PR DESCRIPTION
## Summary
- Replaces positional doc↔slot pairing with an explicit `Document.slotId` FK plus a partial unique index that enforces at-most-one bound document per slot.
- `resolveSlotForUpload` honors an explicit `slotId` from the per-slot upload button (with task/kind/occupancy checks) or auto-links to the lowest-index empty slot; the upload route catches `P2002` to retry auto-link races and returns 409 for stale explicit pins.
- Overdue and requirement-stats queries now read "filled" from the FK (`documents: { some/none: {} }`) instead of counting docs by folder family, and `gantt.listSlots` embeds the bound document so the popover/drawer render directly from slot data.
- Migrations: additive `slotId` FK with positional backfill + slot pre-creation for tasks whose lazy backfill never ran, then a partial unique index (`Document_slotId_unique WHERE slotId IS NOT NULL`) with a safety pass that unbinds any pre-existing duplicates.

## Test plan
- [ ] `npm run typecheck`
- [ ] `npx vitest run src/__tests__/server/upload-slot-resolve.test.ts src/__tests__/server/approval-overdue-fk.test.ts`
- [ ] Upload to an empty slot via the per-slot button → slot renders filled
- [ ] Upload to the generic folder dropzone → auto-links to first empty slot
- [ ] Reduce slot count with bound docs → docs survive but unbind (ON DELETE SET NULL)
- [ ] Overdue badge in sidebar reflects past-due slots with no bound document

🤖 Generated with [Claude Code](https://claude.com/claude-code)