### PR TITLE
Add customizable column visibility to Bryntum Gantt toolbar

### DIFF
--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -9,6 +9,7 @@ import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
 import { canManageProjects } from '@/lib/permissions';
 import { createGanttConfig } from './config/ganttConfig';
 import GanttToolbar from './components/GanttToolbar';
+import ColumnPickerPopover, { TOGGLEABLE_COLUMNS, type ColumnId } from './components/ColumnPickerPopover';
 import { TaskDetailsPopover } from './components/TaskDetailsPopover';
 import TaskInfoDialog from './components/TaskInfoDialog';
 import { useBryntumThemeAssets } from './hooks/useBryntumThemeAssets';
@@ -72,6 +73,39 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
   const [loadError, setLoadError] = useState<string | null>(null);
   const [taskInfoRecord, setTaskInfoRecord] = useState<BryntumTaskRecord | null>(null);
 
+  const columnStorageKey = projectId ? `bryntum:columns:visible:${projectId}` : null;
+  const [columnsAnchor, setColumnsAnchor] = useState<HTMLElement | null>(null);
+  const [columnVisibility, setColumnVisibility] = useState<Record<ColumnId, boolean>>(() => {
+    const defaults: Record<ColumnId, boolean> = { name: true, startDate: true, endDate: true, duration: true };
+    if (typeof window === 'undefined' || !columnStorageKey) return defaults;
+    try {
+      const raw = window.localStorage.getItem(columnStorageKey);
+      if (!raw) return defaults;
+      const stored = JSON.parse(raw) as Partial<Record<ColumnId, boolean>>;
+      // Force name = true after the spread so a corrupted/tampered value can't hide the row identifier.
+      return { ...defaults, ...stored, name: true };
+    } catch {
+      return defaults;
+    }
+  });
+
+  const handleColumnToggle = useCallback(
+    (id: ColumnId, visible: boolean) => {
+      setColumnVisibility((prev) => {
+        const next = { ...prev, [id]: visible };
+        if (columnStorageKey && typeof window !== 'undefined') {
+          try {
+            window.localStorage.setItem(columnStorageKey, JSON.stringify(next));
+          } catch {
+            /* localStorage unavailable (private mode / quota) — non-fatal */
+          }
+        }
+        return next;
+      });
+    },
+    [columnStorageKey],
+  );
+
   // Lock mode: chart is locked by default; admin-level users click the lock
   // toggle in the toolbar to enter edit mode.
   const { currentOrg } = useOrgFromUrl();
@@ -103,6 +137,34 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     if (!gantt) return;
     gantt.readOnly = !editingUnlocked;
   }, [isLoading, getGanttInstance, editingUnlocked]);
+
+  // `column.hidden = true` only redistributes width inside the locked sub-grid;
+  // we also set the sub-grid's width so the timeline absorbs the freed space.
+  useEffect(() => {
+    if (isLoading) return;
+    const gantt = getGanttInstance();
+    if (!gantt) return;
+
+    let lockedWidth = 0;
+    for (const col of TOGGLEABLE_COLUMNS) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+      const column = gantt.columns.getById(col.id);
+      if (!column) continue;
+      const visible = columnVisibility[col.id] ?? true;
+      const nextHidden = !visible;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (column.hidden !== nextHidden) column.hidden = nextHidden;
+      if (visible) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        lockedWidth += column.width ?? column.minWidth ?? 0;
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (gantt.subGrids.locked.width !== lockedWidth) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      gantt.subGrids.locked.width = lockedWidth;
+    }
+  }, [isLoading, getGanttInstance, columnVisibility]);
 
   // After data loads, run commitAsync to settle the scheduling engine, then
   // enable STM so undo/redo starts tracking from this clean state.
@@ -589,6 +651,14 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         canEditChart={canEditChart}
         isEditMode={editingUnlocked}
         onToggleEditMode={() => setIsEditMode((prev) => !prev)}
