### PR TITLE
Improve add-task UX and fix Bryntum sync regressions

### DIFF
--- a/claudedocs/trpc-guide.md
+++ b/claudedocs/trpc-guide.md
@@ -213,7 +213,7 @@ await ctx.db.$transaction(async (tx) => {
 
 A few procedures deal with data that was migrated additively — a new table sits next to a legacy column without backfilling rows in the migration itself. The pattern is to backfill **on first read** inside the read procedure:
 
-- `gantt.listSlots` lazily creates `TaskRequirementSlot` rows the first time a task with a non-zero `requiredSubmittals` / `requiredInspections` is read. The legacy count column remains the source of truth for the count; the new table holds the per-slot metadata (`name`, `dueDate`, `approverId`).
+- `gantt.listSlots` lazily creates `TaskRequirementSlot` rows the first time a task with a non-zero `requiredSubmittals` / `requiredInspections` is read. The legacy count column remains the source of truth for the count; the new table holds the per-slot metadata (`name`, `dueDate`).
 - Mutations that change the count (`gantt.setSlotCount`) keep the legacy column synced inside the same `$transaction` so existing readers (`gantt.taskDetail`, `gantt.requirementStats`, the inline popover progress) don't need to change.
 
 Use this pattern when a migration is purely additive and the read path can self-heal — it avoids destructive bulk-write migrations on the shared dev DB.

--- a/prisma/migrations/20260522040000_drop_slot_approver/migration.sql
+++ b/prisma/migrations/20260522040000_drop_slot_approver/migration.sql
@@ -1,0 +1,4 @@
+-- Drop the per-slot approver feature: the FK, its index, and the column.
+ALTER TABLE "TaskRequirementSlot" DROP CONSTRAINT IF EXISTS "TaskRequirementSlot_approverId_fkey";
+DROP INDEX IF EXISTS "TaskRequirementSlot_approverId_idx";
+ALTER TABLE "TaskRequirementSlot" DROP COLUMN IF EXISTS "approverId";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,7 +35,6 @@ model User {
     invitations        Invitation[]     @relation("InvitedByUser")
     documents          Document[]
     approvedDocuments  Document[]       @relation("ApprovedByUser")
-    approverSlots      TaskRequirementSlot[] @relation("SlotApprover")
     notifications      Notification[]
     activeOrganization Organization?    @relation("ActiveOrganization", fields: [activeOrganizationId], references: [id], onDelete: SetNull)
     activeProject      Project?         @relation("ActiveProject", fields: [activeProjectId], references: [id], onDelete: SetNull)
@@ -311,17 +310,14 @@ model TaskRequirementSlot {
     index       Int
     name        String?
     dueDate     DateTime?
-    approverId  String?
     createdAt   DateTime  @default(now())
     updatedAt   DateTime  @updatedAt
 
     task      GanttTask  @relation(fields: [taskId], references: [id], onDelete: Cascade)
-    approver  User?      @relation("SlotApprover", fields: [approverId], references: [id], onDelete: SetNull)
     documents Document[]
 
     @@unique([taskId, kind, index])
     @@index([taskId, kind])
-    @@index([approverId])
     @@index([dueDate])
 }
 

--- a/src/__tests__/lib/slot-validations.test.ts
+++ b/src/__tests__/lib/slot-validations.test.ts
@@ -65,9 +65,4 @@ describe("updateSlotSchema", () => {
   it("accepts null dueDate to clear it", () => {
     expect(updateSlotSchema.parse({ slotId: "s1", dueDate: null }).dueDate).toBeNull();
   });
-
-  it("accepts approverId as nullable string", () => {
-    expect(updateSlotSchema.parse({ slotId: "s1", approverId: "u1" }).approverId).toBe("u1");
-    expect(updateSlotSchema.parse({ slotId: "s1", approverId: null }).approverId).toBeNull();
-  });
 });

--- a/src/__tests__/server/gantt-slot-sync.test.ts
+++ b/src/__tests__/server/gantt-slot-sync.test.ts
@@ -7,7 +7,7 @@
 // touched only the integer column, and `gantt.setSlotCount` (drawer) which
 // updated both the integer column AND the TaskRequirementSlot rows in one
 // transaction. The two paths could desync — a popover decrement would orphan
-// slot rows with names/dueDates/approvers that silently reappeared on the next
+// slot rows with names/dueDates that silently reappeared on the next
 // increment.
 //
 // Post Phase 1, `updateRequirement` is removed and `setSlotCount` is the only
@@ -70,7 +70,7 @@ function makeCtx(existingSlots: Array<{ id: string; index: number; name: string 
             }),
           );
         }
-        return Promise.resolve(finalSlots.map((s) => ({ ...s, approver: null })));
+        return Promise.resolve(finalSlots);
       }),
       createMany: vi.fn().mockImplementation(({ data }: { data: Array<{ index: number; name: string | null }> }) => {
         for (const row of data) {

--- a/src/__tests__/server/gantt-sync-add.test.ts
+++ b/src/__tests__/server/gantt-sync-add.test.ts
@@ -274,6 +274,40 @@ describe("gantt.sync — add task", () => {
     warnSpy.mockRestore();
   });
 
+  // Regression: Bryntum's CrudManager treats every entry in `tasks.rows` as a
+  // phantom→real id swap and dereferences `phantomMap[row.$PhantomId]`. Pushing
+  // an "update" row (which has no $PhantomId) into the same array makes
+  // afterSyncAttempt throw "Cannot set properties of undefined (setting
+  // 'isBeingMaterialized')" the moment a sync contains both adds and updates —
+  // which happens every time a subtask is added (parent task gets re-ordered).
+  it("does NOT push updated tasks into tasks.rows (only adds with $PhantomId)", async () => {
+    const ctx = makeCtx();
+    // Mark the updated row as existing so the update mock resolves
+    ctx.tx.ganttTask.update.mockResolvedValue({ id: "existing-real-id" });
+
+    const result = await sync._handler({
+      ctx,
+      input: {
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        tasks: {
+          added: [{ $PhantomId: "_new1", name: "New task" }],
+          updated: [{ id: "existing-real-id", name: "Renamed" }],
+        },
+      },
+    });
+
+    // 1 add → 1 row. The update must NOT contribute a row.
+    expect(result.tasks.rows).toHaveLength(1);
+    expect(result.tasks.rows[0]!.$PhantomId).toBe("_new1");
+    // No entry in rows should be missing $PhantomId — that's the contract.
+    for (const row of result.tasks.rows) {
+      expect(row.$PhantomId).toBeDefined();
+    }
+    // Sanity: the update still ran against the DB.
+    expect(ctx.tx.ganttTask.update).toHaveBeenCalledTimes(1);
+  });
+
   it("nulls parentId when the referenced parent does not exist (orphan defense)", async () => {
     const ctx = makeCtx();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/app/api/gantt/sync/route.ts
+++ b/src/app/api/gantt/sync/route.ts
@@ -42,16 +42,41 @@ export async function POST(request: Request) {
     // Parse request body
     const body = await request.json() as Record<string, unknown>;
 
-    const taskChanges = body.tasks as { added?: unknown[]; updated?: Array<Record<string, unknown>>; removed?: unknown[] } | undefined;
+    const taskChanges = body.tasks as { added?: Array<Record<string, unknown>>; updated?: Array<Record<string, unknown>>; removed?: Array<Record<string, unknown>> } | undefined;
     console.log('[Gantt:sync] Incoming request — projectId:', projectId,
       'tasks: +' + (taskChanges?.added?.length ?? 0),
       '~' + (taskChanges?.updated?.length ?? 0),
       '-' + (taskChanges?.removed?.length ?? 0));
-    if ((taskChanges?.added?.length ?? 0) > 0) {
-      console.log('[Gantt:sync] Added task payload:', JSON.stringify(taskChanges?.added?.[0], null, 2));
+
+    // Full-list payload dumps fire on every autosync (~500ms during edits) and
+    // balloon Vercel log volume. Keep the per-sync counts above, and only emit
+    // the full breakdown when GANTT_SYNC_DEBUG is set or in development.
+    const verbose = process.env.NODE_ENV !== 'production' || process.env.GANTT_SYNC_DEBUG === '1';
+    if (verbose && (taskChanges?.added?.length ?? 0) > 0) {
+      console.log('[Gantt:sync] Added tasks (full list):', JSON.stringify(
+        taskChanges?.added?.map((t) => ({
+          $PhantomId: t.$PhantomId,
+          id: t.id,
+          name: t.name,
+          parentId: t.parentId,
+          startDate: t.startDate,
+          duration: t.duration,
+          keys: Object.keys(t),
+        })),
+        null,
+        2,
+      ));
     }
-    if ((taskChanges?.updated?.length ?? 0) > 0) {
-      console.log('[Gantt:sync] First updated task payload:', JSON.stringify(taskChanges?.updated?.[0], null, 2));
+    if (verbose && (taskChanges?.updated?.length ?? 0) > 0) {
+      console.log('[Gantt:sync] Updated tasks (full list):', JSON.stringify(
+        taskChanges?.updated?.map((t) => ({
+          id: t.id,
+          parentId: t.parentId,
+          changedKeys: Object.keys(t).filter((k) => k !== 'id'),
+        })),
+        null,
+        2,
+      ));
     }
 
     // Create tRPC context and caller
@@ -68,7 +93,14 @@ export async function POST(request: Request) {
       ...body,
     });
 
-    console.log('[Gantt:sync] Success — task rows returned:', (result as { tasks?: { rows?: unknown[] } }).tasks?.rows?.length ?? 0);
+    const typedResult = result as { tasks?: { rows?: Array<{ id?: string; $PhantomId?: string }> } };
+    const rows = typedResult.tasks?.rows ?? [];
+    if (verbose) {
+      console.log('[Gantt:sync] Success — task rows returned:', rows.length, 'mapping:',
+        JSON.stringify(rows.map((r) => ({ phantom: r.$PhantomId, real: r.id })), null, 2));
+    } else {
+      console.log('[Gantt:sync] Success — task rows returned:', rows.length);
+    }
 
     return NextResponse.json(result);
   } catch (error) {

--- a/src/components/approvals/ReviewQueueContent.tsx
+++ b/src/components/approvals/ReviewQueueContent.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Box, Typography, Tabs, Tab, ToggleButton, ToggleButtonGroup, Alert, Avatar } from '@mui/material';
+import { Box, Typography, Tabs, Tab, ToggleButton, ToggleButtonGroup, Alert } from '@mui/material';
 import { SealCheck, Clock, WarningCircle, PaperPlaneTilt, ClipboardText } from '@phosphor-icons/react';
 import { format, formatDistanceToNow } from 'date-fns';
 import { api } from '@/trpc/react';
@@ -229,7 +229,6 @@ interface OverdueSlot {
   index: number;
   name: string | null;
   dueDate: Date | string;
-  approver: { id: string; name: string | null; email: string; image: string | null } | null;
 }
 
 function OverdueSlotRow({ slot }: { slot: OverdueSlot }) {
@@ -296,17 +295,6 @@ function OverdueSlotRow({ slot }: { slot: OverdueSlot }) {
           {slot.taskName}
         </Typography>
       </Box>
-      {slot.approver && (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexShrink: 0, color: 'text.secondary' }}>
-          <Avatar
-            src={slot.approver.image ?? undefined}
-            sx={{ width: 18, height: 18, fontSize: 9, fontWeight: 600 }}
-          >
-            {(slot.approver.name ?? slot.approver.email).charAt(0).toUpperCase()}
-          </Avatar>
-          <Typography sx={{ fontSize: 11 }}>{slot.approver.name ?? slot.approver.email}</Typography>
-        </Box>
-      )}
       <Box sx={{ textAlign: 'right', flexShrink: 0 }}>
         <Typography sx={{ fontSize: 11, fontWeight: 600, color: 'warning.main' }}>
           Due {format(due, 'MMM d')}

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useRef, useEffect, useCallback, useMemo, type CSSProperties } from 'react';
 import { BryntumGantt } from '@bryntum/gantt-react';
-import { Menu } from '@bryntum/gantt';
 import '@bryntum/gantt/gantt.css';
 import { Box } from '@mui/material';
 import { api } from '@/trpc/react';
@@ -130,20 +129,112 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     const gantt = getGanttInstance();
     if (!gantt?.project) return;
 
+    // Intercept the sync POST itself so we capture the raw response BEFORE
+    // Bryntum's afterSyncAttempt iterates it. afterSyncAttempt can throw
+    // ("Cannot set properties of undefined (setting 'isBeingMaterialized')")
+    // and when it does, our `sync` event listener never fires — so the only
+    // way to see what the server returned is to tee the response here.
+    //
+    // Dev-only: this reassigns `window.fetch` globally for the page lifetime
+    // and we don't want production traffic paying the wrapper cost (or risking
+    // collisions with other fetch interceptors across HMR cycles). The whole
+    // block is dead-code-eliminated in production builds.
+    const fetchDebugEnabled = process.env.NODE_ENV !== 'production';
+    const originalFetch = window.fetch;
+    const wrappedFetch: typeof window.fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const isGanttSync = typeof url === 'string' && url.includes('/api/gantt/sync');
+      if (!isGanttSync) return originalFetch(input, init);
+
+      // Log the outgoing request body too — confirms what really hit the wire.
+      if (init?.body) {
+        try {
+          const parsed = JSON.parse(String(init.body)) as { tasks?: { added?: Array<Record<string, unknown>> } };
+          console.log('[Gantt:fetch] POST /api/gantt/sync → outgoing body', {
+            addedCount: parsed.tasks?.added?.length ?? 0,
+            added: (parsed.tasks?.added ?? []).map((t) => ({
+              id: t.id,
+              $PhantomId: t.$PhantomId,
+              parentId: t.parentId,
+              name: t.name,
+            })),
+          });
+        } catch {
+          /* not JSON */
+        }
+      }
+
+      const response = await originalFetch(input, init);
+      // Clone so Bryntum can still consume the body unmodified.
+      const clone = response.clone();
+      void clone.text().then((text) => {
+        try {
+          const json = JSON.parse(text) as {
+            success?: boolean;
+            message?: string;
+            tasks?: { rows?: Array<{ id?: string; $PhantomId?: string }> };
+          };
+          console.log('[Gantt:fetch] /api/gantt/sync → raw response (clone)', {
+            httpStatus: response.status,
+            success: json.success,
+            message: json.message,
+            taskRowsCount: json.tasks?.rows?.length ?? 0,
+            rows: json.tasks?.rows,
+          });
+        } catch {
+          console.warn('[Gantt:fetch] /api/gantt/sync → non-JSON response', { httpStatus: response.status, text });
+        }
+      });
+      return response;
+    };
+    if (fetchDebugEnabled) {
+      window.fetch = wrappedFetch;
+    }
+
     const onSync = (event: unknown) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const response = (event as any)?.response;
-      console.log('[Gantt:client] sync OK', {
-        success: response?.success,
-        tasksReturned: response?.tasks?.rows?.length ?? 0,
-        sentAdded: lastSyncAddedIdsRef.current.size,
-        sentRemoved: lastSyncRemovedIdsRef.current.size,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const sentIds = Array.from(lastSyncAddedIdsRef.current);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const responseRows: Array<{ id?: string; $PhantomId?: string }> = (response?.tasks?.rows ?? []) as any[];
+      const responsePhantomIds = new Set(
+        responseRows.map((r) => r?.$PhantomId).filter(Boolean) as string[],
+      );
+      const sentButNotReturned = sentIds.filter((id) => !responsePhantomIds.has(id));
+
+      // Inspect each sent record AFTER the response was applied — if it's still
+      // phantom, Bryntum failed to materialize the phantom→real id swap and
+      // the row will stay stuck (snackbar "Saving task — try again in a moment").
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+      const stillPhantom = sentIds.map((id) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        const r = gantt.project.taskStore.getById(id) as
+          | { id?: string; isPhantom?: boolean; parentId?: string | null; parent?: { id?: string } | null; name?: string }
+          | null;
+        return r
+          ? {
+              sentId: id,
+              currentId: r.id,
+              isPhantom: r.isPhantom,
+              parentId: r.parentId ?? r.parent?.id ?? null,
+              name: r.name,
+            }
+          : { sentId: id, lookup: 'null — record gone' };
       });
 
-      // Clear only the IDs that were actually sent in this sync cycle; any IDs
-      // added to pending* after `onBeforeSync` fired belong to the next sync.
-      for (const id of lastSyncAddedIdsRef.current) pendingAddedIdsRef.current.delete(id);
-      for (const id of lastSyncRemovedIdsRef.current) pendingRemovedIdsRef.current.delete(id);
+      console.log('[Gantt:client] sync OK', {
+        success: response?.success,
+        tasksReturned: responseRows.length,
+        rowsMapping: responseRows.map((r) => ({ phantom: r?.$PhantomId, real: r?.id })),
+        sentAdded: sentIds,
+        sentButNotReturned,
+        sentRemoved: Array.from(lastSyncRemovedIdsRef.current),
+        afterReconcile: stillPhantom,
+      });
+
+      // Pending refs are dormant (reconcile disabled). Just clear the
+      // in-flight snapshot.
       lastSyncAddedIdsRef.current.clear();
       lastSyncRemovedIdsRef.current.clear();
       // Trailing-edge debounce: with autoSync flushing every ~500ms during a
@@ -175,28 +266,65 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     };
 
     const onBeforeSync = ({ pack }: { pack: unknown }) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const taskStore = gantt.project.taskStore;
-      reconcileSyncPack(
-        pack,
-        taskStore as Parameters<typeof reconcileSyncPack>[1],
-        pendingAddedIdsRef.current,
-        pendingRemovedIdsRef.current,
-      );
+      // reconcileSyncPack DISABLED — it was the root cause of duplicate
+      // adds: it tracked record ids at taskStore.add time, but Bryntum's
+      // scheduling engine re-creates records during commitAsync (new id),
+      // so the bag and our pending tracker held DIFFERENT ids for the same
+      // record. Reconcile then injected the old id as "missing", producing
+      // duplicate rows server-side and a $PhantomId in the response that
+      // didn't match any client record → afterSyncAttempt crashed with
+      // "Cannot set properties of undefined (setting 'isBeingMaterialized')".
+      // Bryntum 7.2 + commitAsync (in handleAddTask) appears to keep the
+      // bag reliable on its own; we trust it as the single source of truth.
 
-      // Snapshot IDs actually being sent so `onSync` can clear only these on success,
-      // without dropping new changes that arrive mid-request.
-      lastSyncAddedIdsRef.current = new Set(pendingAddedIdsRef.current);
-      lastSyncRemovedIdsRef.current = new Set(pendingRemovedIdsRef.current);
+      // Snapshot IDs actually in the outgoing pack so `onSync` knows which
+      // pending entries to clear. Source of truth is now the bag, not our
+      // pending tracker.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const packAddedIds = new Set<string>(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (((pack as any)?.tasks?.added ?? []) as Array<{ id?: string }>)
+          .map((t) => String(t.id ?? '')),
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const packRemovedIds = new Set<string>(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (((pack as any)?.tasks?.removed ?? []) as Array<{ id?: string }>)
+          .map((t) => String(t.id ?? '')),
+      );
+      lastSyncAddedIdsRef.current = packAddedIds;
+      lastSyncRemovedIdsRef.current = packRemovedIds;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const p = pack as any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const summarizeAdded = (t: any) => ({
+        id: t?.id,
+        $PhantomId: t?.$PhantomId,
+        parentId: t?.parentId,
+        name: t?.name,
+        // Bryntum sometimes uses `parentIndex` to position; surface it so we can
+        // see whether a subtask is missing parentId but has positional intent.
+        parentIndex: t?.parentIndex,
+        keys: t ? Object.keys(t) : [],
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const summarizeUpdated = (t: any) => ({
+        id: t?.id,
+        parentId: t?.parentId,
+        name: t?.name,
+        changedKeys: t ? Object.keys(t).filter((k) => k !== 'id') : [],
+      });
+
       console.log('[Gantt:client] beforeSync — pack about to POST', {
         addedTasks: p?.tasks?.added?.length ?? 0,
         updatedTasks: p?.tasks?.updated?.length ?? 0,
         removedTasks: p?.tasks?.removed?.length ?? 0,
-        firstAdded: p?.tasks?.added?.[0],
-        firstUpdated: p?.tasks?.updated?.[0],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        added: (p?.tasks?.added ?? []).map(summarizeAdded),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        updated: (p?.tasks?.updated ?? []).map(summarizeUpdated),
+        removed: p?.tasks?.removed,
       });
     };
 
@@ -206,34 +334,38 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     // commits state between cycles).
     const taskStore = gantt.project.taskStore;
 
-    const onTaskAdd = ({ records, isExpand }: { records: Array<{ id?: string; isRoot?: boolean }>; isExpand?: boolean }) => {
+    const onTaskAdd = ({ records, isExpand }: {
+      records: Array<{
+        id?: string;
+        isRoot?: boolean;
+        isPhantom?: boolean;
+        parentId?: string | null;
+        parent?: { id?: string } | null;
+        name?: string;
+      }>;
+      isExpand?: boolean;
+    }) => {
       if (isExpand) return;
-      const tracked: string[] = [];
-      for (const r of records) {
-        if (!r.isRoot && r.id) {
-          pendingAddedIdsRef.current.add(String(r.id));
-          tracked.push(String(r.id));
-        }
-      }
+      // Logging only — pendingAddedIdsRef is no longer the source of truth.
+      // Bryntum's CrudManager bag tracks adds; reconcileSyncPack is disabled.
+      const tracked = records
+        .filter((r) => !r.isRoot && r.id)
+        .map((r) => ({
+          id: String(r.id),
+          isPhantom: r.isPhantom,
+          parentId: r.parentId ?? r.parent?.id ?? null,
+          name: r.name,
+        }));
       if (tracked.length > 0) {
-        console.log('[Gantt:client] taskStore.add — pending add IDs', {
-          newlyTracked: tracked,
-          totalPendingAdds: pendingAddedIdsRef.current.size,
-        });
+        console.log('[Gantt:client] taskStore.add (info)', { tracked });
       }
     };
 
     const onTaskRemove = ({ records, isCollapse }: { records: Array<{ id?: string; isRoot?: boolean }>; isCollapse?: boolean }) => {
       if (isCollapse) return;
-      for (const r of records) {
-        if (r.isRoot || !r.id) continue;
-        const id = String(r.id);
-        if (pendingAddedIdsRef.current.has(id)) {
-          pendingAddedIdsRef.current.delete(id);
-        } else {
-          pendingRemovedIdsRef.current.add(id);
-        }
-      }
+      // No-op: reconcileSyncPack is disabled, so we no longer maintain
+      // pendingRemovedIdsRef as a shadow of Bryntum's bag.
+      void records;
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
@@ -252,6 +384,12 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
       gantt.project?.taskStore?.un('add', onTaskAdd);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       gantt.project?.taskStore?.un('remove', onTaskRemove);
+      // Restore native fetch — only if we still own it, so HMR-stacked
+      // interceptors don't strand a stale reference as the active fetch.
+      // No-op in production because the patch wasn't installed there.
+      if (fetchDebugEnabled && window.fetch === wrappedFetch) {
+        window.fetch = originalFetch;
+      }
       if (sidebarInvalidateTimerRef.current) {
         clearTimeout(sidebarInvalidateTimerRef.current);
         sidebarInvalidateTimerRef.current = null;
@@ -347,105 +485,6 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     return () => { detach?.(); };
   }, [isLoading, getGanttInstance, closeTaskPopover, editingUnlocked]);
 
-  // Row action menu — detect clicks on the ⋮ button injected by the name column
-  // renderer, then show a programmatic Bryntum Menu at the button position.
-  const activeMenuRef = useRef<{ destroy: () => void } | null>(null);
-  useEffect(() => {
-    if (isLoading) return;
-    const gantt = getGanttInstance();
-    if (!gantt) return;
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const onCellClick = ({ record, column, event }: { record: any; column: { type: string }; event: MouseEvent }) => {
-      const target = event.target as HTMLElement;
-
-      const btn = target.closest('.gantt-row-actions-btn') as HTMLElement | null;
-      if (!btn || column.type !== 'name') return;
-
-      event.stopPropagation();
-
-      // Row action menu contains write actions (add subtask, indent, delete, …) —
-      // don't open it when the chart is locked.
-      if (!editingUnlocked) return;
-
-      // Destroy any previously open menu
-      if (activeMenuRef.current) {
-        activeMenuRef.current.destroy();
-        activeMenuRef.current = null;
-      }
-
-      const taskRecord = record as BryntumTaskRecord;
-      const g = gantt as unknown as BryntumGanttInstance;
-
-      btn.classList.add('gantt-menu-open');
-
-      activeMenuRef.current = new Menu({
-        forElement: btn,
-        align: 't-b',
-        items: [
-          {
-            ref: 'taskDetails',
-            text: 'Task Details',
-            icon: 'b-icon b-icon-edit',
-            onItem: () => { closeTaskPopover(); setTaskInfoRecord(taskRecord); },
-          },
-          {
-            ref: 'addSubtask',
-            text: 'Add Subtask',
-            icon: 'b-icon b-icon-add',
-            onItem: () => {
-              taskRecord.appendChild({ name: 'New Subtask', duration: 1, startDate: new Date() });
-              if (!taskRecord.isExpanded) g.expand(taskRecord);
-            },
-          },
-          {
-            ref: 'indent',
-            text: 'Indent',
-            icon: 'b-icon b-icon-indent',
-            onItem: () => { g.indent([taskRecord]); },
-          },
-          {
-            ref: 'outdent',
-            text: 'Outdent',
-            icon: 'b-icon b-icon-outdent',
-            onItem: () => { g.outdent([taskRecord]); },
-          },
-          {
-            ref: 'unlinkTask',
-            text: 'Unlink',
-            icon: 'b-icon b-icon-unlink',
-            onItem: () => {
-              const deps = [...(taskRecord.predecessors ?? []), ...(taskRecord.successors ?? [])];
-              if (deps.length > 0) g.dependencyStore.remove(deps);
-            },
-          },
-          {
-            ref: 'deleteTask',
-            text: 'Delete',
-            icon: 'b-icon b-icon-trash',
-            cls: 'gantt-action-danger',
-            onItem: () => { taskRecord.remove(); },
-          },
-        ],
-        onDestroy: () => {
-          btn.classList.remove('gantt-menu-open');
-          activeMenuRef.current = null;
-        },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-    };
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-    const detach = gantt.on('cellClick', onCellClick) as (() => void) | undefined;
-    return () => {
-      detach?.();
-      if (activeMenuRef.current) {
-        activeMenuRef.current.destroy();
-        activeMenuRef.current = null;
-      }
-    };
-  }, [isLoading, getGanttInstance, closeTaskPopover, editingUnlocked]);
-
   // taskMenu config — passed as the top-level `taskMenuFeature` prop on
   // <BryntumGantt> below. NOT via `features.taskMenu` in the config object —
   // the React wrapper's `features → ${key}Feature` translation drops function
@@ -533,15 +572,6 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     },
   }), [getGanttInstance]);
 
-  // Close any open row-action menu the moment the chart is locked.
-  useEffect(() => {
-    if (editingUnlocked) return;
-    if (activeMenuRef.current) {
-      activeMenuRef.current.destroy();
-      activeMenuRef.current = null;
-    }
-  }, [editingUnlocked]);
-
   return (
     <div style={WRAPPER_STYLE}>
       <GanttToolbar
@@ -584,31 +614,7 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
           text-overflow: ellipsis;
           white-space: nowrap;
         }
-        /* Row actions ⋮ button — right side of name cell, always visible */
-        .gantt-row-actions-btn {
-          flex-shrink: 0;
-          opacity: 1;
-          background: none;
-          border: none;
-          box-shadow: none;
-          min-width: 0;
-          padding: 4px 6px;
-          cursor: pointer;
-          border-radius: 4px;
-          color: var(--text-secondary, #8D99AE);
-          font-size: 16px;
-          font-weight: bold;
-          letter-spacing: 1px;
-          line-height: 1;
-        }
-        .gantt-row-actions-btn:hover {
-          background: var(--bg-hover, rgba(0, 0, 0, 0.04));
-        }
-        /* Hide mutation affordances while the chart is locked. */
-        .bryntum-gantt-container[data-locked="true"] .gantt-row-actions-btn {
-          display: none;
-        }
-        /* "Needs review" pill — appears in the name cell when a task has
+/* "Needs review" pill — appears in the name cell when a task has
            unapproved submittals or inspections (count rolls up to parents). */
         .gantt-needs-review-badge {
           flex-shrink: 0;
@@ -628,6 +634,60 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
           letter-spacing: 0;
           cursor: default;
         }
+        /* Task-bar inner layout — used when a leaf task has any submittal /
+           inspection requirements. Renders the task name on the left and a
+           donut-in-chip indicator on the right (a tiny SVG progress donut + the
+           filled/total ratio). States: empty (faint chip, hollow ring), partial
+           (white chip, partial arc, indigo text), done (green chip, white check
+           circle, white text). */
+        .gantt-task-bar-inner {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          width: 100%;
+          height: 100%;
+          padding: 0 6px 0 8px;
+          box-sizing: border-box;
+        }
+        .gantt-task-bar-name {
+          flex: 1;
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+        .gantt-task-bar-chip {
+          flex-shrink: 0;
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+          padding: 2px 8px 2px 4px;
+          border-radius: 999px;
+          background: rgba(255, 255, 255, 0.95);
+          color: #1e40af;
+          font-size: 10px;
+          font-weight: 700;
+          line-height: 1.4;
+          font-variant-numeric: tabular-nums;
+          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.10);
+          cursor: default;
+        }
+        .gantt-task-bar-chip.is-done {
+          background: #16a34a;
+          color: #fff;
+        }
+        .gantt-task-bar-chip.is-empty {
+          background: rgba(255, 255, 255, 0.18);
+          color: rgba(255, 255, 255, 0.95);
+          box-shadow: none;
+        }
+        .gantt-task-bar-chip-donut {
+          display: inline-flex;
+          align-items: center;
+          flex-shrink: 0;
+        }
+        .gantt-task-bar-chip-donut svg { display: block; }
+        .gantt-task-bar-chip-text { line-height: 1; }
       `}</style>
 
       <div

--- a/src/components/bryntum/components/SubmittalDrawer.tsx
+++ b/src/components/bryntum/components/SubmittalDrawer.tsx
@@ -1,14 +1,11 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   Box,
   Drawer,
   IconButton,
   Typography,
-  Avatar,
-  Menu,
-  MenuItem,
   CircularProgress,
 } from '@mui/material';
 import {
@@ -18,8 +15,6 @@ import {
   PaperPlaneTilt,
   ClipboardText,
   CheckCircle,
-  UserCircle,
-  Trash,
   CloudArrowUp,
   WarningCircle,
 } from '@phosphor-icons/react';
@@ -27,9 +22,18 @@ import { format, isBefore, startOfDay } from 'date-fns';
 
 import { api } from '@/trpc/react';
 import type { SlotKind } from '@/lib/validations/gantt';
+import { nextSuggestedSlotName } from '@/lib/constants/slotNameLibrary';
+import UserAvatar from '@/components/ui/UserAvatar';
+import ApprovalToggleSwitch from './task-popover/ApprovalToggleSwitch';
 import type { DocumentItem } from './task-popover/types';
 
 const SUBMITTAL_COLOR = '#2563EB';
+
+// Optimistic slot IDs are tagged with this prefix so any code path that would
+// otherwise send the placeholder ID to the server (uploads, slot updates) can
+// short-circuit until the real row arrives.
+const OPTIMISTIC_SLOT_ID_PREFIX = 'optimistic-';
+const isOptimisticSlotId = (id: string): boolean => id.startsWith(OPTIMISTIC_SLOT_ID_PREFIX);
 const INSPECTION_COLOR = '#8E44AD';
 
 const KIND_META: Record<SlotKind, {
@@ -65,6 +69,8 @@ interface SubmittalDrawerProps {
   projectId: string;
   taskId: string;
   taskName: string;
+  /** Current user's org-membership role — gates the inline approval toggle. */
+  memberRole: string;
   initialKind?: SlotKind;
   /** Documents already uploaded under this task — used for the tab badge counts. */
   docsByKind: Record<SlotKind, DocumentItem[]>;
@@ -83,6 +89,7 @@ export default function SubmittalDrawer({
   projectId,
   taskId,
   taskName,
+  memberRole,
   initialKind = 'submittal',
   docsByKind,
   onUploadToFolder,
@@ -126,6 +133,7 @@ export default function SubmittalDrawer({
         organizationId={organizationId}
         projectId={projectId}
         taskId={taskId}
+        memberRole={memberRole}
         kind={activeKind}
         onUploadToFolder={(slotId) => onUploadToFolder(KIND_META[activeKind].folderId, slotId)}
       />
@@ -295,12 +303,14 @@ function DrawerContent({
   organizationId,
   projectId,
   taskId,
+  memberRole,
   kind,
   onUploadToFolder,
 }: {
   organizationId: string;
   projectId: string;
   taskId: string;
+  memberRole: string;
   kind: SlotKind;
   onUploadToFolder: (slotId?: string) => void;
 }) {
@@ -314,7 +324,51 @@ function DrawerContent({
   const slots = slotsQuery.data ?? [];
 
   const setCountMutation = api.gantt.setSlotCount.useMutation({
-    onSuccess: () => {
+    // Optimistically reshape the slot list so the UI updates instantly instead
+    // of waiting for the server round trip + three query invalidations.
+    onMutate: async ({ count }) => {
+      const queryKey = { organizationId, projectId, taskId, kind };
+      await utils.gantt.listSlots.cancel(queryKey);
+      const previous = utils.gantt.listSlots.getData(queryKey);
+
+      utils.gantt.listSlots.setData(queryKey, (current) => {
+        const prev = current ?? [];
+        if (count === prev.length) return prev;
+        if (count < prev.length) return prev.slice(0, count);
+        // Mirror the server's name-picking so the placeholder matches the
+        // value that will arrive on reconcile (no visible name flip).
+        const existingNames: (string | null)[] = prev.map((s) => s.name);
+        const now = new Date();
+        const baseId = `${OPTIMISTIC_SLOT_ID_PREFIX}${now.getTime()}`;
+        const additions = Array.from({ length: count - prev.length }, (_, i) => {
+          const name = nextSuggestedSlotName(kind, existingNames);
+          existingNames.push(name);
+          return {
+            id: `${baseId}-${i}`,
+            taskId,
+            kind,
+            index: prev.length + i,
+            name,
+            dueDate: null,
+            createdAt: now,
+            updatedAt: now,
+            document: null,
+          };
+        });
+        return [...prev, ...additions];
+      });
+
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) {
+        utils.gantt.listSlots.setData(
+          { organizationId, projectId, taskId, kind },
+          ctx.previous,
+        );
+      }
+    },
+    onSettled: () => {
       void utils.gantt.listSlots.invalidate({ organizationId, projectId, taskId, kind });
       void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId });
       void utils.gantt.requirementStats.invalidate({ projectId });
@@ -326,13 +380,6 @@ function DrawerContent({
       void utils.gantt.listSlots.invalidate({ organizationId, projectId, taskId, kind });
     },
   });
-
-  // Members for the approver picker (cached at the org level).
-  const membersQuery = api.member.list.useQuery(
-    { organizationId },
-    { enabled: !!organizationId, staleTime: 60_000 },
-  );
-  const members = membersQuery.data ?? [];
 
   // Decrement-with-data confirm state.
   const [confirmRemove, setConfirmRemove] = useState<null | { trailingFilled: number; nextCount: number }>(null);
@@ -370,7 +417,6 @@ function DrawerContent({
     setConfirmRemove(null);
   };
 
-  const isPending = setCountMutation.isPending;
   const isLoading = slotsQuery.isLoading;
 
   return (
@@ -403,7 +449,7 @@ function DrawerContent({
           <Stepper
             value={slots.length}
             onChange={handleStepCount}
-            disabled={isPending || isLoading}
+            disabled={isLoading}
           />
         </Box>
 
@@ -434,25 +480,34 @@ function DrawerContent({
           <EmptyState kind={kind} onSeed={(count) => setCountMutation.mutate({ organizationId, projectId, taskId, kind, count })} />
         ) : (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            {slots.map((slot) => (
-              <SlotCard
-                key={slot.id}
-                slot={slot}
-                kind={kind}
-                doc={slot.document}
-                members={members}
-                onRename={(name) =>
-                  updateSlotMutation.mutate({ organizationId, projectId, slotId: slot.id, name })
-                }
-                onSetDueDate={(dueDate) =>
-                  updateSlotMutation.mutate({ organizationId, projectId, slotId: slot.id, dueDate })
-                }
-                onSetApprover={(approverId) =>
-                  updateSlotMutation.mutate({ organizationId, projectId, slotId: slot.id, approverId })
-                }
-                onUpload={() => onUploadToFolder(slot.id)}
-              />
-            ))}
+            {slots.map((slot) => {
+              const isPending = isOptimisticSlotId(slot.id);
+              return (
+                <SlotCard
+                  key={slot.id}
+                  slot={slot}
+                  kind={kind}
+                  doc={slot.document}
+                  organizationId={organizationId}
+                  memberRole={memberRole}
+                  // Optimistic rows hold placeholder IDs that don't exist on
+                  // the server yet — block any action that would send the ID.
+                  isPending={isPending}
+                  onRename={(name) => {
+                    if (isPending) return;
+                    updateSlotMutation.mutate({ organizationId, projectId, slotId: slot.id, name });
+                  }}
+                  onSetDueDate={(dueDate) => {
+                    if (isPending) return;
+                    updateSlotMutation.mutate({ organizationId, projectId, slotId: slot.id, dueDate });
+                  }}
+                  onUpload={() => {
+                    if (isPending) return;
+                    onUploadToFolder(slot.id);
+                  }}
+                />
+              );
+            })}
           </Box>
         )}
       </Box>
@@ -603,8 +658,6 @@ type SlotData = {
   index: number;
   name: string | null;
   dueDate: Date | null;
-  approverId: string | null;
-  approver: { id: string; name: string | null; email: string; image: string | null } | null;
 };
 
 // SlotCard only renders the bound document's name + upload date in the
@@ -613,33 +666,36 @@ type SlotBoundDoc = {
   id: string;
   name: string;
   createdAt: Date | string | null;
-};
-
-type Member = {
-  user: { id: string; name: string | null; email: string; image: string | null };
+  approvalStatus: string;
+  approvedAt: Date | string | null;
+  approvedBy: { id: string; name: string | null; email: string } | null;
 };
 
 function SlotCard({
   slot,
   kind,
   doc,
-  members,
+  organizationId,
+  memberRole,
+  isPending = false,
   onRename,
   onSetDueDate,
-  onSetApprover,
   onUpload,
 }: {
   slot: SlotData;
   kind: SlotKind;
   doc: SlotBoundDoc | null;
-  members: Member[];
+  organizationId: string;
+  memberRole: string;
+  /** True while the slot row is an optimistic placeholder (server hasn't returned the real id yet). */
+  isPending?: boolean;
   onRename: (name: string | null) => void;
   onSetDueDate: (dueDate: string | null) => void;
-  onSetApprover: (approverId: string | null) => void;
   onUpload: () => void;
 }) {
   const meta = KIND_META[kind];
   const isReceived = !!doc;
+  const isApproved = isReceived && doc.approvalStatus === 'approved';
   const isOverdue = !isReceived && slot.dueDate && isBefore(new Date(slot.dueDate), startOfDay(new Date()));
 
   // Local input state so typing doesn't fire a mutation per keystroke.
@@ -653,14 +709,6 @@ function SlotCard({
     onRename(next);
   };
 
-  // Approver menu
-  const [approverAnchor, setApproverAnchor] = useState<HTMLElement | null>(null);
-  const closeApprover = () => setApproverAnchor(null);
-  const handleApproverPick = (id: string | null) => {
-    onSetApprover(id);
-    closeApprover();
-  };
-
   // Native date input — local state so calendar picker doesn't fire mid-edit.
   const [draftDue, setDraftDue] = useState(slot.dueDate ? toInputDate(slot.dueDate) : '');
   useEffect(() => setDraftDue(slot.dueDate ? toInputDate(slot.dueDate) : ''), [slot.dueDate]);
@@ -670,6 +718,12 @@ function SlotCard({
     if (next === current) return;
     onSetDueDate(next);
   };
+
+  // Due date is optional — collapsed to a "+ Add due date" button until the
+  // user opts in or a value already exists on the slot.
+  const [dueDateExpanded, setDueDateExpanded] = useState(false);
+  const dueDateInputRef = useRef<HTMLInputElement | null>(null);
+  const showDueDateField = !!slot.dueDate || dueDateExpanded;
 
   const cardBg = isReceived
     ? 'success.main'
@@ -704,7 +758,7 @@ function SlotCard({
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, mb: 1.25, position: 'relative' }}>
-        <SlotNumberBadge index={slot.index} kind={kind} isReceived={isReceived} />
+        <SlotNumberBadge index={slot.index} kind={kind} isReceived={isReceived} isApproved={isApproved} />
         <SlotNameInput
           value={draftName}
           onChange={setDraftName}
@@ -712,79 +766,73 @@ function SlotCard({
           placeholder={`Name this ${meta.label}…`}
           color={meta.color}
         />
-        <SlotStatusPill received={isReceived} overdue={!!isOverdue} />
+        <SlotStatusPill received={isReceived} overdue={!!isOverdue} approved={isApproved} />
       </Box>
 
-      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1, position: 'relative' }}>
-        <FieldSlot label="Due date">
-          <Box
-            component="input"
-            type="date"
-            value={draftDue}
-            onChange={(e) => setDraftDue(e.target.value)}
-            onBlur={commitDue}
-            sx={{
-              fontFamily: 'inherit',
-              fontSize: 12,
-              border: '1px solid',
-              borderColor: 'divider',
-              borderRadius: '6px',
-              bgcolor: 'background.default',
-              color: isOverdue ? 'warning.main' : 'text.primary',
-              px: 1,
-              py: 0.75,
-              outline: 'none',
-              width: '100%',
-              transition: 'border-color 0.15s',
-              '&:hover': { borderColor: 'text.disabled' },
-              '&:focus': { borderColor: meta.color },
-            }}
-          />
-        </FieldSlot>
-        <FieldSlot label="Approver">
+      <Box sx={{ position: 'relative' }}>
+        {showDueDateField ? (
+          <FieldSlot label="Due date">
+            <Box
+              ref={dueDateInputRef}
+              component="input"
+              type="date"
+              value={draftDue}
+              onChange={(e) => setDraftDue(e.target.value)}
+              onBlur={commitDue}
+              sx={{
+                fontFamily: 'inherit',
+                fontSize: 12,
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: '6px',
+                bgcolor: 'background.default',
+                color: isOverdue ? 'warning.main' : 'text.primary',
+                px: 1,
+                py: 0.75,
+                outline: 'none',
+                width: '100%',
+                transition: 'border-color 0.15s',
+                '&:hover': { borderColor: 'text.disabled' },
+                '&:focus': { borderColor: meta.color },
+              }}
+            />
+          </FieldSlot>
+        ) : (
           <Box
             component="button"
-            onClick={(e) => setApproverAnchor(e.currentTarget)}
+            type="button"
+            onClick={() => {
+              setDueDateExpanded(true);
+              // Defer focus until after the input mounts.
+              requestAnimationFrame(() => dueDateInputRef.current?.focus());
+            }}
             sx={{
-              display: 'flex',
+              display: 'inline-flex',
               alignItems: 'center',
-              gap: 0.75,
+              gap: 0.5,
+              px: 1,
+              py: 0.5,
               fontFamily: 'inherit',
-              fontSize: 12,
-              border: '1px solid',
+              fontSize: 11,
+              fontWeight: 500,
+              color: 'text.secondary',
+              bgcolor: 'transparent',
+              border: '1px dashed',
               borderColor: 'divider',
               borderRadius: '6px',
-              bgcolor: 'background.default',
-              color: slot.approver ? 'text.primary' : 'text.disabled',
-              px: 1,
-              py: 0.75,
               cursor: 'pointer',
-              width: '100%',
-              minWidth: 0,
-              textAlign: 'left',
-              '&:hover': { borderColor: 'text.disabled' },
+              transition: 'color 0.15s, border-color 0.15s, background-color 0.15s',
+              '&:hover': {
+                color: meta.color,
+                borderColor: meta.color,
+                bgcolor: `${meta.color}0F`,
+              },
             }}
           >
-            {slot.approver ? (
-              <>
-                <Avatar
-                  src={slot.approver.image ?? undefined}
-                  sx={{ width: 18, height: 18, fontSize: 9, fontWeight: 600 }}
-                >
-                  {(slot.approver.name ?? slot.approver.email).charAt(0).toUpperCase()}
-                </Avatar>
-                <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
-                  {slot.approver.name ?? slot.approver.email}
-                </Box>
-              </>
-            ) : (
-              <>
-                <UserCircle size={14} />
-                <span>Assign…</span>
-              </>
-            )}
+            <Plus size={11} weight="bold" />
+            Add due date
           </Box>
-        </FieldSlot>
+        )}
       </Box>
 
       {/* Footer: file info or upload CTA */}
@@ -814,6 +862,15 @@ function SlotCard({
             }}>
               {doc.name}
             </Box>
+            <ApprovalToggleSwitch
+              documentId={doc.id}
+              documentName={doc.name}
+              approvalStatus={doc.approvalStatus}
+              approvedBy={doc.approvedBy}
+              organizationId={organizationId}
+              memberRole={memberRole}
+              size="sm"
+            />
             <Box sx={{ color: 'text.secondary', flexShrink: 0 }}>
               {doc.createdAt ? format(new Date(doc.createdAt), 'MMM d') : ''}
             </Box>
@@ -821,71 +878,70 @@ function SlotCard({
         ) : (
           <Box
             component="button"
+            type="button"
             onClick={onUpload}
+            disabled={isPending}
+            aria-label={isPending ? 'Saving slot…' : meta.uploadCta}
             sx={{
               display: 'inline-flex',
               alignItems: 'center',
               gap: 0.75,
               border: 'none',
               background: 'transparent',
-              cursor: 'pointer',
+              cursor: isPending ? 'wait' : 'pointer',
               fontFamily: 'inherit',
               fontSize: 11,
               fontWeight: 500,
               color: meta.color,
+              opacity: isPending ? 0.5 : 1,
               p: 0,
-              '&:hover': { textDecoration: 'underline' },
+              '&:hover': { textDecoration: isPending ? 'none' : 'underline' },
             }}
           >
             <CloudArrowUp size={13} />
-            {meta.uploadCta}
+            {isPending ? 'Saving…' : meta.uploadCta}
           </Box>
         )}
       </Box>
 
-      {/* Approver picker menu */}
-      <Menu
-        anchorEl={approverAnchor}
-        open={!!approverAnchor}
-        onClose={closeApprover}
-        slotProps={{
-          paper: {
-            sx: { minWidth: 220, maxHeight: 320, mt: 0.5, borderRadius: '10px' },
-          },
-        }}
-      >
-        {slot.approverId && (
-          <MenuItem onClick={() => handleApproverPick(null)} sx={{ fontSize: 12, color: 'error.main' }}>
-            <Trash size={14} style={{ marginRight: 8 }} />
-            Clear approver
-          </MenuItem>
-        )}
-        {members.length === 0 ? (
-          <MenuItem disabled sx={{ fontSize: 12 }}>No members in this org</MenuItem>
-        ) : (
-          members.map((m) => (
-            <MenuItem
-              key={m.user.id}
-              onClick={() => handleApproverPick(m.user.id)}
-              selected={m.user.id === slot.approverId}
-              sx={{ fontSize: 12, gap: 1 }}
-            >
-              <Avatar
-                src={m.user.image ?? undefined}
-                sx={{ width: 22, height: 22, fontSize: 10, fontWeight: 600 }}
-              >
-                {(m.user.name ?? m.user.email).charAt(0).toUpperCase()}
-              </Avatar>
-              <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-                <Box sx={{ fontWeight: 500, lineHeight: 1.2 }}>{m.user.name ?? m.user.email}</Box>
-                {m.user.name && (
-                  <Box sx={{ fontSize: 10, color: 'text.secondary', lineHeight: 1.2 }}>{m.user.email}</Box>
-                )}
-              </Box>
-            </MenuItem>
-          ))
-        )}
-      </Menu>
+      {isApproved && doc && <ApprovedByLine doc={doc} />}
+
+    </Box>
+  );
+}
+
+function ApprovedByLine({ doc }: { doc: SlotBoundDoc }) {
+  const approver = doc.approvedBy;
+  const approverLabel = approver?.name ?? approver?.email ?? 'a reviewer';
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.75,
+        mt: 1,
+        pt: 1,
+        borderTop: '1px solid',
+        borderColor: 'rgba(22,163,74,0.18)',
+        fontSize: 10.5,
+        color: 'success.main',
+        fontWeight: 500,
+      }}
+    >
+      {approver ? (
+        <UserAvatar user={approver} size={16} sx={{ fontSize: 9 }} />
+      ) : (
+        <CheckCircle size={14} weight="fill" />
+      )}
+      <Box component="span">Approved by {approverLabel}</Box>
+      {doc.approvedAt && (
+        <>
+          <Box component="span" sx={{ color: 'text.disabled' }}>·</Box>
+          <Box component="span" sx={{ color: 'text.secondary' }}>
+            {format(new Date(doc.approvedAt), 'MMM d')}
+          </Box>
+        </>
+      )}
     </Box>
   );
 }
@@ -894,10 +950,12 @@ function SlotNumberBadge({
   index,
   kind,
   isReceived,
+  isApproved,
 }: {
   index: number;
   kind: SlotKind;
   isReceived: boolean;
+  isApproved: boolean;
 }) {
   const meta = KIND_META[kind];
   const bg = isReceived ? 'var(--mui-palette-success-main, #16a34a)' : `${meta.color}1F`;
@@ -916,6 +974,8 @@ function SlotNumberBadge({
         fontSize: 10,
         fontWeight: 700,
         flexShrink: 0,
+        boxShadow: isApproved ? '0 0 0 3px rgba(22,163,74,0.20)' : 'none',
+        transition: 'box-shadow 0.15s',
       }}
     >
       {isReceived ? <CheckCircle size={12} weight="fill" /> : index + 1}
@@ -985,15 +1045,28 @@ function FieldSlot({ label, children }: { label: string; children: React.ReactNo
   );
 }
 
-function SlotStatusPill({ received, overdue }: { received: boolean; overdue: boolean }) {
-  const config = received
-    ? { label: 'Received', bg: 'rgba(22,163,74,0.14)', color: 'success.main' }
-    : overdue
-      ? { label: 'Overdue', bg: 'rgba(217,119,6,0.14)', color: 'warning.main' }
-      : { label: 'Pending', bg: 'action.selected', color: 'text.secondary' };
+function SlotStatusPill({
+  received,
+  overdue,
+  approved,
+}: {
+  received: boolean;
+  overdue: boolean;
+  approved: boolean;
+}) {
+  const config = approved
+    ? { label: 'Approved', bg: 'success.main', color: 'success.contrastText', showCheck: true }
+    : received
+      ? { label: 'Received', bg: 'rgba(22,163,74,0.14)', color: 'success.main', showCheck: false }
+      : overdue
+        ? { label: 'Overdue', bg: 'rgba(217,119,6,0.14)', color: 'warning.main', showCheck: false }
+        : { label: 'Pending', bg: 'action.selected', color: 'text.secondary', showCheck: false };
   return (
     <Box
       sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '3px',
         fontSize: 10,
         fontWeight: 600,
         px: 0.875,
@@ -1005,6 +1078,7 @@ function SlotStatusPill({ received, overdue }: { received: boolean; overdue: boo
         flexShrink: 0,
       }}
     >
+      {config.showCheck && <CheckCircle size={11} weight="fill" />}
       {config.label}
     </Box>
   );

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -299,6 +299,9 @@ export function TaskDetailsPopover({
               onClose={handleClose}
               onOpenCsiPanel={openCsiPanel}
               onScrollToRequirements={handleScrollToRequirements}
+              onOpenRequirementsDrawer={
+                canManageSlots ? () => setDrawerKind('submittal') : undefined
+              }
               submittalsCurrent={submittalsCurrent}
               inspectionsCurrent={inspectionsCurrent}
             />
@@ -501,6 +504,7 @@ export function TaskDetailsPopover({
           projectId={projectId}
           taskId={taskId}
           taskName={taskName}
+          memberRole={memberRole}
           initialKind={drawerKind}
           docsByKind={{
             submittal: ((allDocs ?? []) as DocumentItem[]).filter((d) =>

--- a/src/components/bryntum/components/task-popover/ApprovalToggleSwitch.tsx
+++ b/src/components/bryntum/components/task-popover/ApprovalToggleSwitch.tsx
@@ -47,6 +47,10 @@ export default function ApprovalToggleSwitch({
       void utils.document.aiSearch.invalidate();
       void utils.document.listByFolder.invalidate();
       void utils.document.listByTask.invalidate();
+      // Refresh slot state so the SubmittalDrawer pill + ApprovedByLine
+      // update after the user approves a bound submittal/inspection.
+      void utils.gantt.listSlots.invalidate();
+      void utils.gantt.taskDetail.invalidate();
     },
     onError: () => setOptimistic(null),
   });

--- a/src/components/bryntum/components/task-popover/FolderRow.tsx
+++ b/src/components/bryntum/components/task-popover/FolderRow.tsx
@@ -13,7 +13,6 @@ import {
   CaretDown,
   CaretRight,
   Plus,
-  Sliders,
   CheckCircle,
   Clock,
   type Icon as PhosphorIcon,
@@ -250,11 +249,11 @@ export default FolderRow;
 /**
  * Inline progress + state-driven chip for trackable folder headers (admins).
  *
- * Four states derived from (required, approved, pending):
- *   - Not set up        → required is null/0          → "Set up" chip
- *   - In progress       → uploads exist, not complete → "Manage" chip
+ * States derived from (required, approved, pending):
+ *   - Not set up        → required is null/0          → row renders nothing
+ *   - In progress       → uploads exist, not complete → progress segments + count
  *   - Pending review    → some uploads awaiting       → "N in review" indigo pill
- *   - Complete          → approved >= required         → no chip; ✓ next to count
+ *   - Complete          → approved >= required         → ✓ next to count
  */
 function ManageChipRow({
   current,
@@ -275,20 +274,10 @@ function ManageChipRow({
   const isComplete = total > 0 && approved >= total;
   const hasPending = pending > 0;
 
-  // State 1 — Not set up: just the chip.
+  // State 1 — Not set up: render a flex spacer so the trailing "+" upload
+  // button stays right-aligned, matching non-trackable folder rows.
   if (total === 0) {
-    return (
-      <Box
-        onClick={(e: React.MouseEvent) => e.stopPropagation()}
-        sx={{ display: 'flex', alignItems: 'center', flex: 1, minWidth: 0, ml: 0.5 }}
-      >
-        <Box sx={{ flex: 1 }} />
-        <ChipButton color={folderColor} onClick={onManage} ariaLabel="Set up">
-          <Sliders size={10} weight="bold" />
-          Set up
-        </ChipButton>
-      </Box>
-    );
+    return <Box sx={{ flex: 1 }} />;
   }
 
   // Segment fill rule (left-to-right):
@@ -374,8 +363,8 @@ function ManageChipRow({
         </Typography>
       )}
 
-      {/* Trailing chip — varies by state */}
-      {isComplete ? null : hasPending ? (
+      {/* Trailing status pill — only shown when items are awaiting approval. */}
+      {!isComplete && hasPending && (
         <ChipButton
           color="#4f46e5"
           onClick={onManage}
@@ -383,11 +372,6 @@ function ManageChipRow({
         >
           <Clock size={10} weight="bold" />
           {pending} in review
-        </ChipButton>
-      ) : (
-        <ChipButton color={folderColor} onClick={onManage} ariaLabel="Manage requirements">
-          <Sliders size={10} weight="bold" />
-          Manage
         </ChipButton>
       )}
     </Box>

--- a/src/components/bryntum/components/task-popover/TaskHeader.tsx
+++ b/src/components/bryntum/components/task-popover/TaskHeader.tsx
@@ -108,6 +108,12 @@ interface TaskHeaderProps {
   onClose: () => void;
   onOpenCsiPanel: () => void;
   onScrollToRequirements?: () => void;
+  /**
+   * Open the Manage submittals/inspections drawer. When provided, the empty
+   * "No requirements yet" CTA uses this instead of `onScrollToRequirements`
+   * so admins can create their first slot directly.
+   */
+  onOpenRequirementsDrawer?: () => void;
   /** Number of documents uploaded across all submittal folders */
   submittalsCurrent?: number;
   /** Number of documents uploaded across all inspection folders */
@@ -121,9 +127,11 @@ export default function TaskHeader({
   onClose,
   onOpenCsiPanel,
   onScrollToRequirements,
+  onOpenRequirementsDrawer,
   submittalsCurrent = 0,
   inspectionsCurrent = 0,
 }: TaskHeaderProps) {
+  const emptyCtaAction = onOpenRequirementsDrawer ?? onScrollToRequirements;
   const theme = useTheme();
 
   // Progress derived from requirements
@@ -481,10 +489,10 @@ export default function TaskHeader({
                 </Typography>
               )}
             </Box>
-            {onScrollToRequirements && (
+            {emptyCtaAction && (
               <Box
                 component="button"
-                onClick={onScrollToRequirements}
+                onClick={emptyCtaAction}
                 sx={{
                   background: 'transparent',
                   border: 'none',
@@ -505,7 +513,7 @@ export default function TaskHeader({
         ) : showEmptyProgressCta ? (
           <Box
             component="button"
-            onClick={onScrollToRequirements}
+            onClick={emptyCtaAction}
             sx={{
               display: 'flex',
               alignItems: 'center',
@@ -516,11 +524,11 @@ export default function TaskHeader({
               border: '1px dashed',
               borderColor: 'divider',
               bgcolor: 'action.hover',
-              cursor: onScrollToRequirements ? 'pointer' : 'default',
+              cursor: emptyCtaAction ? 'pointer' : 'default',
               textAlign: 'left',
               transition: 'all 0.15s',
               width: '100%',
-              '&:hover': onScrollToRequirements
+              '&:hover': emptyCtaAction
                 ? {
                     borderColor: 'text.disabled',
                     borderStyle: 'solid',
@@ -552,7 +560,7 @@ export default function TaskHeader({
                 Add submittals or inspections to track progress.
               </Typography>
             </Box>
-            {onScrollToRequirements && (
+            {emptyCtaAction && (
               <Typography
                 component="span"
                 sx={{

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -2,13 +2,16 @@ import { TaskModel } from '@bryntum/gantt';
 import type { DomClassList } from '@bryntum/gantt';
 import type { GanttConfig, ColumnRendererData } from '../types';
 
-// Extend TaskModel to include the `needsReviewCount` field that drives the
-// review-queue badge in the name column. Without explicit `fields`, Bryntum
-// drops it from loaded data.
+// Extend TaskModel to include custom fields. Without explicit `fields`, Bryntum
+// drops them from loaded data. `needsReviewCount` drives the review-queue badge
+// in the name column. `requirementsTotal` / `requirementsFilled` drive the
+// submittal+inspection completion % shown on each task bar.
 class AppTaskModel extends TaskModel {
   static override get fields() {
     return [
       { name: 'needsReviewCount', type: 'int', defaultValue: 0 },
+      { name: 'requirementsTotal', type: 'int', defaultValue: 0 },
+      { name: 'requirementsFilled', type: 'int', defaultValue: 0 },
     ];
   }
 }
@@ -103,9 +106,6 @@ export function createGanttConfig(
         flex: 1,
         minWidth: 300,
         resizable: true,
-        // Inject a three-dot actions button alongside the task name.
-        // TreeColumn renderer return value replaces the cell content —
-        // return a DomConfig object that includes both the name and the button.
         renderer({ value, record }: ColumnRendererData) {
           const needsReviewCount = Number(record.get('needsReviewCount') ?? 0);
           const children: Array<Record<string, unknown>> = [
@@ -121,14 +121,6 @@ export function createGanttConfig(
               text: String(needsReviewCount),
             });
           }
-
-          children.push({
-            tag: 'button',
-            class: 'gantt-row-actions-btn',
-            type: 'button',
-            dataset: { taskId: String(record.id) },
-            html: '<i class="fa-solid fa-ellipsis-vertical"></i>',
-          });
 
           return {
             class: 'gantt-name-cell-inner',
@@ -230,6 +222,9 @@ export function createGanttConfig(
     // Differentiate parent bars from child bars.
     // Adds 'gantt-parent-bar' class to parent tasks for CSS targeting.
     // Parent bars show no text (name is in the tree column).
+    // Leaf bars show the task name plus a donut-in-chip indicator carrying
+    // both the visual progress (mini SVG donut) and the count (e.g. 1/2) when
+    // the task has any requirements set (requirementsTotal > 0).
     taskRenderer({ taskRecord, renderData }: {
       taskRecord: TaskModel;
       renderData: { cls: DomClassList | string; style: string | Record<string, string>; wrapperCls: DomClassList | string; iconCls: DomClassList | string };
@@ -240,7 +235,55 @@ export function createGanttConfig(
         }
         return '';
       }
-      return taskRecord.name;
+
+      const total = Number(taskRecord.get('requirementsTotal') ?? 0);
+      if (total <= 0) {
+        return taskRecord.name;
+      }
+
+      const filled = Math.min(
+        Number(taskRecord.get('requirementsFilled') ?? 0),
+        total,
+      );
+      const isDone = filled >= total;
+      const isEmpty = filled === 0;
+
+      // Donut math — viewBox 14x14, r=5.5, circumference = 2πr ≈ 34.56.
+      // The fill arc uses stroke-dasharray/offset to draw a partial circle.
+      const CIRCUMFERENCE = 34.56;
+      const offset = CIRCUMFERENCE * (1 - filled / total);
+
+      const donutSvg = isDone
+        ? '<svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">'
+          + '<circle cx="7" cy="7" r="5.5" fill="#fff"/>'
+          + '<path d="M4 7L6.2 9L10 5" stroke="#16a34a" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>'
+          + '</svg>'
+        : isEmpty
+        ? '<svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">'
+          + '<circle cx="7" cy="7" r="5.5" fill="none" stroke="rgba(255,255,255,0.30)" stroke-width="2"/>'
+          + '</svg>'
+        : '<svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">'
+          + '<circle cx="7" cy="7" r="5.5" fill="none" stroke="rgba(0,0,0,0.15)" stroke-width="2"/>'
+          + `<circle cx="7" cy="7" r="5.5" fill="none" stroke="#1e40af" stroke-width="2" stroke-dasharray="${CIRCUMFERENCE}" stroke-dashoffset="${offset.toFixed(2)}" transform="rotate(-90 7 7)" stroke-linecap="round"/>`
+          + '</svg>';
+
+      const chipClass = `gantt-task-bar-chip${isDone ? ' is-done' : ''}${isEmpty ? ' is-empty' : ''}`;
+
+      return {
+        class: 'gantt-task-bar-inner',
+        children: [
+          { tag: 'span', class: 'gantt-task-bar-name', text: String(taskRecord.name ?? '') },
+          {
+            tag: 'span',
+            class: chipClass,
+            title: `${filled} of ${total} submittals and inspections complete`,
+            children: [
+              { tag: 'span', class: 'gantt-task-bar-chip-donut', html: donutSvg },
+              { tag: 'span', class: 'gantt-task-bar-chip-text', text: `${filled}/${total}` },
+            ],
+          },
+        ],
+      };
     },
   };
 }

--- a/src/components/bryntum/hooks/useGanttControls.ts
+++ b/src/components/bryntum/hooks/useGanttControls.ts
@@ -16,16 +16,55 @@ export function useGanttControls() {
   const handleAddTask = useCallback(() => {
     const gantt = getGanttInstance();
     if (!gantt) return;
-    const now = new Date();
-    const tomorrow = new Date(now);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-    gantt.taskStore.add({
-      name: 'New Task',
-      startDate: now,
-      endDate: tomorrow,
-      duration: 1,
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+    const taskStore = gantt.taskStore;
+
+    // Seed each task with a unique "Task N". Picking N from the existing
+    // names (not just count+1) avoids collisions after deletes, and giving
+    // every row a real name up-front means an auto-sync mid-edit can't
+    // ship an empty name to the server.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const existing = new Set<string>(
+      (taskStore.allRecords as Array<{ name?: string }>).map((r) => r.name ?? '')
+    );
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    let n = (taskStore.count as number) + 1;
+    while (existing.has(`Task ${n}`)) n++;
+
+    const startDate = new Date();
+    const endDate = new Date(startDate);
+    endDate.setDate(endDate.getDate() + 5);
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+    const added = taskStore.add({
+      name: `Task ${n}`,
+      startDate,
+      endDate,
+      duration: 5,
     });
+    const record = (Array.isArray(added) ? added[0] : added) as
+      | { startDate: Date }
+      | undefined;
+    if (!record) return;
+
+    // The new task isn't fully materialized in the project graph until the
+    // next commit. Touching it before then (selectedRecords setter, then
+    // startEditing) reaches into a half-built record and throws
+    // "Cannot set properties of undefined (setting 'isBeingMaterialized')".
+    // commitAsync resolves once the project finishes propagating the add.
+    void (async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      await gantt.project?.commitAsync?.();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      await gantt.scrollRowIntoView(record);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      gantt.scrollToDate?.(record.startDate, { block: 'center' });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      gantt.selectedRecords = [record];
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      gantt.startEditing({ record, field: 'name' });
+    })();
   }, [getGanttInstance]);
 
   const handleIndent = useCallback(() => {

--- a/src/components/bryntum/utils/reconcileSyncPack.ts
+++ b/src/components/bryntum/utils/reconcileSyncPack.ts
@@ -29,6 +29,13 @@ export function reconcileSyncPack(
     if (missing.length > 0) {
       typed.tasks = typed.tasks ?? {};
       typed.tasks.added = typed.tasks.added ?? [];
+      const injected: Array<{
+        id: string;
+        $PhantomId: string;
+        parentIdInData: unknown;
+        dataKeys: string[];
+      }> = [];
+      const skipped: Array<{ id: string; reason: string }> = [];
       for (const id of missing) {
         const record = taskStore.getById(id);
         if (record?.data) {
@@ -38,7 +45,22 @@ export function reconcileSyncPack(
           // and Bryntum's afterSyncAttempt crashes trying to materialize it.
           const phantomId = (record.data.$PhantomId as string | undefined) ?? record.$PhantomId ?? id;
           typed.tasks.added.push({ ...record.data, $PhantomId: phantomId });
+          injected.push({
+            id,
+            $PhantomId: phantomId,
+            parentIdInData: (record.data as Record<string, unknown>).parentId,
+            dataKeys: Object.keys(record.data),
+          });
+        } else {
+          skipped.push({ id, reason: record ? 'no record.data' : 'getById returned null' });
         }
+      }
+      if (injected.length > 0 || skipped.length > 0) {
+        console.log('[Gantt:reconcileSyncPack] injected missing added records', {
+          injected,
+          skipped,
+          bagAddedIds: Array.from(bagAddedIds),
+        });
       }
     }
   }

--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { useParams, usePathname } from 'next/navigation';
 import { Box, Typography } from '@mui/material';
 import ProjectSwitcher from './ProjectSwitcher';
@@ -18,7 +17,7 @@ function getTrailingLabel(segment: string | undefined): string | null {
 export default function Breadcrumb() {
   const params = useParams<{ orgSlug?: string; projectSlug?: string }>();
   const pathname = usePathname();
-  const { orgSlug, projectSlug } = params;
+  const { projectSlug } = params;
 
   // Determine the trailing page segment. For project routes, it's the segment after [projectSlug].
   // For org-root, there is no trailing segment.
@@ -50,34 +49,9 @@ export default function Breadcrumb() {
     );
   }
 
-  // Inside a project — render: Projects / [Project chip] / [trailing static label?]
+  // Inside a project — render: [Project chip] / [trailing static label?]
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.125, minWidth: 0 }}>
-      {/* "Projects" crumb — links back to the org root for now (will retarget to /projects in Phase 2) */}
-      <Box
-        component={Link}
-        href={`/${orgSlug}`}
-        sx={{
-          fontSize: '14.5px',
-          color: 'text.secondary',
-          textDecoration: 'none',
-          px: 1,
-          py: 0.75,
-          borderRadius: '6px',
-          lineHeight: 1,
-          transition: 'background-color 0.15s, color 0.15s',
-          '&:hover': {
-            bgcolor: 'action.hover',
-            color: 'text.primary',
-          },
-        }}
-      >
-        Projects
-      </Box>
-
-      <Separator />
-
-      {/* Active project chip — outlined button that opens the project switcher */}
       <ProjectSwitcher />
 
       {trailingLabel && (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -71,7 +71,7 @@ export default function Header({ onMenuOpen }: HeaderProps) {
       </Box>
 
       {/* Right: weather (when applicable) + notifications + identity */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0 }}>
         {currentProject?.location && activeOrganizationId && (
           <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
             <LocationWeather

--- a/src/components/layout/IdentityMenu.tsx
+++ b/src/components/layout/IdentityMenu.tsx
@@ -71,44 +71,21 @@ export default function IdentityMenu() {
             }}
           >
             {user && <UserAvatar user={user} size={32} borderRadius="8px" />}
-            <Box
+            <Typography
               sx={{
-                display: { xs: 'none', md: 'flex' },
-                flexDirection: 'column',
-                alignItems: 'flex-start',
-                minWidth: 0,
-                gap: '2px',
+                display: { xs: 'none', md: 'block' },
+                fontSize: '0.8125rem',
+                fontWeight: 600,
+                color: 'text.primary',
                 lineHeight: 1.2,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                maxWidth: 160,
               }}
             >
-              <Typography
-                sx={{
-                  fontSize: '0.8125rem',
-                  fontWeight: 600,
-                  color: 'text.primary',
-                  lineHeight: 1.2,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  maxWidth: 160,
-                }}
-              >
-                {user?.name ?? 'User'}
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: '0.6875rem',
-                  color: 'text.secondary',
-                  lineHeight: 1.2,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  maxWidth: 160,
-                }}
-              >
-                {user?.email ?? ''}
-              </Typography>
-            </Box>
+              {user?.name ?? 'User'}
+            </Typography>
           </Box>
         </DropdownMenuTrigger>
 

--- a/src/components/layout/LocationWeather.tsx
+++ b/src/components/layout/LocationWeather.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from 'react';
 import {
-  MapPin,
   Clock,
   Sun,
   Moon,
@@ -107,19 +106,10 @@ export default function LocationWeather({ location, organizationId }: LocationWe
     return () => clearInterval(interval);
   }, [weather?.timezoneOffset]);
 
-  const shortLocation = location.length > 30 ? location.slice(0, 28) + '\u2026' : location;
   const weatherInfo = weather ? getWeatherIcon(weather.icon) : null;
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
-      {/* Location chip */}
-      <Box sx={chipSx}>
-        <MapPin size={13} weight="bold" style={{ flexShrink: 0, opacity: 0.55 }} />
-        <Typography sx={labelSx}>
-          {shortLocation}
-        </Typography>
-      </Box>
-
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
       {/* Weather chip — condition-tinted background */}
       {weather && weatherInfo && (
         <Box

--- a/src/components/layout/ProjectShell.tsx
+++ b/src/components/layout/ProjectShell.tsx
@@ -9,6 +9,7 @@ import { differenceInCalendarDays } from 'date-fns';
 import FilesContent from '@/components/files/FilesContent';
 import { IBeamLoader } from '@/components/ui/IBeamLoader';
 import TaskProgressCard from '@/components/bryntum/components/TaskProgressCard';
+import TaskCountPill from '@/components/layout/TaskCountPill';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
 import { useProjectSwitcher } from '@/hooks/useProjectSwitcher';
 import { api } from '@/trpc/react';
@@ -135,8 +136,9 @@ export default function ProjectShell({ children, projectId, projectName }: Proje
           }}
         >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5, flexShrink: 0 }}>
-            {currentProject && (
+            {currentProject && activeOrganizationId && (
               <>
+                <TaskCountPill organizationId={activeOrganizationId} projectId={projectId} />
                 <TaskProgressCard
                   uploaded={reqStats?.totalUploaded ?? 0}
                   required={reqStats?.totalRequired ?? 0}

--- a/src/components/layout/ProjectSwitcher.tsx
+++ b/src/components/layout/ProjectSwitcher.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useParams } from 'next/navigation';
-import { CaretUpDown, MagnifyingGlass, Check, Plus } from '@phosphor-icons/react';
+import { CaretUpDown, MagnifyingGlass, Check, Plus, MapPin } from '@phosphor-icons/react';
 import { Box, Typography, Menu, ButtonBase, alpha, useTheme } from '@mui/material';
 import ProjectAvatar from '@/components/ui/ProjectAvatar';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
@@ -59,9 +59,9 @@ export default function ProjectSwitcher() {
           display: 'inline-flex',
           alignItems: 'center',
           gap: 1,
-          pl: 0.75,
+          pl: 0.625,
           pr: 1,
-          py: 0.875,
+          py: 0.5,
           bgcolor: 'background.paper',
           border: '1px solid',
           borderColor: 'divider',
@@ -69,10 +69,7 @@ export default function ProjectSwitcher() {
           boxShadow: '0 1px 2px rgba(0,0,0,0.03)',
           transition: 'background-color 0.15s, border-color 0.15s, box-shadow 0.15s',
           color: 'text.primary',
-          fontSize: '14.5px',
-          fontWeight: 600,
           letterSpacing: '-0.005em',
-          lineHeight: 1,
           minWidth: 0,
           maxWidth: 320,
           '&:hover': {
@@ -86,26 +83,63 @@ export default function ProjectSwitcher() {
           imageUrl={currentProject?.imageUrl}
           icon={currentProject?.icon}
           colorId={currentProject?.imageUrl ? null : currentProject?.color}
-          size={22}
-          borderRadius="5px"
+          size={28}
+          borderRadius="6px"
           color="var(--text-secondary)"
         />
-        <Typography
-          component="span"
+        <Box
           sx={{
-            fontSize: '14.5px',
-            fontWeight: 600,
-            letterSpacing: '-0.005em',
-            color: hasProject ? 'text.primary' : 'text.secondary',
-            lineHeight: 1,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-start',
+            gap: '1px',
             minWidth: 0,
           }}
         >
-          {hasProject ? currentProject.name : 'Select project'}
-        </Typography>
+          <Typography
+            component="span"
+            sx={{
+              fontSize: '13.5px',
+              fontWeight: 600,
+              letterSpacing: '-0.005em',
+              color: hasProject ? 'text.primary' : 'text.secondary',
+              lineHeight: 1.15,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              maxWidth: 240,
+            }}
+          >
+            {hasProject ? currentProject.name : 'Select project'}
+          </Typography>
+          {hasProject && currentProject.location && (
+            <Box
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '3px',
+                maxWidth: 240,
+                minWidth: 0,
+              }}
+            >
+              <MapPin size={10} weight="bold" style={{ flexShrink: 0, opacity: 0.55 }} />
+              <Typography
+                component="span"
+                sx={{
+                  fontSize: '11px',
+                  fontWeight: 500,
+                  color: 'text.secondary',
+                  lineHeight: 1.15,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {currentProject.location}
+              </Typography>
+            </Box>
+          )}
+        </Box>
         <CaretUpDown size={14} style={{ flexShrink: 0, color: 'var(--text-secondary)' }} />
       </ButtonBase>
 
@@ -273,6 +307,26 @@ export default function ProjectSwitcher() {
                       <Check size={13} weight="bold" style={{ flexShrink: 0, color: theme.palette.primary.main }} />
                     )}
                   </Box>
+
+                  {/* Address */}
+                  {project.location && (
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: '3px', mt: 0.5, minWidth: 0 }}>
+                      <MapPin size={10} weight="bold" style={{ flexShrink: 0, opacity: 0.55, color: theme.palette.text.secondary }} />
+                      <Typography
+                        sx={{
+                          fontSize: '0.6875rem',
+                          fontWeight: 500,
+                          color: 'text.secondary',
+                          lineHeight: 1.2,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {project.location}
+                      </Typography>
+                    </Box>
+                  )}
 
                   {/* Progress bar */}
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 0.75 }}>

--- a/src/components/layout/TaskCountPill.tsx
+++ b/src/components/layout/TaskCountPill.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { ListChecks } from '@phosphor-icons/react';
+import { Box, Tooltip, Typography } from '@mui/material';
+import { keepPreviousData } from '@tanstack/react-query';
+import { api } from '@/trpc/react';
+
+interface TaskCountPillProps {
+  organizationId: string;
+  projectId: string;
+}
+
+export default function TaskCountPill({ organizationId, projectId }: TaskCountPillProps) {
+  const { data: tasks } = api.gantt.tasks.useQuery(
+    { organizationId, projectId },
+    { enabled: !!organizationId && !!projectId, placeholderData: keepPreviousData },
+  );
+
+  if (!tasks) return null;
+
+  const count = tasks.length;
+  const label = count === 1 ? 'task' : 'tasks';
+
+  return (
+    <Tooltip title="Total tasks in this Gantt" arrow placement="bottom">
+      <Box
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.625,
+          height: 34,
+          px: 1.25,
+          borderRadius: '10px',
+          bgcolor: 'var(--bg-card)',
+          border: '1px solid var(--border-color)',
+          boxShadow: '0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)',
+          flexShrink: 0,
+        }}
+      >
+        <ListChecks size={13} style={{ flexShrink: 0, opacity: 0.5 }} />
+        <Typography
+          sx={{
+            fontSize: '0.6875rem',
+            fontWeight: 600,
+            color: 'text.primary',
+            lineHeight: 1,
+            fontVariantNumeric: 'tabular-nums',
+            letterSpacing: '-0.01em',
+          }}
+        >
+          {count}
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: '0.6875rem',
+            fontWeight: 500,
+            color: 'text.secondary',
+            lineHeight: 1,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {label}
+        </Typography>
+      </Box>
+    </Tooltip>
+  );
+}

--- a/src/lib/validations/gantt.ts
+++ b/src/lib/validations/gantt.ts
@@ -117,7 +117,6 @@ export const updateSlotSchema = z.object({
   slotId: z.string(),
   name: z.string().trim().max(200).nullable().optional(),
   dueDate: z.string().or(z.date()).nullable().optional(),
-  approverId: z.string().nullable().optional(),
 });
 
 export type ListSlotsInput = z.infer<typeof listSlotsSchema>;

--- a/src/server/api/helpers/ganttSync.ts
+++ b/src/server/api/helpers/ganttSync.ts
@@ -200,13 +200,19 @@ export async function syncTasks(
       }
 
       try {
-        const updated = await db.ganttTask.update({
+        await db.ganttTask.update({
           where: { id: task.id, projectId },
           data: updateData,
           select: { id: true },
         });
 
-        result.rows.push({ id: updated.id });
+        // Bryntum's CrudManager protocol: `tasks.rows` is strictly the
+        // phantom→real id swap table for ADDED records. Pushing updated rows
+        // (which carry no $PhantomId) into the same array poisons
+        // afterSyncAttempt — it iterates every row assuming a $PhantomId and
+        // throws "Cannot set properties of undefined (setting
+        // 'isBeingMaterialized')" on the first one without one. Updates don't
+        // need echoing: the client already knows the id from the request.
       } catch (error) {
         // P2025 = record not found (deleted concurrently or never existed —
         // e.g. STM undo of an unsynced add sends an UPDATE for a phantom id).

--- a/src/server/api/helpers/ganttTree.ts
+++ b/src/server/api/helpers/ganttTree.ts
@@ -23,13 +23,18 @@ type GanttTaskSelect = {
   csiCode: string | null;
   baselines: unknown;
   orderIndex: number;
+  requiredSubmittals?: number | null;
+  requiredInspections?: number | null;
 };
 
 // Bryntum expects specific field names - map DB fields to Bryntum fields
 export function mapTaskToGantt(
   task: GanttTaskSelect,
   needsReviewCount = 0,
+  requirementsFilled = 0,
 ): Record<string, unknown> {
+  const requirementsTotal =
+    (task.requiredSubmittals ?? 0) + (task.requiredInspections ?? 0);
   return {
     id: task.id,
     parentId: task.parentId,
@@ -52,6 +57,8 @@ export function mapTaskToGantt(
     csiCode: task.csiCode,
     baselines: task.baselines,
     needsReviewCount,
+    requirementsTotal,
+    requirementsFilled: Math.min(requirementsFilled, requirementsTotal),
   };
 }
 
@@ -106,13 +113,18 @@ export function mapTimeRangeToGantt(timeRange: GanttTimeRange): Record<string, u
 export function buildTaskTree(
   tasks: GanttTaskSelect[],
   needsReviewCounts?: Map<string, number>,
+  requirementsFilledCounts?: Map<string, number>,
 ): Record<string, unknown>[] {
   const taskMap = new Map<string, Record<string, unknown>>();
   const rootTasks: Record<string, unknown>[] = [];
 
   // First pass: create all task objects
   for (const task of tasks) {
-    const ganttTask = mapTaskToGantt(task, needsReviewCounts?.get(task.id) ?? 0);
+    const ganttTask = mapTaskToGantt(
+      task,
+      needsReviewCounts?.get(task.id) ?? 0,
+      requirementsFilledCounts?.get(task.id) ?? 0,
+    );
     ganttTask.children = [];
     taskMap.set(task.id, ganttTask);
   }

--- a/src/server/api/routers/approval.ts
+++ b/src/server/api/routers/approval.ts
@@ -125,7 +125,6 @@ export const approvalRouter = createTRPCRouter({
         orderBy: { dueDate: "asc" },
         include: {
           task: { select: { id: true, name: true } },
-          approver: { select: { id: true, name: true, email: true, image: true } },
         },
       });
 
@@ -137,7 +136,6 @@ export const approvalRouter = createTRPCRouter({
         index: slot.index,
         name: slot.name,
         dueDate: slot.dueDate!,
-        approver: slot.approver,
       }));
     }),
 

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -192,7 +192,15 @@ export const ganttRouter = createTRPCRouter({
       }
 
       // Fetch all Gantt data in parallel with optimized queries
-      const [tasks, dependencies, resources, assignments, timeRanges, needsReviewRows] = await Promise.all([
+      const [
+        tasks,
+        dependencies,
+        resources,
+        assignments,
+        timeRanges,
+        needsReviewRows,
+        filledSlotRows,
+      ] = await Promise.all([
         ctx.db.ganttTask.findMany({
           where: { projectId },
           orderBy: { orderIndex: "asc" },
@@ -219,6 +227,8 @@ export const ganttRouter = createTRPCRouter({
             csiCode: true,
             baselines: true,
             orderIndex: true,
+            requiredSubmittals: true,
+            requiredInspections: true,
           },
         }),
         ctx.db.ganttDependency.findMany({
@@ -242,6 +252,18 @@ export const ganttRouter = createTRPCRouter({
           },
           _count: { _all: true },
         }),
+        // Count requirement slots that have at least one bound document, grouped by task.
+        // The partial unique index on Document.slotId enforces at-most-one doc per slot,
+        // so counting documents-with-slotId equals counting filled slots.
+        ctx.db.document.groupBy({
+          by: ["taskId"],
+          where: {
+            projectId,
+            taskId: { not: null },
+            slotId: { not: null },
+          },
+          _count: { _all: true },
+        }),
       ]);
 
       // Build needsReviewCount map per task (rolled up to parents in buildTaskTree)
@@ -252,8 +274,17 @@ export const ganttRouter = createTRPCRouter({
         }
       }
 
+      // Build filled-slot count per task. requirementsTotal comes from each task's
+      // legacy required* columns (already selected). Bars show a % when total > 0.
+      const filledSlotCounts = new Map<string, number>();
+      for (const row of filledSlotRows) {
+        if (row.taskId) {
+          filledSlotCounts.set(row.taskId, row._count._all);
+        }
+      }
+
       // Build hierarchical task tree
-      const taskTree = buildTaskTree(tasks, needsReviewCounts);
+      const taskTree = buildTaskTree(tasks, needsReviewCounts, filledSlotCounts);
 
       // Map other entities to Gantt format
       const ganttDependencies = dependencies.map(mapDependencyToGantt);
@@ -416,9 +447,9 @@ export const ganttRouter = createTRPCRouter({
 
   // ─── Per-slot tracking (Tier 2/3) ──────────────────────────────────────
   // Slots carry the metadata that the legacy requiredSubmittals/Inspections
-  // integers don't: name, due date, approver. They are kept in sync with those
-  // count columns by setSlotCount so the popover and existing readers keep
-  // working. listSlots auto-backfills from the legacy count on first read.
+  // integers don't: name, due date. They are kept in sync with those count
+  // columns by setSlotCount so the popover and existing readers keep working.
+  // listSlots auto-backfills from the legacy count on first read.
 
   listSlots: orgProcedure
     .input(z.object({ projectId: z.string() }).merge(listSlotsSchema))
@@ -434,7 +465,6 @@ export const ganttRouter = createTRPCRouter({
       }
 
       const slotInclude = {
-        approver: { select: { id: true, name: true, email: true, image: true } },
         documents: {
           orderBy: { createdAt: "asc" },
           take: 1,
@@ -556,9 +586,6 @@ export const ganttRouter = createTRPCRouter({
         return tx.taskRequirementSlot.findMany({
           where: { taskId, kind },
           orderBy: { index: "asc" },
-          include: {
-            approver: { select: { id: true, name: true, email: true, image: true } },
-          },
         });
       });
     }),
@@ -587,25 +614,6 @@ export const ganttRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Slot not found" });
       }
 
-      // If approverId is provided, verify the user is a member of this org.
-      if (patch.approverId) {
-        const member = await ctx.db.membership.findUnique({
-          where: {
-            userId_organizationId: {
-              userId: patch.approverId,
-              organizationId: ctx.organization.id,
-            },
-          },
-          select: { id: true },
-        });
-        if (!member) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "Approver must be a member of this organization",
-          });
-        }
-      }
-
       const data: Record<string, unknown> = {};
       if (patch.name !== undefined) {
         data.name = patch.name === null ? null : patch.name.trim() || null;
@@ -613,14 +621,10 @@ export const ganttRouter = createTRPCRouter({
       if (patch.dueDate !== undefined) {
         data.dueDate = patch.dueDate === null ? null : new Date(patch.dueDate);
       }
-      if (patch.approverId !== undefined) data.approverId = patch.approverId;
 
       return ctx.db.taskRequirementSlot.update({
         where: { id: slotId },
         data,
-        include: {
-          approver: { select: { id: true, name: true, email: true, image: true } },
-        },
       });
     }),
 });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -746,11 +746,9 @@ body {
   display: none !important;
 }
 
-/* Destructive items — Delete by built-in trash icon, plus opt-in classes
-   for menus we author programmatically (row-action `gantt-action-danger`,
-   future `menu-item-danger`). */
+/* Destructive items — Delete by built-in trash icon, plus opt-in
+   `menu-item-danger` class for menus we author programmatically. */
 .b-menu.b-popup .b-menu-item:has(.b-icon-trash),
-.b-menu.b-popup .b-menu-item.gantt-action-danger,
 .b-menu.b-popup .b-menu-item.menu-item-danger {
   --b-menu-item-color: var(--status-red);
   --b-menu-item-icon-color: var(--status-red);
@@ -763,7 +761,6 @@ body {
 }
 
 .b-menu.b-popup .b-menu-item:has(.b-icon-trash):active,
-.b-menu.b-popup .b-menu-item.gantt-action-danger:active,
 .b-menu.b-popup .b-menu-item.menu-item-danger:active {
   --b-menu-item-hover-background: var(--menu-danger-active-bg);
   --b-menu-item-focus-background: var(--menu-danger-active-bg);


### PR DESCRIPTION
## Summary

- **Add-task UX**: seeds unique `Task N` names, waits for `commitAsync` before scrolling/selecting/starting inline edit, and replaces the row-action ⋮ menu with a task-bar donut chip rendering `filled/total` submittal + inspection progress.
- **Bryntum sync correctness**: stops pushing updated rows into `tasks.rows` (afterSyncAttempt requires `$PhantomId`), disables `reconcileSyncPack` with a regression test, and adds dev-only fetch + log instrumentation to diagnose phantom-id swaps.
- **Slots**: drops the per-slot approver feature (migration + schema + UI + Review Queue), wires optimistic `setSlotCount` updates that gate uploads/renames on placeholder `optimistic-…` IDs to avoid FK errors, and surfaces inline approval toggles + Approved-by attribution in `SubmittalDrawer`.
- **Layout polish**: trims the breadcrumb to project chip only, restructures `ProjectSwitcher` (larger avatar, two-line name + location), simplifies `IdentityMenu` and `LocationWeather`, and adds `TaskCountPill` to the project header.

## Test plan
- [ ] Add a task via the toolbar — name auto-edits and increments past existing `Task N` rows
- [ ] Add a subtask via Bryntum's task menu and confirm no duplicate row appears in DB
- [ ] Step submittals up/down in the drawer — optimistic rows render immediately; uploads on optimistic rows show `Saving…` and are no-ops until reconcile
- [ ] Approve a bound submittal — toggle reflects in drawer pill and Approved-by line
- [ ] Verify Review Queue Overdue tab still loads (now without approver column)
- [ ] Production build: `npm run build` succeeds and `/api/gantt/sync` logs only one-liners

🤖 Generated with [Claude Code](https://claude.com/claude-code)