### PR TITLE
Add 5-day weather forecast popover and project address copy button

### DIFF
--- a/src/components/layout/LocationWeather.tsx
+++ b/src/components/layout/LocationWeather.tsx
@@ -11,6 +11,7 @@ import {
   CloudLightning,
   CloudFog,
   Drop,
+  CaretDown,
   type Icon,
 } from '@phosphor-icons/react';
 import { Box, Typography, Popover, ButtonBase } from '@mui/material';
@@ -63,6 +64,23 @@ function getWeatherTint(icon: string): string {
     case '13': return 'rgba(141, 153, 174, 0.08)';  // silver — snow
     case '50': return 'rgba(141, 153, 174, 0.06)';  // light gray — fog
     default:   return 'rgba(141, 153, 174, 0.08)';
+  }
+}
+
+/** Stronger version of the condition tint, used for hover state on the clickable chip. */
+function getWeatherTintStrong(icon: string): string {
+  const code = icon.slice(0, 2);
+  switch (code) {
+    case '01': return 'rgba(251, 191, 36, 0.22)';
+    case '02': return 'rgba(251, 191, 36, 0.16)';
+    case '03':
+    case '04': return 'rgba(141, 153, 174, 0.24)';
+    case '09':
+    case '10': return 'rgba(37, 99, 235, 0.18)';
+    case '11': return 'rgba(107, 114, 128, 0.24)';
+    case '13': return 'rgba(141, 153, 174, 0.22)';
+    case '50': return 'rgba(141, 153, 174, 0.18)';
+    default:   return 'rgba(141, 153, 174, 0.2)';
   }
 }
 
@@ -126,9 +144,14 @@ export default function LocationWeather({ location, organizationId }: LocationWe
             ...chipSx,
             bgcolor: getWeatherTint(weather.icon),
             opacity: 1,
-            transition: 'opacity 0.3s ease, transform 0.15s ease',
+            transition: 'background-color 0.15s ease, transform 0.15s ease, opacity 0.3s ease',
             cursor: hasForecast ? 'pointer' : 'default',
-            '&:hover': hasForecast ? { transform: 'translateY(-1px)' } : undefined,
+            '&:hover': hasForecast
+              ? {
+                  bgcolor: getWeatherTintStrong(weather.icon),
+                  transform: 'translateY(-1px)',
+                }
+              : undefined,
             '&:focus-visible': {
               outline: '2px solid',
               outlineColor: 'primary.main',
@@ -162,6 +185,19 @@ export default function LocationWeather({ location, organizationId }: LocationWe
           >
             {weatherInfo.label}
           </Typography>
+          {hasForecast && (
+            <CaretDown
+              size={10}
+              weight="bold"
+              style={{
+                flexShrink: 0,
+                opacity: 0.5,
+                marginLeft: 2,
+                transition: 'transform 0.15s ease',
+                transform: popoverOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+              }}
+            />
+          )}
         </ButtonBase>
       )}
 
@@ -220,7 +256,7 @@ export default function LocationWeather({ location, organizationId }: LocationWe
               lineHeight: 1,
             }}
           >
-            5-day forecast
+            {forecast.length}-day forecast
           </Typography>
         </Box>
         <Box sx={{ py: 0.5 }}>

--- a/src/components/layout/LocationWeather.tsx
+++ b/src/components/layout/LocationWeather.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   Clock,
   Sun,
