### PR TITLE
Improve slot dropzones with per-slot DnD, due dates, and background uploads

### DIFF
--- a/src/components/bryntum/components/SubmittalDrawer.tsx
+++ b/src/components/bryntum/components/SubmittalDrawer.tsx
@@ -7,6 +7,7 @@ import {
   IconButton,
   Typography,
   CircularProgress,
+  alpha,
 } from '@mui/material';
 import {
   X,
@@ -1000,7 +1001,7 @@ function SlotNumberBadge({
         boxShadow: isApproved
           ? '0 0 0 3px rgba(22,163,74,0.20)'
           : isReceived
-            ? '0 0 0 3px rgba(79,70,229,0.18)'
+            ? `0 0 0 3px ${alpha(RECEIVED_COLOR, 0.18)}`
             : 'none',
         transition: 'box-shadow 0.15s, background-color 0.2s',
       }}
@@ -1078,6 +1079,42 @@ function FieldSlot({ label, children }: { label: string; children: React.ReactNo
   );
 }
 
+// Approved → solid green pill with ✓ (the "done" signal).
+// Received → indigo tint + border + inbox icon ("awaiting your decision",
+//   visually distinct from approved).
+// Overdue → amber tint, no icon.
+// Pending → neutral gray, no icon.
+const PILL_CONFIG = {
+  approved: {
+    label: 'Approved',
+    bg: 'success.main',
+    color: 'success.contrastText',
+    borderColor: 'transparent',
+    icon: <CheckCircle size={11} weight="fill" />,
+  },
+  received: {
+    label: 'Received',
+    bg: alpha(RECEIVED_COLOR, 0.10),
+    color: RECEIVED_COLOR,
+    borderColor: alpha(RECEIVED_COLOR, 0.30),
+    icon: <Tray size={11} weight="bold" />,
+  },
+  overdue: {
+    label: 'Overdue',
+    bg: 'rgba(217,119,6,0.14)',
+    color: 'warning.main',
+    borderColor: 'transparent',
+    icon: null,
+  },
+  pending: {
+    label: 'Pending',
+    bg: 'action.selected',
+    color: 'text.secondary',
+    borderColor: 'transparent',
+    icon: null,
+  },
+} as const;
+
 function SlotStatusPill({
   received,
   overdue,
@@ -1087,42 +1124,8 @@ function SlotStatusPill({
   overdue: boolean;
   approved: boolean;
 }) {
-  // Approved → solid green pill with ✓ (the "done" signal).
-  // Received → indigo pill with a soft tint + indigo border + inbox icon (the
-  //   "awaiting your decision" signal — visually distinct from approved).
-  // Overdue → amber tint, no icon.
-  // Pending → neutral gray, no icon.
-  const config = approved
-    ? {
-        label: 'Approved',
-        bg: 'success.main',
-        color: 'success.contrastText',
-        borderColor: 'transparent',
-        icon: <CheckCircle size={11} weight="fill" />,
-      }
-    : received
-      ? {
-          label: 'Received',
-          bg: 'rgba(79,70,229,0.10)',
-          color: RECEIVED_COLOR,
-          borderColor: 'rgba(79,70,229,0.30)',
-          icon: <Tray size={11} weight="bold" />,
-        }
-      : overdue
-        ? {
-            label: 'Overdue',
-            bg: 'rgba(217,119,6,0.14)',
-            color: 'warning.main',
-            borderColor: 'transparent',
-            icon: null,
-          }
-        : {
-            label: 'Pending',
-            bg: 'action.selected',
-            color: 'text.secondary',
-            borderColor: 'transparent',
-            icon: null,
-          };
+  const status = approved ? 'approved' : received ? 'received' : overdue ? 'overdue' : 'pending';
+  const config = PILL_CONFIG[status];
   return (
     <Box
       sx={{

--- a/src/components/bryntum/components/SubmittalDrawer.tsx
+++ b/src/components/bryntum/components/SubmittalDrawer.tsx
@@ -17,6 +17,7 @@ import {
   CheckCircle,
   CloudArrowUp,
   WarningCircle,
+  Tray,
 } from '@phosphor-icons/react';
 import { format, isBefore, startOfDay } from 'date-fns';
 
@@ -28,6 +29,10 @@ import ApprovalToggleSwitch from './task-popover/ApprovalToggleSwitch';
 import type { DocumentItem } from './task-popover/types';
 
 const SUBMITTAL_COLOR = '#2563EB';
+// Indigo signals "received, awaiting approval" — matches the "in review"
+// pill convention used by FolderRow in the task popover, and intentionally
+// differs from the solid green used for "approved".
+const RECEIVED_COLOR = '#4f46e5';
 
 // Optimistic slot IDs are tagged with this prefix so any code path that would
 // otherwise send the placeholder ID to the server (uploads, slot updates) can
@@ -620,7 +625,7 @@ function SlotSummary({
   const parts: React.ReactNode[] = [];
   if (filledCount > 0) {
     parts.push(
-      <Box key="r" component="span" sx={{ color: 'success.main', fontWeight: 600 }}>
+      <Box key="r" component="span" sx={{ color: RECEIVED_COLOR, fontWeight: 600 }}>
         {filledCount} received
       </Box>,
     );
@@ -725,33 +730,41 @@ function SlotCard({
   const dueDateInputRef = useRef<HTMLInputElement | null>(null);
   const showDueDateField = !!slot.dueDate || dueDateExpanded;
 
-  const cardBg = isReceived
-    ? 'success.main'
-    : isOverdue
-      ? 'warning.main'
-      : null;
+  // Tint hierarchy: approved (green) > received (indigo) > overdue (amber).
+  // Received-but-not-approved is intentionally distinct from approved so the
+  // reviewer can tell at a glance which slots still need their decision.
+  const cardTintColor = isApproved
+    ? 'var(--mui-palette-success-main, #16a34a)'
+    : isReceived
+      ? RECEIVED_COLOR
+      : isOverdue
+        ? 'var(--mui-palette-warning-main, #d97706)'
+        : null;
+  // Only overdue gets a colored border — received/approved rely on tint + pill
+  // for their visual signal so the cards don't shout for attention.
+  const cardBorderColor = isOverdue ? 'warning.main' : 'divider';
 
   return (
     <Box
       sx={{
         border: '1px solid',
-        borderColor: isOverdue ? 'warning.main' : 'divider',
+        borderColor: cardBorderColor,
         borderRadius: '10px',
         px: 1.75,
         py: 1.5,
         bgcolor: 'background.paper',
         position: 'relative',
-        // Subtle tint for received/overdue states without losing the white surface
-        backgroundImage: cardBg
+        // Subtle tint conveys state without losing the white surface.
+        backgroundImage: cardTintColor
           ? `linear-gradient(0deg, var(--mui-palette-background-paper, #fff), var(--mui-palette-background-paper, #fff))`
           : 'none',
-        '&::before': cardBg ? {
+        '&::before': cardTintColor ? {
           content: '""',
           position: 'absolute',
           inset: 0,
           borderRadius: '10px',
-          bgcolor: cardBg,
-          opacity: 0.05,
+          bgcolor: cardTintColor,
+          opacity: isReceived && !isApproved ? 0.04 : 0.05,
           pointerEvents: 'none',
         } : undefined,
         transition: 'border-color 0.15s',
@@ -851,7 +864,11 @@ function SlotCard({
       >
         {isReceived ? (
           <>
-            <CheckCircle size={13} weight="fill" color="var(--mui-palette-success-main, #16a34a)" />
+            {isApproved ? (
+              <CheckCircle size={13} weight="fill" color="var(--mui-palette-success-main, #16a34a)" />
+            ) : (
+              <Tray size={13} weight="fill" color={RECEIVED_COLOR} />
+            )}
             <Box sx={{
               flex: 1,
               minWidth: 0,
@@ -958,7 +975,13 @@ function SlotNumberBadge({
   isApproved: boolean;
 }) {
   const meta = KIND_META[kind];
-  const bg = isReceived ? 'var(--mui-palette-success-main, #16a34a)' : `${meta.color}1F`;
+  // Approved → solid green ✓. Received (not approved) → solid indigo inbox.
+  // Empty slot → soft folder-tinted disc with the slot number.
+  const bg = isApproved
+    ? 'var(--mui-palette-success-main, #16a34a)'
+    : isReceived
+      ? RECEIVED_COLOR
+      : `${meta.color}1F`;
   const color = isReceived ? '#fff' : meta.color;
   return (
     <Box
@@ -974,11 +997,21 @@ function SlotNumberBadge({
         fontSize: 10,
         fontWeight: 700,
         flexShrink: 0,
-        boxShadow: isApproved ? '0 0 0 3px rgba(22,163,74,0.20)' : 'none',
-        transition: 'box-shadow 0.15s',
+        boxShadow: isApproved
+          ? '0 0 0 3px rgba(22,163,74,0.20)'
+          : isReceived
+            ? '0 0 0 3px rgba(79,70,229,0.18)'
+            : 'none',
+        transition: 'box-shadow 0.15s, background-color 0.2s',
       }}
     >
-      {isReceived ? <CheckCircle size={12} weight="fill" /> : index + 1}
+      {isApproved ? (
+        <CheckCircle size={12} weight="fill" />
+      ) : isReceived ? (
+        <Tray size={12} weight="fill" />
+      ) : (
+        index + 1
+      )}
     </Box>
   );
 }
@@ -1054,19 +1087,48 @@ function SlotStatusPill({
   overdue: boolean;
   approved: boolean;
 }) {
+  // Approved → solid green pill with ✓ (the "done" signal).
+  // Received → indigo pill with a soft tint + indigo border + inbox icon (the
+  //   "awaiting your decision" signal — visually distinct from approved).
+  // Overdue → amber tint, no icon.
+  // Pending → neutral gray, no icon.
   const config = approved
-    ? { label: 'Approved', bg: 'success.main', color: 'success.contrastText', showCheck: true }
+    ? {
+        label: 'Approved',
+        bg: 'success.main',
+        color: 'success.contrastText',
+        borderColor: 'transparent',
+        icon: <CheckCircle size={11} weight="fill" />,
+      }
     : received
-      ? { label: 'Received', bg: 'rgba(22,163,74,0.14)', color: 'success.main', showCheck: false }
+      ? {
+          label: 'Received',
+          bg: 'rgba(79,70,229,0.10)',
+          color: RECEIVED_COLOR,
+          borderColor: 'rgba(79,70,229,0.30)',
+          icon: <Tray size={11} weight="bold" />,
+        }
       : overdue
-        ? { label: 'Overdue', bg: 'rgba(217,119,6,0.14)', color: 'warning.main', showCheck: false }
-        : { label: 'Pending', bg: 'action.selected', color: 'text.secondary', showCheck: false };
+        ? {
+            label: 'Overdue',
+            bg: 'rgba(217,119,6,0.14)',
+            color: 'warning.main',
+            borderColor: 'transparent',
+            icon: null,
+          }
+        : {
+            label: 'Pending',
+            bg: 'action.selected',
+            color: 'text.secondary',
+            borderColor: 'transparent',
+            icon: null,
+          };
   return (
     <Box
       sx={{
         display: 'inline-flex',
         alignItems: 'center',
-        gap: '3px',
+        gap: '4px',
         fontSize: 10,
         fontWeight: 600,
         px: 0.875,
@@ -1074,11 +1136,13 @@ function SlotStatusPill({
         borderRadius: '999px',
         bgcolor: config.bg,
         color: config.color,
+        border: '1px solid',
+        borderColor: config.borderColor,
         letterSpacing: '0.02em',
         flexShrink: 0,
       }}
     >
-      {config.showCheck && <CheckCircle size={11} weight="fill" />}
+      {config.icon}
       {config.label}
     </Box>
   );

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -59,6 +59,7 @@ export function TaskDetailsPopover({
   const [uploadingSlotIds, setUploadingSlotIds] = useState<Set<string>>(new Set());
   const markSlotUploading = useCallback((slotId: string, on: boolean) => {
     setUploadingSlotIds((prev) => {
+      if (prev.has(slotId) === on) return prev;
       const next = new Set(prev);
       if (on) next.add(slotId);
       else next.delete(slotId);

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -10,6 +10,7 @@ import { useProjectContext } from '@/components/providers/ProjectProvider';
 import { useOrgContext } from '@/components/providers/OrgProvider';
 import UploadDialog from '@/components/documents/UploadDialog';
 import { api } from '@/trpc/react';
+import { trackUpload } from '@/store/uploadStatusStore';
 import type { PopoverPlacement, BryntumGanttInstance } from '../types';
 import type { PreviewDoc, DocumentItem } from './task-popover/types';
 
@@ -51,6 +52,19 @@ export function TaskDetailsPopover({
   const [uploadTarget, setUploadTarget] = useState<{ folder: { id: string; name: string }; slotId?: string } | null>(null);
   const [rightPanel, setRightPanel] = useState<RightPanel>(null);
   const [drawerKind, setDrawerKind] = useState<SlotKind | null>(null);
+  // Per-slot upload tracking — drives the in-place "Uploading…" badge on
+  // SlotDropzone rows so the user can see where the file is landing even
+  // after the dialog closes. Both the dialog path and the DnD path feed
+  // this set via markSlotUploading.
+  const [uploadingSlotIds, setUploadingSlotIds] = useState<Set<string>>(new Set());
+  const markSlotUploading = useCallback((slotId: string, on: boolean) => {
+    setUploadingSlotIds((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(slotId);
+      else next.delete(slotId);
+      return next;
+    });
+  }, []);
 
   const openUploadDialog = useCallback(
     (folder: { id: string; name: string }, slotId?: string) => {
@@ -174,6 +188,34 @@ export function TaskDetailsPopover({
     setUploadTarget(null);
   }, [organizationId, projectId, taskId, utils]);
 
+  // Per-slot drag-and-drop upload: bypasses the dialog (no title/notes prompt)
+  // and routes through trackUpload so the global chip shows progress. The
+  // slotId is marked uploading so the SlotDropzone row also reflects that
+  // state in-place until the upload resolves.
+  const handleUploadFile = useCallback(
+    (folderId: string, slotId: string, file: File) => {
+      if (!taskId) return;
+      markSlotUploading(slotId, true);
+      void trackUpload<{ document: { id: string } }>(
+        file,
+        () => {
+          const formData = new FormData();
+          formData.append('file', file);
+          formData.append('projectId', projectId);
+          formData.append('taskId', taskId);
+          formData.append('folderId', folderId);
+          formData.append('slotId', slotId);
+          return fetch('/api/upload', { method: 'POST', body: formData });
+        },
+        { maxBytes: 50 * 1024 * 1024 },
+      ).then((result) => {
+        markSlotUploading(slotId, false);
+        if (result.ok) handleUploadComplete();
+      });
+    },
+    [projectId, taskId, handleUploadComplete, markSlotUploading],
+  );
+
   const handleClose = () => {
     setExpandedFolders(new Set());
     setRightPanel(null);
@@ -216,8 +258,8 @@ export function TaskDetailsPopover({
   const inspectionsCounts = inspectionsFolder
     ? getTrackableCount(inspectionsFolder)
     : { total: 0, approved: 0, pending: 0 };
-  const submittalsCurrent = submittalsCounts.total;
-  const inspectionsCurrent = inspectionsCounts.total;
+  const submittalsCurrent = submittalsCounts.approved;
+  const inspectionsCurrent = inspectionsCounts.approved;
 
   const coverDocumentId = taskDetail?.coverDocumentId ?? null;
   const photos = ((allDocs ?? []) as DocumentItem[]).filter(
@@ -410,7 +452,7 @@ export function TaskDetailsPopover({
                       total += c?.total ?? 0;
                       approved += c?.approved ?? 0;
                     }
-                    trackingCurrent = total;
+                    trackingCurrent = approved;
                     trackingApproved = approved;
                     trackingPending = total - approved;
                     trackingRequired = taskDetail?.[folder.requirementField] ?? null;
@@ -425,6 +467,7 @@ export function TaskDetailsPopover({
                       count={count}
                       docs={folderDocs}
                       onUpload={openUploadDialog}
+                      onUploadFile={handleUploadFile}
                       onSelectDoc={openPreview}
                       selectedDocId={selectedDocId}
                       // Tracking props
@@ -449,6 +492,7 @@ export function TaskDetailsPopover({
                           : undefined
                       }
                       memberRole={memberRole}
+                      uploadingSlotIds={uploadingSlotIds}
                     />
                   );
                 })}
@@ -463,8 +507,7 @@ export function TaskDetailsPopover({
               {rightPanel.type === 'preview' ? (
                 <FilePreviewPanel
                   previewDoc={rightPanel.doc}
-                  organizationId={organizationId}
-                  memberRole={memberRole}
+                  onClose={closeRightPanel}
                 />
               ) : (
                 <CsiCodePanel
@@ -480,20 +523,36 @@ export function TaskDetailsPopover({
       </Popover>
 
       {/* Upload dialog */}
-      {uploadTarget && taskId && (
-        <UploadDialog
-          open
-          onOpenChange={(isOpen) => {
-            if (!isOpen) setUploadTarget(null);
-          }}
-          projectId={projectId}
-          taskId={taskId}
-          folderId={uploadTarget.folder.id}
-          folderName={uploadTarget.folder.name}
-          slotId={uploadTarget.slotId}
-          onUploadComplete={handleUploadComplete}
-        />
-      )}
+      {uploadTarget && taskId && (() => {
+        // Snapshot the slotId so the lifecycle callbacks survive the dialog
+        // closing — `setUploadTarget(null)` runs synchronously inside
+        // onOpenChange, but the upload resolves later. Reading
+        // `uploadTarget.slotId` from inside the callback at that point would
+        // dereference null.
+        const slotIdSnapshot = uploadTarget.slotId;
+        return (
+          <UploadDialog
+            open
+            onOpenChange={(isOpen) => {
+              if (!isOpen) setUploadTarget(null);
+            }}
+            projectId={projectId}
+            taskId={taskId}
+            folderId={uploadTarget.folder.id}
+            folderName={uploadTarget.folder.name}
+            slotId={slotIdSnapshot}
+            onUploadComplete={handleUploadComplete}
+            // Only the slot-bound path needs the lifecycle hooks — the "+" button
+            // upload path has no slot to badge, the global chip alone covers it.
+            onUploadStart={
+              slotIdSnapshot ? () => markSlotUploading(slotIdSnapshot, true) : undefined
+            }
+            onUploadEnd={
+              slotIdSnapshot ? () => markSlotUploading(slotIdSnapshot, false) : undefined
+            }
+          />
+        );
+      })()}
 
       {/* Submittal/inspection management drawer */}
       {drawerKind && taskId && (

--- a/src/components/bryntum/components/task-popover/ApprovalToggleSwitch.tsx
+++ b/src/components/bryntum/components/task-popover/ApprovalToggleSwitch.tsx
@@ -47,6 +47,8 @@ export default function ApprovalToggleSwitch({
       void utils.document.aiSearch.invalidate();
       void utils.document.listByFolder.invalidate();
       void utils.document.listByTask.invalidate();
+      // Drives the segmented progress bar + "N/M" count in FolderRow.
+      void utils.document.countByTask.invalidate();
       // Refresh slot state so the SubmittalDrawer pill + ApprovedByLine
       // update after the user approves a bound submittal/inspection.
       void utils.gantt.listSlots.invalidate();

--- a/src/components/bryntum/components/task-popover/FilePreviewPanel.tsx
+++ b/src/components/bryntum/components/task-popover/FilePreviewPanel.tsx
@@ -1,27 +1,19 @@
 'use client';
 
 import { Box, Typography, Divider } from '@mui/material';
-import { ImageSquare, FileText, DownloadSimple, ArrowsOut } from '@phosphor-icons/react';
+import { ImageSquare, FileText, DownloadSimple, ArrowsOut, X } from '@phosphor-icons/react';
 import { formatFileSize } from '@/lib/utils/formatting';
-import { isApprovableFolder } from '@/lib/folders';
 import type { PreviewDoc } from './types';
-import ApprovalToggleSwitch from './ApprovalToggleSwitch';
 
 interface FilePreviewPanelProps {
   previewDoc: PreviewDoc;
-  organizationId?: string;
-  memberRole?: string;
+  onClose: () => void;
 }
 
 export default function FilePreviewPanel({
   previewDoc,
-  organizationId,
-  memberRole,
+  onClose,
 }: FilePreviewPanelProps) {
-  const showApproval =
-    isApprovableFolder(previewDoc.folderId) &&
-    !!organizationId &&
-    typeof memberRole === 'string';
   const approvedByName = previewDoc.approvedBy?.name ?? null;
   const approvedAtLabel = previewDoc.approvedAt
     ? new Date(previewDoc.approvedAt).toLocaleDateString('en-US', {
@@ -62,25 +54,15 @@ export default function FilePreviewPanel({
           </Typography>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
-          {showApproval && (
-            <ApprovalToggleSwitch
-              documentId={previewDoc.id}
-              documentName={previewDoc.name}
-              approvalStatus={previewDoc.approvalStatus}
-              approvedBy={previewDoc.approvedBy}
-              organizationId={organizationId!}
-              memberRole={memberRole!}
-              size="md"
-            />
-          )}
           {[
-            { icon: DownloadSimple, label: 'Download' },
-            { icon: ArrowsOut, label: 'Expand' },
-          ].map(({ icon: Icon, label }) => (
+            { icon: DownloadSimple, label: 'Download', onClick: () => window.open(previewDoc.blobUrl, '_blank') },
+            { icon: ArrowsOut, label: 'Expand', onClick: () => window.open(previewDoc.blobUrl, '_blank') },
+            { icon: X, label: 'Close preview', onClick: onClose },
+          ].map(({ icon: Icon, label, onClick }) => (
             <Box
               key={label}
               component="button"
-              onClick={() => window.open(previewDoc.blobUrl, '_blank')}
+              onClick={onClick}
               sx={{
                 width: 28,
                 height: 28,

--- a/src/components/bryntum/components/task-popover/FolderRow.tsx
+++ b/src/components/bryntum/components/task-popover/FolderRow.tsx
@@ -43,6 +43,11 @@ interface FolderRowProps {
   count: number;
   docs: DocumentItem[];
   onUpload: (folder: { id: string; name: string }, slotId?: string) => void;
+  /**
+   * Direct file upload bound to a specific slot in this folder — used by
+   * per-slot drag-and-drop on trackable folders.
+   */
+  onUploadFile?: (folderId: string, slotId: string, file: File) => void;
   onSelectDoc: (doc: PreviewDoc) => void;
   selectedDocId: string | null;
   // Tracking props (only used for trackable folders)
@@ -62,6 +67,8 @@ interface FolderRowProps {
   onManage?: () => void;
   // Approval context (only used by trackable folders)
   memberRole?: string;
+  /** Slot ids currently uploading — forwarded to the trackable content. */
+  uploadingSlotIds?: Set<string>;
 }
 
 function FolderRowInner({
@@ -71,6 +78,7 @@ function FolderRowInner({
   count,
   docs,
   onUpload,
+  onUploadFile,
   onSelectDoc,
   selectedDocId,
   required,
@@ -86,6 +94,7 @@ function FolderRowInner({
   pinnedDocId,
   onManage,
   memberRole,
+  uploadingSlotIds,
 }: FolderRowProps) {
   const FolderIcon = folderIconMap[folder.id] ?? (isExpanded ? FolderOpen : FolderSimple);
   const isTrackable = folder.trackable && !!onSaveRequirement;
@@ -95,12 +104,16 @@ function FolderRowInner({
     onSelectDoc,
     selectedDocId,
     onUpload: (slotId?: string) => onUpload({ id: folder.id, name: folder.name }, slotId),
+    onUploadFile: onUploadFile
+      ? (slotId: string, file: File) => onUploadFile(folder.id, slotId, file)
+      : undefined,
     folderName: folder.name,
     projectId,
     taskId,
     organizationId,
     pinnedDocId,
     memberRole,
+    uploadingSlotIds,
   };
 
   const renderContent = () => {

--- a/src/components/bryntum/components/task-popover/SlotDropzone.tsx
+++ b/src/components/bryntum/components/task-popover/SlotDropzone.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Box, CircularProgress, Typography, alpha, useTheme } from '@mui/material';
 import { useDropzone } from 'react-dropzone';
 import { CloudArrowUp } from '@phosphor-icons/react';
@@ -79,8 +79,12 @@ function SlotDropzoneInner({
     disabled: !onDropFile || isUploading,
   });
 
-  // Derive due-date display from the raw value.
-  const parsedDue = dueDate ? (typeof dueDate === 'string' ? new Date(dueDate) : dueDate) : null;
+  // Stable Date reference so the effect below doesn't fire on every render
+  // (a fresh `new Date(...)` would be a new identity each pass).
+  const parsedDue = useMemo(
+    () => (dueDate ? (typeof dueDate === 'string' ? new Date(dueDate) : dueDate) : null),
+    [dueDate],
+  );
   const dueState = parsedDue ? describeDueDate(parsedDue) : null;
   const isOverdue = dueState?.tone === 'overdue';
 
@@ -108,11 +112,6 @@ function SlotDropzoneInner({
     requestAnimationFrame(() => dueInputRef.current?.focus());
   };
 
-  // Visual states:
-  // Resting: no border, action.hover bg, quiet badge.
-  // Hover:   dashed accent outline.
-  // Drag:    solid folderColor outline + alpha bg + scaled badge/icon.
-  // Overdue: badge tinted with error.main @12%, date text red.
   const dragBg = alpha(folderColor, 0.08);
   const dragRing = alpha(folderColor, 0.18);
 
@@ -132,7 +131,7 @@ function SlotDropzoneInner({
 
   return (
     <Box
-      {...(onDropFile && !isUploading ? getRootProps() : {})}
+      {...getRootProps()}
       onClick={isUploading ? undefined : onClick}
       sx={{
         position: 'relative',
@@ -165,11 +164,8 @@ function SlotDropzoneInner({
               }),
       }}
     >
-      {onDropFile && !isUploading && <input {...getInputProps()} />}
+      <input {...getInputProps()} />
 
-      {/* Slot number badge — overdue tints it red. While uploading, the badge
-          becomes a spinner so the user can see which slot the active upload
-          is landing in. */}
       <Box
         sx={{
           display: 'flex',
@@ -230,7 +226,6 @@ function SlotDropzoneInner({
         {isUploading ? `Uploading ${label}…` : isDragActive ? `Drop to upload ${label}` : label}
       </Typography>
 
-      {/* Due-date column — 4 states (editing | with date | no date + editor | nothing). */}
       {editingDue ? (
         <Box
           component="input"

--- a/src/components/bryntum/components/task-popover/SlotDropzone.tsx
+++ b/src/components/bryntum/components/task-popover/SlotDropzone.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, CircularProgress, Typography, alpha, useTheme } from '@mui/material';
+import { useDropzone } from 'react-dropzone';
+import { CloudArrowUp } from '@phosphor-icons/react';
+import { format, differenceInCalendarDays, isToday, isTomorrow, isYesterday } from 'date-fns';
+
+interface SlotDropzoneProps {
+  slotNum: number;
+  label: string;
+  folderColor: string;
+  /** Slot due date (raw — the component owns formatting). */
+  dueDate: Date | string | null;
+  /** When true, the date chip is interactive (click → date input). */
+  canEditDueDate: boolean;
+  /** Called when the user picks or clears a due date (yyyy-MM-dd or null). */
+  onSetDueDate?: (dueDate: string | null) => void;
+  onClick: () => void;
+  /**
+   * Called when a file is dropped on the row. Omit to disable DnD (the row
+   * still works as click-to-upload). The parent is expected to route through
+   * trackUpload + /api/upload bound to this slot.
+   */
+  onDropFile?: (file: File) => void;
+  /**
+   * When true the row renders an in-place "Uploading…" state — spinner badge,
+   * disabled click + drop, no hover. Pairs with the global upload chip so the
+   * user can see which slot the active upload is landing in.
+   */
+  isUploading?: boolean;
+}
+
+interface DueState {
+  /** Short label for the chip — "Jun 15", "in 2 days", "3 days late", etc. */
+  label: string;
+  /** Color treatment: muted (future), amber (soon), red (overdue). */
+  tone: 'muted' | 'soon' | 'overdue';
+}
+
+function describeDueDate(dueDate: Date): DueState {
+  const now = new Date();
+  const diff = differenceInCalendarDays(dueDate, now);
+
+  if (diff < 0) {
+    const days = Math.abs(diff);
+    return {
+      label: isYesterday(dueDate) ? 'yesterday' : `${days} ${days === 1 ? 'day' : 'days'} late`,
+      tone: 'overdue',
+    };
+  }
+  if (isToday(dueDate)) return { label: 'today', tone: 'soon' };
+  if (isTomorrow(dueDate)) return { label: 'tomorrow', tone: 'soon' };
+  if (diff <= 3) return { label: `in ${diff} days`, tone: 'soon' };
+  return { label: format(dueDate, 'MMM d'), tone: 'muted' };
+}
+
+function SlotDropzoneInner({
+  slotNum,
+  label,
+  folderColor,
+  dueDate,
+  canEditDueDate,
+  onSetDueDate,
+  onClick,
+  onDropFile,
+  isUploading = false,
+}: SlotDropzoneProps) {
+  const theme = useTheme();
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop: (accepted) => {
+      const f = accepted[0];
+      if (f && onDropFile) onDropFile(f);
+    },
+    maxFiles: 1,
+    noClick: true, // we own the click — opens the dialog (title + notes)
+    noKeyboard: true,
+    disabled: !onDropFile || isUploading,
+  });
+
+  // Derive due-date display from the raw value.
+  const parsedDue = dueDate ? (typeof dueDate === 'string' ? new Date(dueDate) : dueDate) : null;
+  const dueState = parsedDue ? describeDueDate(parsedDue) : null;
+  const isOverdue = dueState?.tone === 'overdue';
+
+  // Inline date-input editor — mirrors the SubmittalDrawer pattern.
+  const [editingDue, setEditingDue] = useState(false);
+  const [draftDue, setDraftDue] = useState(parsedDue ? format(parsedDue, 'yyyy-MM-dd') : '');
+  const dueInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (editingDue) return;
+    setDraftDue(parsedDue ? format(parsedDue, 'yyyy-MM-dd') : '');
+  }, [parsedDue, editingDue]);
+
+  const commitDue = () => {
+    const next = draftDue || null;
+    const current = parsedDue ? format(parsedDue, 'yyyy-MM-dd') : null;
+    if (next !== current) onSetDueDate?.(next);
+    setEditingDue(false);
+  };
+
+  const openDueEditor = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!canEditDueDate || !onSetDueDate) return;
+    setEditingDue(true);
+    requestAnimationFrame(() => dueInputRef.current?.focus());
+  };
+
+  // Visual states:
+  // Resting: no border, action.hover bg, quiet badge.
+  // Hover:   dashed accent outline.
+  // Drag:    solid folderColor outline + alpha bg + scaled badge/icon.
+  // Overdue: badge tinted with error.main @12%, date text red.
+  const dragBg = alpha(folderColor, 0.08);
+  const dragRing = alpha(folderColor, 0.18);
+
+  const badgeBg = isDragActive
+    ? folderColor
+    : isOverdue
+      ? alpha(theme.palette.error.main, 0.12)
+      : alpha(folderColor, 0.1);
+  const badgeColor = isDragActive ? '#fff' : isOverdue ? theme.palette.error.main : folderColor;
+
+  const dueToneColor =
+    dueState?.tone === 'overdue'
+      ? 'error.main'
+      : dueState?.tone === 'soon'
+        ? 'warning.dark'
+        : 'text.secondary';
+
+  return (
+    <Box
+      {...(onDropFile && !isUploading ? getRootProps() : {})}
+      onClick={isUploading ? undefined : onClick}
+      sx={{
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.75,
+        px: 1,
+        py: '5px',
+        minHeight: 32,
+        borderRadius: '8px',
+        cursor: isUploading ? 'default' : 'pointer',
+        bgcolor: isUploading ? alpha(folderColor, 0.06) : isDragActive ? dragBg : 'action.hover',
+        // Use outline instead of border so the row doesn't reflow between states.
+        outline: '1.5px solid transparent',
+        outlineOffset: '-1.5px',
+        boxShadow: isDragActive ? `0 0 0 3px ${dragRing}` : 'none',
+        transition: 'background-color 0.15s, box-shadow 0.15s, outline-color 0.15s',
+        ...(isUploading
+          ? {}
+          : isDragActive
+            ? {
+                outlineColor: folderColor,
+                outlineStyle: 'solid',
+              }
+            : {
+                '&:hover': {
+                  outlineStyle: 'dashed',
+                  outlineColor: theme.palette.divider,
+                },
+              }),
+      }}
+    >
+      {onDropFile && !isUploading && <input {...getInputProps()} />}
+
+      {/* Slot number badge — overdue tints it red. While uploading, the badge
+          becomes a spinner so the user can see which slot the active upload
+          is landing in. */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 18,
+          height: 18,
+          borderRadius: '50%',
+          bgcolor: isUploading ? alpha(folderColor, 0.12) : badgeBg,
+          color: isUploading ? folderColor : badgeColor,
+          flexShrink: 0,
+          transform: isDragActive ? 'scale(1.05)' : 'none',
+          transition: 'background-color 0.15s, color 0.15s, transform 0.15s',
+        }}
+      >
+        {isUploading ? (
+          <CircularProgress size={10} thickness={6} sx={{ color: folderColor }} />
+        ) : (
+          <Typography
+            sx={{
+              fontSize: 9,
+              fontWeight: 600,
+              lineHeight: 1,
+              color: 'inherit',
+            }}
+          >
+            {slotNum}
+          </Typography>
+        )}
+      </Box>
+
+      <Box
+        sx={{
+          display: 'inline-flex',
+          flexShrink: 0,
+          color: isUploading || isDragActive ? folderColor : 'text.secondary',
+          transform: isDragActive ? 'scale(1.1)' : 'none',
+          transition: 'color 0.15s, transform 0.15s',
+        }}
+      >
+        <CloudArrowUp size={14} weight={isUploading || isDragActive ? 'fill' : 'regular'} />
+      </Box>
+
+      <Typography
+        sx={{
+          fontSize: 11,
+          color: isUploading || isDragActive ? folderColor : 'text.secondary',
+          fontWeight: isUploading || isDragActive ? 500 : 400,
+          lineHeight: 1,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          minWidth: 0,
+          flex: 1,
+          transition: 'color 0.15s',
+        }}
+      >
+        {isUploading ? `Uploading ${label}…` : isDragActive ? `Drop to upload ${label}` : label}
+      </Typography>
+
+      {/* Due-date column — 4 states (editing | with date | no date + editor | nothing). */}
+      {editingDue ? (
+        <Box
+          component="input"
+          ref={dueInputRef}
+          type="date"
+          value={draftDue}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDraftDue(e.target.value)}
+          onBlur={commitDue}
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              commitDue();
+            } else if (e.key === 'Escape') {
+              setDraftDue(parsedDue ? format(parsedDue, 'yyyy-MM-dd') : '');
+              setEditingDue(false);
+            }
+          }}
+          sx={{
+            fontFamily: 'inherit',
+            fontSize: 11,
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: '6px',
+            bgcolor: 'background.paper',
+            color: 'text.primary',
+            px: 0.75,
+            py: 0.25,
+            outline: 'none',
+            flexShrink: 0,
+            '&:focus': { borderColor: folderColor },
+          }}
+        />
+      ) : dueState ? (
+        <Box
+          component={canEditDueDate ? 'button' : 'span'}
+          onClick={canEditDueDate ? openDueEditor : undefined}
+          sx={{
+            fontSize: 10.5,
+            color: dueToneColor,
+            fontWeight: dueState.tone === 'muted' ? 400 : 500,
+            lineHeight: 1,
+            flexShrink: 0,
+            border: 'none',
+            background: 'transparent',
+            fontFamily: 'inherit',
+            p: 0,
+            cursor: canEditDueDate ? 'pointer' : 'default',
+            transition: 'color 0.15s',
+            '&:hover': canEditDueDate ? { color: 'text.primary' } : undefined,
+          }}
+          aria-label={canEditDueDate ? `Edit due date (currently ${dueState.label})` : undefined}
+        >
+          {dueState.label}
+        </Box>
+      ) : canEditDueDate ? (
+        <Box
+          component="button"
+          onClick={openDueEditor}
+          sx={{
+            fontSize: 9.5,
+            color: 'text.disabled',
+            lineHeight: 1,
+            flexShrink: 0,
+            border: '1px dashed',
+            borderColor: 'divider',
+            borderRadius: '5px',
+            bgcolor: 'transparent',
+            fontFamily: 'inherit',
+            px: 0.625,
+            py: 0.25,
+            cursor: 'pointer',
+            transition: 'color 0.15s, border-color 0.15s',
+            '&:hover': { color: 'text.secondary', borderColor: 'text.disabled' },
+          }}
+          aria-label="Add due date"
+        >
+          + due date
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+const SlotDropzone = React.memo(SlotDropzoneInner);
+export default SlotDropzone;

--- a/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Box, Typography, alpha, useTheme } from '@mui/material';
 import { FileText, CheckCircle } from '@phosphor-icons/react';
 import type { FolderContentProps, PreviewDoc } from './types';
@@ -58,10 +58,13 @@ function TrackableFolderContentInner({
       }
     },
   });
-  const setSlotDueDate = (slotId: string, dueDate: string | null) => {
-    if (!organizationId || !projectId) return;
-    updateSlotMutation.mutate({ organizationId, projectId, slotId, dueDate });
-  };
+  const setSlotDueDate = useCallback(
+    (slotId: string, dueDate: string | null) => {
+      if (!organizationId || !projectId) return;
+      updateSlotMutation.mutate({ organizationId, projectId, slotId, dueDate });
+    },
+    [organizationId, projectId, updateSlotMutation],
+  );
 
   // No requirement set — empty state (no dropzones until a requirement is configured)
   if (required === null || required === 0) {

--- a/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/TrackableFolderContent.tsx
@@ -2,11 +2,13 @@
 
 import React from 'react';
 import { Box, Typography, alpha, useTheme } from '@mui/material';
-import { CloudArrowUp, FileText, CheckCircle } from '@phosphor-icons/react';
+import { FileText, CheckCircle } from '@phosphor-icons/react';
 import type { FolderContentProps, PreviewDoc } from './types';
 import { api } from '@/trpc/react';
 import type { SlotKind } from '@/lib/validations/gantt';
+import { canApproveDocuments } from '@/lib/permissions';
 import ApprovalToggleSwitch from './ApprovalToggleSwitch';
+import SlotDropzone from './SlotDropzone';
 
 interface TrackableFolderContentProps extends FolderContentProps {
   required: number | null;
@@ -18,6 +20,7 @@ function TrackableFolderContentInner({
   onSelectDoc,
   selectedDocId,
   onUpload,
+  onUploadFile,
   folderName,
   required,
   folderColor,
@@ -26,11 +29,14 @@ function TrackableFolderContentInner({
   projectId,
   organizationId,
   memberRole,
+  uploadingSlotIds,
 }: TrackableFolderContentProps) {
   const theme = useTheme();
+  const utils = api.useUtils();
   const successMain = theme.palette.success.main;
   const canShowApproval =
     !!organizationId && typeof memberRole === 'string';
+  const canEditDueDate = !!memberRole && canApproveDocuments(memberRole);
 
   // Slots now carry their bound document (Document.slotId FK). The first
   // element of slot.documents is the doc; null means the slot is empty.
@@ -39,6 +45,23 @@ function TrackableFolderContentInner({
     { enabled: !!kind && !!taskId && !!projectId && !!organizationId && (required ?? 0) > 0 },
   );
   const slots = slotsQuery.data ?? [];
+
+  // Per-slot due-date editing — mutation invalidates listSlots so the chip
+  // re-renders, and the Review Queue's Overdue tab so it picks up changes too.
+  const updateSlotMutation = api.gantt.updateSlot.useMutation({
+    onSuccess: () => {
+      if (organizationId && projectId && taskId && kind) {
+        void utils.gantt.listSlots.invalidate({ organizationId, projectId, taskId, kind });
+      }
+      if (projectId) {
+        void utils.approval.listOverdueSlots.invalidate({ projectId });
+      }
+    },
+  });
+  const setSlotDueDate = (slotId: string, dueDate: string | null) => {
+    if (!organizationId || !projectId) return;
+    updateSlotMutation.mutate({ organizationId, projectId, slotId, dueDate });
+  };
 
   // No requirement set — empty state (no dropzones until a requirement is configured)
   if (required === null || required === 0) {
@@ -101,6 +124,7 @@ function TrackableFolderContentInner({
                 gap: 0.75,
                 py: '5px',
                 px: 1,
+                minHeight: 32,
                 borderRadius: '8px',
                 cursor: 'pointer',
                 bgcolor: isSelected ? 'action.selected' : 'transparent',
@@ -160,70 +184,32 @@ function TrackableFolderContentInner({
                 />
               )}
               {doc.createdAt != null && (
-                <Typography sx={{ fontSize: 11, color: 'text.secondary', flexShrink: 0 }}>
-                  {new Date(doc.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                <Typography
+                  sx={{ fontSize: 11, color: 'text.secondary', flexShrink: 0 }}
+                  title={`Uploaded ${new Date(doc.createdAt).toLocaleString()}`}
+                >
+                  ↑ {new Date(doc.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
                 </Typography>
               )}
             </Box>
           );
         }
 
-        // Empty slot — clicking pins the upload to this specific slot via slotId.
+        // Empty slot — drop a file directly onto the row (real DnD), or
+        // click to open the upload dialog (where you can add title + notes).
         return (
-          <Box
+          <SlotDropzone
             key={slot.id}
+            slotNum={slotNum}
+            label={slot.name?.trim() || `${singularName} ${slotNum}`}
+            folderColor={folderColor}
+            dueDate={slot.dueDate}
+            canEditDueDate={canEditDueDate}
+            onSetDueDate={(dueDate) => setSlotDueDate(slot.id, dueDate)}
             onClick={() => onUpload(slot.id)}
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 0.75,
-              py: '6px',
-              px: 1,
-              borderRadius: '8px',
-              border: '1.5px dashed',
-              borderColor: 'divider',
-              bgcolor: 'action.hover',
-              cursor: 'pointer',
-              transition: 'border-color 0.2s, background-color 0.2s',
-              '&:hover': {
-                borderColor: folderColor,
-                bgcolor: `${folderColor}06`,
-              },
-            }}
-          >
-            {/* Slot number badge — empty */}
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                width: 18,
-                height: 18,
-                borderRadius: '50%',
-                bgcolor: 'action.hover',
-                flexShrink: 0,
-              }}
-            >
-              <Typography sx={{ fontSize: 9, fontWeight: 600, color: 'text.secondary', lineHeight: 1 }}>
-                {slotNum}
-              </Typography>
-            </Box>
-
-            <CloudArrowUp size={14} color="var(--text-secondary)" style={{ flexShrink: 0 }} />
-            <Typography
-              sx={{
-                fontSize: 11,
-                color: 'text.secondary',
-                lineHeight: 1,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                minWidth: 0,
-              }}
-            >
-              {slot.name?.trim() || `${singularName} ${slotNum}`}
-            </Typography>
-          </Box>
+            onDropFile={onUploadFile ? (file) => onUploadFile(slot.id, file) : undefined}
+            isUploading={uploadingSlotIds?.has(slot.id) ?? false}
+          />
         );
       })}
     </Box>

--- a/src/components/bryntum/components/task-popover/types.ts
+++ b/src/components/bryntum/components/task-popover/types.ts
@@ -42,6 +42,12 @@ export interface FolderContentProps {
    * omit it to let the server auto-link to the first empty slot.
    */
   onUpload: (slotId?: string) => void;
+  /**
+   * Direct file upload bound to a specific slot — bypasses the dialog and
+   * routes through trackUpload so the global chip shows progress. Used by
+   * per-slot drag-and-drop on trackable folders.
+   */
+  onUploadFile?: (slotId: string, file: File) => void;
   folderName: string;
   // Optional pin context — only consumed by the Photos folder
   projectId?: string;
@@ -50,4 +56,10 @@ export interface FolderContentProps {
   pinnedDocId?: string | null;
   // Approval context — only consumed by trackable folders (submittals, inspections)
   memberRole?: string;
+  /**
+   * Slot ids whose upload is currently in-flight. The trackable folder reads
+   * this to render each row's in-place "Uploading…" state alongside the
+   * global upload chip.
+   */
+  uploadingSlotIds?: Set<string>;
 }

--- a/src/components/documents/UploadDialog.tsx
+++ b/src/components/documents/UploadDialog.tsx
@@ -13,10 +13,10 @@ import {
   useTheme,
 } from '@mui/material';
 import { Button } from '@/components/ui/button';
-import UploadOverlay from '@/components/ui/UploadOverlay';
 import FileDropzone from '@/components/ui/FileDropzone';
 import { useSnackbar } from '@/hooks/useSnackbar';
 import { formatFileSize } from '@/lib/utils/formatting';
+import { trackUpload } from '@/store/uploadStatusStore';
 
 interface UploadDialogProps {
   open: boolean;
@@ -32,6 +32,10 @@ interface UploadDialogProps {
    */
   slotId?: string;
   onUploadComplete: () => void;
+  /** Fired after the user clicks Upload, right before the dialog closes. Used to mark a slot as uploading. */
+  onUploadStart?: () => void;
+  /** Fired when the background upload resolves. `success` is true only on a 2xx response. */
+  onUploadEnd?: (success: boolean) => void;
 }
 
 export default function UploadDialog({
@@ -43,11 +47,12 @@ export default function UploadDialog({
   folderName,
   slotId,
   onUploadComplete,
+  onUploadStart,
+  onUploadEnd,
 }: UploadDialogProps) {
   const [file, setFile] = useState<File | null>(null);
   const [title, setTitle] = useState('');
   const [notes, setNotes] = useState('');
-  const [isUploading, setIsUploading] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const { showSnackbar } = useSnackbar();
   const theme = useTheme();
@@ -82,11 +87,9 @@ export default function UploadDialog({
     },
     maxFiles: 1,
     maxSize: 50 * 1024 * 1024,
-    disabled: isUploading,
   });
 
   const handleClose = () => {
-    if (isUploading) return;
     if (previewUrl) URL.revokeObjectURL(previewUrl);
     setFile(null);
     setPreviewUrl(null);
@@ -123,44 +126,43 @@ export default function UploadDialog({
     }
   };
 
-  const handleUpload = async () => {
+  const handleUpload = () => {
     if (!file) return;
-    setIsUploading(true);
 
-    try {
-      const formData = new FormData();
-      formData.append('file', file);
-      formData.append('projectId', projectId);
-      formData.append('taskId', taskId);
-      formData.append('folderId', folderId);
-      if (slotId) formData.append('slotId', slotId);
-      if (title.trim()) formData.append('title', title.trim());
-      if (notes.trim()) formData.append('notes', notes.trim());
+    // Snapshot the form values + preview before we reset state and close.
+    const uploadFile = file;
+    const trimmedTitle = title.trim();
+    const trimmedNotes = notes.trim();
+    const previewToRevoke = previewUrl;
 
-      const response = await fetch('/api/upload', {
-        method: 'POST',
-        body: formData,
-      });
+    onUploadStart?.();
 
-      if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.error || 'Upload failed');
-      }
+    void trackUpload<{ document: { id: string } }>(
+      uploadFile,
+      () => {
+        const formData = new FormData();
+        formData.append('file', uploadFile);
+        formData.append('projectId', projectId);
+        formData.append('taskId', taskId);
+        formData.append('folderId', folderId);
+        if (slotId) formData.append('slotId', slotId);
+        if (trimmedTitle) formData.append('title', trimmedTitle);
+        if (trimmedNotes) formData.append('notes', trimmedNotes);
+        return fetch('/api/upload', { method: 'POST', body: formData });
+      },
+      { maxBytes: 50 * 1024 * 1024, doneLabel: `Uploaded to ${folderName}` },
+    ).then((result) => {
+      onUploadEnd?.(result.ok);
+      if (result.ok) onUploadComplete();
+    });
 
-      showSnackbar('File uploaded successfully', 'success');
-      if (previewUrl) URL.revokeObjectURL(previewUrl);
-      setFile(null);
-      setPreviewUrl(null);
-      setTitle('');
-      setNotes('');
-      onUploadComplete();
-      onOpenChange(false);
-    } catch (error) {
-      console.error('Upload error:', error);
-      showSnackbar(error instanceof Error ? error.message : 'Failed to upload file', 'error');
-    } finally {
-      setIsUploading(false);
-    }
+    // Close immediately so the user can keep working while the upload runs in the chip.
+    if (previewToRevoke) URL.revokeObjectURL(previewToRevoke);
+    setFile(null);
+    setPreviewUrl(null);
+    setTitle('');
+    setNotes('');
+    onOpenChange(false);
   };
 
   const inputSx = {
@@ -253,13 +255,7 @@ export default function UploadDialog({
       </Box>
 
       {/* Body */}
-      <DialogContent sx={{ px: 3.5, pt: 2.5, pb: 1, position: 'relative' }}>
-        {isUploading && (
-          <Box sx={{ position: 'absolute', inset: 0, zIndex: 2 }}>
-            <UploadOverlay variant="light" text="Uploading document…" size={28} />
-          </Box>
-        )}
-
+      <DialogContent sx={{ px: 3.5, pt: 2.5, pb: 1 }}>
         {/* Dropzone ↔ File card swap */}
         {!file ? (
           <Box sx={{ mb: 2.5 }}>
@@ -267,7 +263,6 @@ export default function UploadDialog({
               getRootProps={getRootProps}
               getInputProps={getInputProps}
               isDragActive={isDragActive}
-              disabled={isUploading}
               hintText="PDF, JPG, PNG, DWG up to 50 MB"
               sx={{ py: 4 }}
             />
@@ -393,7 +388,7 @@ export default function UploadDialog({
                 <Box
                   component="button"
                   onClick={handleGenerateDescription}
-                  disabled={isGenerating || isUploading}
+                  disabled={isGenerating}
                   sx={{
                     display: 'flex',
                     alignItems: 'center',
@@ -465,8 +460,6 @@ export default function UploadDialog({
         <Button
           variant="contained"
           onClick={handleUpload}
-          loading={isUploading}
-          loadingPosition="start"
           disabled={!file}
           startIcon={<UploadSimple size={16} />}
           sx={{
@@ -482,7 +475,7 @@ export default function UploadDialog({
             },
           }}
         >
-          {isUploading ? 'Uploading...' : 'Upload Document'}
+          Upload Document
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
## Summary

- New `SlotDropzone` component adds real drag-and-drop on trackable slot rows, an inline editable due-date chip (with overdue/soon/muted tones), and an in-place "Uploading…" badge that pairs with the global upload chip.
- `UploadDialog` now routes through `trackUpload` and closes immediately so uploads run in the background; `TaskDetailsPopover` tracks per-slot uploading state via lifecycle hooks (`onUploadStart`/`onUploadEnd`).
- Submittals/inspections counters in the popover header and folder rows now reflect approved (not just received) counts.
- `SubmittalDrawer` introduces a distinct indigo "received, awaiting approval" treatment (badge, pill, card tint, and `Tray` icon) separate from the existing green "approved" state.
- `FilePreviewPanel` drops its inline approval toggle (now lives on the slot row) and gains an explicit close button.

## Test plan

- [ ] Drag a file onto an empty submittal/inspection slot — chip shows progress, slot row shows in-place uploading state, then becomes a filled row.
- [ ] Click an empty slot, use the dialog, confirm it closes immediately and the global chip tracks the upload.
- [ ] Add, edit, and clear a slot due date inline; confirm Review Queue's Overdue tab reflects changes.
- [ ] Verify submittal/inspection counts in the popover header reflect approved totals.
- [ ] In SubmittalDrawer, confirm received-but-not-approved slots render indigo and approved slots render green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)