+        onColumnsClick={(e) => setColumnsAnchor(e.currentTarget)}
+      />
+      <ColumnPickerPopover
+        anchorEl={columnsAnchor}
+        open={!!columnsAnchor}
+        onClose={() => setColumnsAnchor(null)}
+        visibility={columnVisibility}
+        onToggle={handleColumnToggle}
       />
 
       {/* Bryntum must always render in a visible container so its internal layout

--- a/src/components/bryntum/components/ColumnPickerPopover.tsx
+++ b/src/components/bryntum/components/ColumnPickerPopover.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { Box, Popover, Switch, Typography } from '@mui/material';
+
+export type ColumnId = 'name' | 'startDate' | 'endDate' | 'duration';
+export type ColumnDef = { id: ColumnId; label: string; lockable?: boolean };
+
+export const TOGGLEABLE_COLUMNS: ColumnDef[] = [
+  { id: 'name', label: 'Name', lockable: true },
+  { id: 'startDate', label: 'Start' },
+  { id: 'endDate', label: 'End' },
+  { id: 'duration', label: 'Duration' },
+];
+
+type Props = {
+  anchorEl: HTMLElement | null;
+  open: boolean;
+  onClose: () => void;
+  visibility: Record<ColumnId, boolean>;
+  onToggle: (columnId: ColumnId, visible: boolean) => void;
+};
+
+export default function ColumnPickerPopover({
+  anchorEl,
+  open,
+  onClose,
+  visibility,
+  onToggle,
+}: Props) {
+  return (
+    <Popover
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      slotProps={{
+        paper: {
+          sx: {
+            mt: 0.5,
+            width: 220,
+            borderRadius: '10px',
+            border: '1px solid',
+            borderColor: 'divider',
+            boxShadow: 3,
+          },
+        },
+      }}
+    >
+      <Box sx={{ px: 1.5, pt: 1, pb: 0.5 }}>
+        <Typography
+          sx={{
+            fontSize: '0.5625rem',
+            fontWeight: 600,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: 'text.secondary',
+            userSelect: 'none',
+          }}
+        >
+          Columns
+        </Typography>
+      </Box>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1px', px: 0.5, pb: 0.5 }}>
+        {TOGGLEABLE_COLUMNS.map((col) => {
+          const checked = visibility[col.id] ?? true;
+          const locked = !!col.lockable;
+          return (
+            <Box
+              key={col.id}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                px: 1.25,
+                py: 0.5,
+                borderRadius: '8px',
+                cursor: locked ? 'not-allowed' : 'pointer',
+                '&:hover': locked ? {} : { bgcolor: 'action.hover' },
+              }}
+              onClick={() => {
+                if (!locked) onToggle(col.id, !checked);
+              }}
+            >
+              <Typography
+                sx={{
+                  fontSize: '0.8125rem',
+                  fontWeight: 500,
+                  lineHeight: 1,
+                  color: locked ? 'text.disabled' : 'text.primary',
+                }}
+              >
+                {col.label}
+              </Typography>
+              <Switch
+                size="small"
+                checked={checked}
+                disabled={locked}
+                onChange={(e) => onToggle(col.id, e.target.checked)}
+                onClick={(e) => e.stopPropagation()}
+              />
+            </Box>
+          );
+        })}
+      </Box>
+    </Popover>
+  );
+}

--- a/src/components/bryntum/components/GanttToolbar.tsx
+++ b/src/components/bryntum/components/GanttToolbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, type MouseEvent, type ReactNode } from 'react';
 import { Box, MenuItem, Select, Stack, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { Button } from '@/components/ui/button';
@@ -154,7 +154,7 @@ type GanttToolbarProps = {
   onShiftPrevious?: () => void;
   onShiftNext?: () => void;
   onExport?: () => void;
-  onColumnsClick?: () => void;
+  onColumnsClick?: (event: MouseEvent<HTMLElement>) => void;
   onMoreClick?: () => void;
   onUndo?: () => void;
   onRedo?: () => void;

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -101,8 +101,10 @@ export function createGanttConfig(
     },
     columns: [
       {
+        id: 'name',
         type: 'name',
         field: 'name',
+        text: 'Name',
         flex: 1,
         minWidth: 300,
         resizable: true,
@@ -131,6 +133,7 @@ export function createGanttConfig(
       // Double-clicking the name cell starts inline name editing (Bryntum native behavior).
       // Right-click opens the task context menu (includes "Scroll to item").
       {
+        id: 'startDate',
         type: 'startdate',
         field: 'startDate',
         text: 'Start',
@@ -138,6 +141,7 @@ export function createGanttConfig(
         resizable: true,
       },
       {
+        id: 'endDate',
         type: 'enddate',
         field: 'endDate',
         text: 'End',
@@ -145,6 +149,7 @@ export function createGanttConfig(
         resizable: true,
       },
       {
+        id: 'duration',
         type: 'duration',
         text: 'Duration',
         width: 100,

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -61,6 +61,7 @@ export interface ColumnRendererData {
 }
 
 type GanttColumnConfig = {
+  id?: string;
   type: string;
   field?: string;
   text?: string;


### PR DESCRIPTION
## Summary
- Adds a column picker popover to the Gantt toolbar with toggles for Start, End, and Duration; Name is fixed on so the row identifier can never be hidden.
- Visibility persists per-project in `localStorage` (`bryntum:columns:visible:{projectId}`); a corrupted/tampered payload can't disable Name because it's forced back to true after the spread.
- Hiding a column shrinks the locked sub-grid so the timeline absorbs the freed space, by setting `gantt.subGrids.locked.width` to the sum of visible column widths.

## Test plan
- [ ] Open a project's Gantt, click the Columns button, toggle Start/End/Duration on and off — timeline expands/shrinks accordingly.
- [ ] Reload the page — toggled state survives.
- [ ] Switch between two projects — each project remembers its own column state.
- [ ] Confirm Name row is disabled in the picker and remains visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)