@@ -10,9 +10,10 @@ import {
   CloudSnow,
   CloudLightning,
   CloudFog,
+  Drop,
   type Icon,
 } from '@phosphor-icons/react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Popover, ButtonBase } from '@mui/material';
 import { api } from '@/trpc/react';
 
 interface LocationWeatherProps {
@@ -90,6 +91,8 @@ export default function LocationWeather({ location, organizationId }: LocationWe
   );
 
   const [localTime, setLocalTime] = useState<string | null>(null);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const chipRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     if (weather?.timezoneOffset == null) {
@@ -107,17 +110,30 @@ export default function LocationWeather({ location, organizationId }: LocationWe
   }, [weather?.timezoneOffset]);
 
   const weatherInfo = weather ? getWeatherIcon(weather.icon) : null;
+  const forecast = weather?.forecast ?? [];
+  const hasForecast = forecast.length > 0;
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
-      {/* Weather chip — condition-tinted background */}
+      {/* Weather chip — condition-tinted background, click to open forecast */}
       {weather && weatherInfo && (
-        <Box
+        <ButtonBase
+          ref={chipRef}
+          onClick={hasForecast ? () => setPopoverOpen(true) : undefined}
+          disabled={!hasForecast}
+          aria-label={hasForecast ? 'Show 5-day forecast' : undefined}
           sx={{
             ...chipSx,
             bgcolor: getWeatherTint(weather.icon),
             opacity: 1,
-            transition: 'opacity 0.3s ease',
+            transition: 'opacity 0.3s ease, transform 0.15s ease',
+            cursor: hasForecast ? 'pointer' : 'default',
+            '&:hover': hasForecast ? { transform: 'translateY(-1px)' } : undefined,
+            '&:focus-visible': {
+              outline: '2px solid',
+              outlineColor: 'primary.main',
+              outlineOffset: 2,
+            },
             '@keyframes fadeIn': {
               from: { opacity: 0 },
               to: { opacity: 1 },
@@ -146,7 +162,7 @@ export default function LocationWeather({ location, organizationId }: LocationWe
           >
             {weatherInfo.label}
           </Typography>
-        </Box>
+        </ButtonBase>
       )}
 
       {/* Time chip */}
@@ -172,6 +188,125 @@ export default function LocationWeather({ location, organizationId }: LocationWe
           </Typography>
         </Box>
       )}
+
+      {/* 5-day forecast popover */}
+      <Popover
+        open={popoverOpen}
+        anchorEl={chipRef.current}
+        onClose={() => setPopoverOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        slotProps={{
+          paper: {
+            sx: {
+              mt: 1,
+              minWidth: 280,
+              borderRadius: '10px',
+              border: '1px solid',
+              borderColor: 'divider',
+              overflow: 'hidden',
+            },
+          },
+        }}
+      >
+        <Box sx={{ px: 1.75, py: 1.25, borderBottom: '1px solid', borderColor: 'divider' }}>
+          <Typography
+            sx={{
+              fontSize: '0.5625rem',
+              fontWeight: 600,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: 'text.secondary',
+              lineHeight: 1,
+            }}
+          >
+            5-day forecast
+          </Typography>
+        </Box>
+        <Box sx={{ py: 0.5 }}>
+          {forecast.map((day) => {
+            const info = getWeatherIcon(day.icon);
+            const showPrecip = day.precipPct >= 20;
+            return (
+              <Box
+                key={day.date}
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: '36px 18px 1fr auto auto',
+                  alignItems: 'center',
+                  gap: 1.25,
+                  px: 1.75,
+                  py: 0.875,
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontSize: '0.8125rem',
+                    fontWeight: 550,
+                    color: 'text.primary',
+                    lineHeight: 1,
+                  }}
+                >
+                  {day.label}
+                </Typography>
+                <info.Icon size={14} weight="regular" style={{ opacity: 0.65 }} />
+                <Typography
+                  sx={{
+                    fontSize: '0.75rem',
+                    color: 'text.secondary',
+                    lineHeight: 1,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    textTransform: 'capitalize',
+                  }}
+                >
+                  {day.description || info.label}
+                </Typography>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 0.375,
+                    minWidth: 32,
+                    justifyContent: 'flex-end',
+                    visibility: showPrecip ? 'visible' : 'hidden',
+                  }}
+                >
+                  <Drop size={11} weight="fill" style={{ color: 'rgb(37, 99, 235)', opacity: 0.7 }} />
+                  <Typography
+                    sx={{
+                      fontSize: '0.6875rem',
+                      fontWeight: 500,
+                      color: 'text.secondary',
+                      fontVariantNumeric: 'tabular-nums',
+                      lineHeight: 1,
+                    }}
+                  >
+                    {day.precipPct}%
+                  </Typography>
+                </Box>
+                <Typography
+                  sx={{
+                    fontSize: '0.75rem',
+                    fontWeight: 500,
+                    color: 'text.primary',
+                    fontVariantNumeric: 'tabular-nums',
+                    lineHeight: 1,
+                    letterSpacing: '-0.01em',
+                  }}
+                >
+                  {day.hi}°
+                  <Box component="span" sx={{ color: 'text.secondary', fontWeight: 400 }}>
+                    {' / '}
+                    {day.lo}°
+                  </Box>
+                </Typography>
+              </Box>
+            );
+          })}
+        </Box>
+      </Popover>
     </Box>
   );
 }

--- a/src/components/layout/ProjectSwitcher.tsx
+++ b/src/components/layout/ProjectSwitcher.tsx
@@ -2,13 +2,14 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { CaretDown, MagnifyingGlass, Check, Plus, MapPin, ArrowRight } from '@phosphor-icons/react';
+import { CaretDown, MagnifyingGlass, Check, Plus, MapPin, ArrowRight, Copy } from '@phosphor-icons/react';
 import { Box, Typography, Menu, ButtonBase, alpha, useTheme, type Theme } from '@mui/material';
 import ProjectAvatar from '@/components/ui/ProjectAvatar';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
 import { useProjectSwitcher } from '@/hooks/useProjectSwitcher';
 import AddProjectDialog from '@/components/projects/AddProjectDialog';
 import LocationWeather from '@/components/layout/LocationWeather';
+import { useSnackbar } from '@/hooks/useSnackbar';
 
 const STATUS_HEX: Record<string, (t: Theme) => string> = {
   active: (t) => t.palette.status.active,
@@ -35,6 +36,15 @@ function getInitials(name: string | null | undefined): string {
   if (!name) return '?';
   const parts = name.trim().split(/\s+/).slice(0, 2);
   return parts.map((p) => p[0]?.toUpperCase() ?? '').join('') || '?';
+}
+
+/** Compact label for the header pill. Google Places address descriptions are street-first
+ *  ("street, city, state[, country]"), so the city is the second segment; shorter strings
+ *  ("City, State" or a plain label) read best by their first segment. Full address stays
+ *  available via the title tooltip. */
+function cityFromLocation(location: string): string {
+  const parts = location.split(',').map((p) => p.trim());
+  return parts.length >= 3 ? parts[1]! : parts[0]!;
 }
 
 function MemberAvatar({ name, image, size = 22 }: { name: string | null; image: string | null; size?: number }) {
@@ -87,7 +97,21 @@ interface PreviewPaneProps {
 
 function PreviewPane({ project, isCurrent, organizationId, onSwitch }: PreviewPaneProps) {
   const theme = useTheme();
+  const { showSnackbar } = useSnackbar();
+  const [copied, setCopied] = useState(false);
   const overflow = Math.max(0, project.memberCount - 4);
+
+  const handleCopyAddress = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!project.location) return;
+    try {
+      await navigator.clipboard.writeText(project.location);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      showSnackbar('Could not copy address', 'error');
+    }
+  };
 
   return (
     <Box
@@ -128,7 +152,7 @@ function PreviewPane({ project, isCurrent, organizationId, onSwitch }: PreviewPa
             {project.name}
           </Typography>
           {project.location ? (
-            <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, mt: '3px', minWidth: 0, maxWidth: '100%' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: '3px', minWidth: 0, maxWidth: '100%' }}>
               <MapPin size={10} weight="bold" style={{ flexShrink: 0, opacity: 0.55 }} />
               <Typography
                 sx={{
@@ -139,10 +163,31 @@ function PreviewPane({ project, isCurrent, organizationId, onSwitch }: PreviewPa
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
+                  minWidth: 0,
                 }}
               >
                 {project.location}
               </Typography>
+              <ButtonBase
+                onClick={handleCopyAddress}
+                aria-label={copied ? 'Address copied' : 'Copy address'}
+                title={copied ? 'Copied!' : 'Copy address'}
+                sx={{
+                  flexShrink: 0,
+                  width: 18,
+                  height: 18,
+                  borderRadius: '4px',
+                  color: 'text.secondary',
+                  transition: 'background-color 0.12s, color 0.12s',
+                  '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
+                }}
+              >
+                {copied ? (
+                  <Check size={11} weight="bold" style={{ color: theme.palette.success.main }} />
+                ) : (
+                  <Copy size={11} weight="bold" />
+                )}
+              </ButtonBase>
             </Box>
           ) : (
             <Typography sx={{ fontSize: '11.5px', color: 'text.disabled', mt: '3px' }}>
@@ -548,6 +593,7 @@ export default function ProjectSwitcher() {
               <MapPin size={10} weight="bold" style={{ flexShrink: 0, opacity: 0.55 }} />
               <Typography
                 component="span"
+                title={displayedProject.location}
                 sx={{
                   fontSize: '11px',
                   fontWeight: 500,
@@ -558,7 +604,7 @@ export default function ProjectSwitcher() {
                   whiteSpace: 'nowrap',
                 }}
               >
-                {displayedProject.location}
+                {cityFromLocation(displayedProject.location)}
               </Typography>
             </Box>
           )}

--- a/src/server/api/routers/weather.ts
+++ b/src/server/api/routers/weather.ts
@@ -7,10 +7,102 @@ interface GeoResult {
   lon: number;
 }
 
-interface WeatherResult {
+interface CurrentWeatherResult {
   main: { temp: number };
   weather: Array<{ icon: string; description: string }>;
   timezone: number;
+}
+
+interface ForecastEntry {
+  dt: number; // unix seconds, UTC
+  main: { temp: number; temp_min: number; temp_max: number };
+  weather: Array<{ icon: string; description: string }>;
+  pop: number; // probability of precipitation, 0..1
+}
+
+interface ForecastResult {
+  list: ForecastEntry[];
+  city: { timezone: number };
+}
+
+export interface ForecastDay {
+  /** YYYY-MM-DD in city local time, stable React key */
+  date: string;
+  /** e.g. "Wed" — already in city local time */
+  label: string;
+  /** OpenWeatherMap icon code (e.g. "10d") */
+  icon: string;
+  /** Human description, e.g. "Light rain" */
+  description: string;
+  /** Rounded fahrenheit */
+  hi: number;
+  lo: number;
+  /** 0..100, max across the day */
+  precipPct: number;
+}
+
+/** Group 3-hour forecast entries into per-day summaries in the city's local timezone. */
+function summarizeForecast(entries: ForecastEntry[], timezoneOffsetSec: number): ForecastDay[] {
+  if (!entries.length) return [];
+
+  const buckets = new Map<string, ForecastEntry[]>();
+  for (const entry of entries) {
+    // Shift UTC seconds into city-local seconds, then derive YYYY-MM-DD from the UTC view of that shifted timestamp.
+    const localMs = (entry.dt + timezoneOffsetSec) * 1000;
+    const localDate = new Date(localMs);
+    const dateKey = `${localDate.getUTCFullYear()}-${String(localDate.getUTCMonth() + 1).padStart(2, "0")}-${String(localDate.getUTCDate()).padStart(2, "0")}`;
+    const bucket = buckets.get(dateKey) ?? [];
+    bucket.push(entry);
+    buckets.set(dateKey, bucket);
+  }
+
+  const todayLocalMs = (Math.floor(Date.now() / 1000) + timezoneOffsetSec) * 1000;
+  const todayLocal = new Date(todayLocalMs);
+  const todayKey = `${todayLocal.getUTCFullYear()}-${String(todayLocal.getUTCMonth() + 1).padStart(2, "0")}-${String(todayLocal.getUTCDate()).padStart(2, "0")}`;
+
+  const days: ForecastDay[] = [];
+  for (const [dateKey, bucket] of buckets) {
+    if (dateKey === todayKey) continue; // skip the partial "today" — current pill already shows today
+
+    // Pick the entry closest to local noon for the day's representative icon/description.
+    let representative = bucket[0]!;
+    let bestNoonDelta = Number.POSITIVE_INFINITY;
+    for (const entry of bucket) {
+      const localHour = new Date((entry.dt + timezoneOffsetSec) * 1000).getUTCHours();
+      const delta = Math.abs(localHour - 12);
+      if (delta < bestNoonDelta) {
+        bestNoonDelta = delta;
+        representative = entry;
+      }
+    }
+
+    let hi = -Infinity;
+    let lo = Infinity;
+    let maxPop = 0;
+    for (const entry of bucket) {
+      if (entry.main.temp_max > hi) hi = entry.main.temp_max;
+      if (entry.main.temp_min < lo) lo = entry.main.temp_min;
+      if (entry.pop > maxPop) maxPop = entry.pop;
+    }
+
+    // Use the UTC accessors on the shifted Date to render the city-local weekday.
+    const labelDate = new Date((representative.dt + timezoneOffsetSec) * 1000);
+    const label = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][labelDate.getUTCDay()]!;
+
+    days.push({
+      date: dateKey,
+      label,
+      icon: representative.weather[0]?.icon ?? "01d",
+      description: representative.weather[0]?.description ?? "",
+      hi: Math.round(hi),
+      lo: Math.round(lo),
+      precipPct: Math.round(maxPop * 100),
+    });
+
+    if (days.length >= 5) break;
+  }
+
+  return days;
 }
 
 export const weatherRouter = createTRPCRouter({
@@ -47,17 +139,33 @@ export const weatherRouter = createTRPCRouter({
 
         const { lat, lon } = geoData[0]!;
 
-        // Fetch current weather
-        const weatherUrl = `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&units=imperial&appid=${apiKey}`;
-        const weatherRes = await fetch(weatherUrl, { cache: 'no-store' });
-        if (!weatherRes.ok) return null;
+        // Fetch current weather and 5-day forecast in parallel (separate free-tier endpoints).
+        const [currentRes, forecastRes] = await Promise.all([
+          fetch(
+            `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&units=imperial&appid=${apiKey}`,
+            { cache: 'no-store' },
+          ),
+          fetch(
+            `https://api.openweathermap.org/data/2.5/forecast?lat=${lat}&lon=${lon}&units=imperial&appid=${apiKey}`,
+            { cache: 'no-store' },
+          ),
+        ]);
 
-        const weatherData = (await weatherRes.json()) as WeatherResult;
+        if (!currentRes.ok) return null;
+        const currentData = (await currentRes.json()) as CurrentWeatherResult;
+
+        let forecast: ForecastDay[] = [];
+        if (forecastRes.ok) {
+          const forecastData = (await forecastRes.json()) as ForecastResult;
+          forecast = summarizeForecast(forecastData.list, forecastData.city.timezone);
+        }
+
         return {
-          temp: Math.round(weatherData.main.temp),
-          icon: weatherData.weather[0]?.icon ?? "01d",
-          description: weatherData.weather[0]?.description ?? "",
-          timezoneOffset: weatherData.timezone,
+          temp: Math.round(currentData.main.temp),
+          icon: currentData.weather[0]?.icon ?? "01d",
+          description: currentData.weather[0]?.description ?? "",
+          timezoneOffset: currentData.timezone,
+          forecast,
         };
       } catch {
         return null;

--- a/src/server/api/routers/weather.ts
+++ b/src/server/api/routers/weather.ts
@@ -64,6 +64,14 @@ function summarizeForecast(entries: ForecastEntry[], timezoneOffsetSec: number):
   for (const [dateKey, bucket] of buckets) {
     if (dateKey === todayKey) continue; // skip the partial "today" — current pill already shows today
 
+    // Skip a day without afternoon coverage (no slot at/after ~15:00 local). OWM's ~5-day window
+    // ends mid-morning of the final day; with only morning slots, hi (max temp_max) would be taken
+    // from morning temps and understate the true daytime high — so omit it rather than mislead.
+    const hasAfternoonCoverage = bucket.some(
+      (entry) => new Date((entry.dt + timezoneOffsetSec) * 1000).getUTCHours() >= 15,
+    );
+    if (!hasAfternoonCoverage) continue;
+
     // Pick the entry closest to local noon for the day's representative icon/description.
     let representative = bucket[0]!;
     let bestNoonDelta = Number.POSITIVE_INFINITY;
@@ -154,10 +162,18 @@ export const weatherRouter = createTRPCRouter({
         if (!currentRes.ok) return null;
         const currentData = (await currentRes.json()) as CurrentWeatherResult;
 
+        // Forecast is optional — a malformed body (or a non-JSON 200 from an edge/proxy error)
+        // must not throw to the outer catch and discard the successful current-weather result.
         let forecast: ForecastDay[] = [];
         if (forecastRes.ok) {
-          const forecastData = (await forecastRes.json()) as ForecastResult;
-          forecast = summarizeForecast(forecastData.list, forecastData.city.timezone);
+          try {
+            const forecastData = (await forecastRes.json()) as ForecastResult;
+            if (forecastData?.list && forecastData.city?.timezone != null) {
+              forecast = summarizeForecast(forecastData.list, forecastData.city.timezone);
+            }
+          } catch {
+            // Leave forecast empty; the current-weather pill still renders.
+          }
         }
 
         return {


### PR DESCRIPTION
Adds a 5-day forecast to the header weather pill: the `weather.getByLocation` tRPC procedure now fetches OpenWeatherMap's forecast endpoint in parallel with current weather and summarizes 3-hour entries into per-day highs/lows/precipitation in the city's local timezone. The `LocationWeather` chip becomes a clickable popover with a caret affordance and stronger hover tint, and days lacking afternoon coverage are skipped so daytime highs aren't understated. Forecast fetching is fault-tolerant — a malformed forecast body no longer discards the successful current-weather result. In the `ProjectSwitcher` preview pane, a copy-to-clipboard button was added beside the project address, and the header pill now shows the city (with the full address in a tooltip).