### PR TITLE
CSI picker: optimistic saving indicator + sync licensed Bryntum dark theme

### DIFF
--- a/public/bryntum/stockholm-dark.css
+++ b/public/bryntum/stockholm-dark.css
@@ -1,4 +1,328 @@
 @charset "UTF-8";
+/*!
+ *
+ * Bryntum Gantt 7.2.2
+ *
+ * Copyright(c) 2026 Bryntum AB
+ * https://bryntum.com/contact
+ * https://bryntum.com/license
+ *
+ * Bryntum incorporates third-party code licensed under the MIT and Apache-2.0 licenses.
+ * See the licenses below or visit https://bryntum.com/products/gantt/docs/guide/Gantt/licenses
+ *
+ * # Third Party Notices
+ * 
+ * Bryntum uses the following third party libraries:
+ * 
+ * * [Font Awesome 6 Free](https://fontawesome.com/license/free) (MIT/SIL OFL 1.1)
+ * * [Roboto font (for Material theme only)](https://github.com/google/roboto) (Apache-2.0)
+ * * [Styling Cross-Browser Compatible Range Inputs with Sass](https://github.com/darlanrod/input-range-sass) (MIT)
+ * * [Tree Walker polyfill (only applies to Salesforce)](https://github.com/Krinkle/dom-TreeWalker-polyfill) (MIT)
+ * * [chronograph](https://github.com/bryntum/chronograph) (MIT)
+ * * [later.js](https://github.com/bunkat/later) (MIT)
+ * * [Monaco editor (only used in our demos)](https://microsoft.github.io/monaco-editor) (MIT)
+ * * Map/Set polyfill to fix performance issues for Salesforce LWS (MIT)
+ * * [Chart.js (when using Chart package)](https://github.com/chartjs/Chart.js) (MIT)
+ * 
+ * Note: the **chronograph** and **later.js** libraries are used in Bryntum Scheduler Pro and Bryntum Gantt, but they are
+ * listed for all Bryntum products since the distribution contains trial versions of the thin bundles for all other
+ * products. TreeWalker is only used in the LWC bundle for Salesforce. Roboto font is only used in the material theme.
+ * 
+ * ## Font Awesome 6 Free
+ * 
+ * [Font Awesome Free 6 by @fontawesome](https://fontawesome.com/)
+ * 
+ * Font Awesome Free is free, open source, and GPL friendly. You can use it for commercial projects, open source projects,
+ * or really almost whatever you want.
+ * 
+ * [Full Font Awesome Free license](https://fontawesome.com/license/free)
+ * 
+ * ## Roboto font
+ * 
+ * [Apache License Version 2.0, January 2004](https://www.apache.org/licenses/LICENSE-2.0)
+ * 
+ * TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ * 
+ * 1. Definitions.
+ * 
+ * "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9
+ * of this document.
+ * 
+ * "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+ * 
+ * "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are
+ * under common control with that entity. For the purposes of this definition,
+ * "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by
+ * contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+ * ownership of such entity.
+ * 
+ * "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+ * 
+ * "Source" form shall mean the preferred form for making modifications, including but not limited to software source code,
+ * documentation source, and configuration files.
+ * 
+ * "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including
+ * but not limited to compiled object code, generated documentation, and conversions to other media types.
+ * 
+ * "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as
+ * indicated by a copyright notice that is included in or attached to the work
+ * (an example is provided in the Appendix below).
+ * 
+ * "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work
+ * and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an
+ * original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain
+ * separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+ * 
+ * "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or
+ * additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the
+ * Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner.
+ * For the purposes of this definition, "submitted"
+ * means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including
+ * but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems
+ * that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding
+ * communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a
+ * Contribution."
+ * 
+ * "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received
+ * by Licensor and subsequently incorporated within the Work.
+ * 
+ * 2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to
+ *    You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce,
+ *    prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such
+ *    Derivative Works in Source or Object form.
+ * 
+ * 3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a
+ *    perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+ *    (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise
+ *    transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are
+ *    necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s)
+ *    with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (
+ *    including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within
+ *    the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this
+ *    License for that Work shall terminate as of the date such litigation is filed.
+ * 
+ * 4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with
+ *    or without modifications, and in Source or Object form, provided that You meet the following conditions:
+ * 
+ * (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+ * 
+ * (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+ * 
+ * (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark,
+ * and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the
+ * Derivative Works; and
+ * 
+ * (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute
+ * must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that
+ * do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file
+ * distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the
+ * Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices
+ * normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You
+ * may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the
+ * NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the
+ * License.
+ * 
+ * You may add Your own copyright statement to Your modifications and may provide additional or different license terms and
+ * conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole,
+ * provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this
+ * License.
+ * 
+ * 5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for
+ *    inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any
+ *    additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any
+ *    separate license agreement you may have executed with Licensor regarding such Contributions.
+ * 
+ * 6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product
+ *    names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and
+ *    reproducing the content of the NOTICE file.
+ * 
+ * 7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and
+ *    each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *    either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ *    MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness
+ *    of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this
+ *    License.
+ * 
+ * 8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or
+ *    otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing,
+ *    shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or
+ *    consequential damages of any character arising as a result of this License or out of the use or inability to use the
+ *    Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+ *    any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such
+ *    damages.
+ * 
+ * 9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose
+ *    to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or
+ *    rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and
+ *    on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and
+ *    hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason
+ *    of your accepting any such warranty or additional liability.
+ * 
+ * END OF TERMS AND CONDITIONS
+ * 
+ * APPENDIX: How to apply the Apache License to your work.
+ * 
+ * To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by
+ * brackets "[]"
+ * replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the
+ * appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose
+ * be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+ * 
+ * Copyright [yyyy] [name of copyright owner]
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * [APACHE LICENSE, VERSION 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "
+ * AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ * 
+ * ## Styling Cross-Browser Compatible Range Inputs with Sass
+ * 
+ * Github: [input-range-sass](https://github.com/darlanrod/input-range-sass)
+ * 
+ * Author: [Darlan Rod](https://github.com/darlanrod)
+ * 
+ * Version 1.4.1
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016 Darlan Rod
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## Tree Walker polyfill
+ * 
+ * The MIT License (MIT)
+ * 
+ * [Copyright 2013–2017 Timo Tijhof](https://github.com/Krinkle/dom-TreeWalker-polyfill)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## chronograph
+ * 
+ * GitHub: [chronograph](https://github.com/bryntum/chronograph)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2023 Bryntum
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## later.js
+ * 
+ * GitHub: [later.js](https://github.com/bunkat/later)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright © 2013 BunKat
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## Monaco editor
+ * 
+ * GitHub: [Monaco editor](https://microsoft.github.io/monaco-editor) (MIT)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016 - present Microsoft Corporation
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## Map/Set polyfill to fix performance issues for Salesforce LWS
+ * 
+ * Copyright © 2024 Certinia Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * 
+ * ## Chart.js
+ * 
+ * GitHub: [Chart.js](https://github.com/chartjs/Chart.js)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2014-2022 Chart.js Contributors
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
 
 /* Themes need more specific rules than Widgets etc. to make sure the values are applied no matter the import order */
 :root:not(.b-nothing), :host(:not(.b-nothing)) {
@@ -111,22 +435,6 @@
     /* TaskBoard */
     --b-task-board-card-background            : var(--b-neutral-95);
     --b-task-board-card-hover-background      : var(--b-neutral-92);
-
-    /* Heat map values ranging from lowest to highest intensity to create
-     * background colors to indicate how "hot" an element is, for example
-     * based on the number of events in a calendar cell.
-     */
-     /*
-      * Start color for the heatmap, representing the lowest intensity (e.g. 1 event in a calendar cell).
-      */
-    --b-heatmap-start          : oklab(0.53 -0.03 0.1);
-
-    /*
-     * End color for the heatmap, representing the highest intensity (e.g. 10 or more events in a calendar cell).
-     */
-    --b-heatmap-end            : oklab(0.38 0.13 0.03);
-
-    --b-heatmap-mix-blend-mode : hard-light;
 }
 
 /* Shades of primary color have to be specified per widget, for color-mix to work as intended */

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -19,12 +19,11 @@ import TaskHeader from './task-popover/TaskHeader';
 import CoverImageBanner from './task-popover/CoverImageBanner';
 import FolderRow from './task-popover/FolderRow';
 import FilePreviewPanel from './task-popover/FilePreviewPanel';
-import CsiCodePanel from './task-popover/CsiCodePanel';
 import SubmittalDrawer from './SubmittalDrawer';
 import { canApproveDocuments } from '@/lib/permissions';
 import type { SlotKind } from '@/lib/validations/gantt';
 
-type RightPanel = { type: 'preview'; doc: PreviewDoc } | { type: 'csi' } | null;
+type RightPanel = { type: 'preview'; doc: PreviewDoc } | null;
 
 type TaskDetailsPopoverProps = {
   open: boolean;
@@ -146,10 +145,6 @@ export function TaskDetailsPopover({
   );
 
   // ── Right panel helpers ──
-  const openCsiPanel = useCallback(() => {
-    setRightPanel({ type: 'csi' });
-  }, []);
-
   const openPreview = useCallback((doc: PreviewDoc) => {
     setRightPanel({ type: 'preview', doc });
   }, []);
@@ -339,8 +334,9 @@ export function TaskDetailsPopover({
               taskName={taskName}
               taskDetail={taskDetail}
               taskDetailLoading={taskDetailLoading}
+              taskId={taskId}
+              ganttInstance={ganttInstance}
               onClose={handleClose}
-              onOpenCsiPanel={openCsiPanel}
               onScrollToRequirements={handleScrollToRequirements}
               onOpenRequirementsDrawer={
                 canManageSlots ? () => setDrawerKind('submittal') : undefined
@@ -505,19 +501,10 @@ export function TaskDetailsPopover({
           {rightPanel && (
             <>
               <Divider orientation="vertical" flexItem />
-              {rightPanel.type === 'preview' ? (
-                <FilePreviewPanel
-                  previewDoc={rightPanel.doc}
-                  onClose={closeRightPanel}
-                />
-              ) : (
-                <CsiCodePanel
-                  csiCode={taskDetail?.csiCode}
-                  taskId={taskId!}
-                  ganttInstance={ganttInstance}
-                  onClose={closeRightPanel}
-                />
-              )}
+              <FilePreviewPanel
+                previewDoc={rightPanel.doc}
+                onClose={closeRightPanel}
+              />
             </>
           )}
         </Box>

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -19,11 +19,12 @@ import TaskHeader from './task-popover/TaskHeader';
 import CoverImageBanner from './task-popover/CoverImageBanner';
 import FolderRow from './task-popover/FolderRow';
 import FilePreviewPanel from './task-popover/FilePreviewPanel';
+import CsiCodePanel from './task-popover/CsiCodePanel';
 import SubmittalDrawer from './SubmittalDrawer';
 import { canApproveDocuments } from '@/lib/permissions';
 import type { SlotKind } from '@/lib/validations/gantt';
 
-type RightPanel = { type: 'preview'; doc: PreviewDoc } | null;
+type RightPanel = { type: 'preview'; doc: PreviewDoc } | { type: 'csi' } | null;
 
 type TaskDetailsPopoverProps = {
   open: boolean;
@@ -149,9 +150,39 @@ export function TaskDetailsPopover({
     setRightPanel({ type: 'preview', doc });
   }, []);
 
+  const openCsiPanel = useCallback(() => {
+    setRightPanel({ type: 'csi' });
+  }, []);
+
   const closeRightPanel = useCallback(() => {
     setRightPanel(null);
   }, []);
+
+  // ── CSI optimistic + saving state ──
+  // The picker writes record.csiCode and the panel slides away, but the chip
+  // reads taskDetail.csiCode, which only refreshes ~1.5s later (autoSync flush +
+  // onSync's 1s debounced invalidate in BryntumGanttWrapper). `pendingCsiCode`
+  // holds the just-picked value so the chip updates instantly and spins until
+  // the server value catches up. `undefined` means nothing is in flight.
+  const [pendingCsiCode, setPendingCsiCode] = useState<string | null | undefined>(undefined);
+  const savedCsiCode = taskDetail?.csiCode ?? null;
+
+  useEffect(() => {
+    if (pendingCsiCode !== undefined && savedCsiCode === pendingCsiCode) {
+      setPendingCsiCode(undefined);
+    }
+  }, [savedCsiCode, pendingCsiCode]);
+
+  // Failsafe: a syncFail never refreshes taskDetail, so drop the spinner after a
+  // few seconds rather than spinning forever.
+  useEffect(() => {
+    if (pendingCsiCode === undefined) return;
+    const timer = setTimeout(() => setPendingCsiCode(undefined), 6000);
+    return () => clearTimeout(timer);
+  }, [pendingCsiCode]);
+
+  const effectiveCsiCode = pendingCsiCode !== undefined ? pendingCsiCode : savedCsiCode;
+  const isSavingCsi = pendingCsiCode !== undefined;
 
   // ── Callbacks ──
   const toggleFolder = useCallback((folderId: string) => {
@@ -334,9 +365,10 @@ export function TaskDetailsPopover({
               taskName={taskName}
               taskDetail={taskDetail}
               taskDetailLoading={taskDetailLoading}
-              taskId={taskId}
-              ganttInstance={ganttInstance}
+              effectiveCsiCode={effectiveCsiCode}
+              isSavingCsi={isSavingCsi}
               onClose={handleClose}
+              onOpenCsiPanel={openCsiPanel}
               onScrollToRequirements={handleScrollToRequirements}
               onOpenRequirementsDrawer={
                 canManageSlots ? () => setDrawerKind('submittal') : undefined
@@ -501,10 +533,20 @@ export function TaskDetailsPopover({
           {rightPanel && (
             <>
               <Divider orientation="vertical" flexItem />
-              <FilePreviewPanel
-                previewDoc={rightPanel.doc}
-                onClose={closeRightPanel}
-              />
+              {rightPanel.type === 'preview' ? (
+                <FilePreviewPanel
+                  previewDoc={rightPanel.doc}
+                  onClose={closeRightPanel}
+                />
+              ) : (
+                <CsiCodePanel
+                  csiCode={effectiveCsiCode}
+                  taskId={taskId!}
+                  ganttInstance={ganttInstance}
+                  onCodeChange={setPendingCsiCode}
+                  onClose={closeRightPanel}
+                />
+              )}
             </>
           )}
         </Box>

--- a/src/components/bryntum/components/task-popover/CsiCodePanel.tsx
+++ b/src/components/bryntum/components/task-popover/CsiCodePanel.tsx
@@ -2,15 +2,13 @@
 
 import { useState, useEffect, useMemo, memo, useCallback } from 'react';
 import {
-  Tag,
   CaretDown,
   CaretRight,
   MagnifyingGlass,
   Check,
   X,
-  Prohibit,
 } from '@phosphor-icons/react';
-import { Box, Typography, IconButton, InputBase, Divider } from '@mui/material';
+import { Box, Typography, IconButton, InputBase } from '@mui/material';
 import { useSnackbar } from '@/hooks/useSnackbar';
 import {
   CSI_MASTERFORMAT,
@@ -119,6 +117,7 @@ interface CsiCodePanelProps {
   csiCode: string | null | undefined;
   taskId: string;
   ganttInstance: BryntumGanttInstance | null;
+  /** Called after a code is selected (auto-close) or when the picker should dismiss. */
   onClose: () => void;
 }
 
@@ -188,9 +187,10 @@ export default function CsiCodePanel({
       if (!record) {
         showSnackbar('Could not find task in chart — try reloading', 'error');
         setOptimisticCode(undefined);
-        return;
+        return false;
       }
       record.csiCode = next;
+      return true;
     },
     [ganttInstance, taskId, showSnackbar],
   );
@@ -198,158 +198,31 @@ export default function CsiCodePanel({
   const handleSelectSubdivision = useCallback(
     (code: string) => {
       setOptimisticCode(code);
-      writeCsiCode(code);
+      const ok = writeCsiCode(code);
+      // Auto-close the picker — the selection is committed via Bryntum autoSync,
+      // and the chip in TaskHeader already reflects the new value.
+      if (ok) onClose();
     },
-    [writeCsiCode],
+    [writeCsiCode, onClose],
   );
-
-  const handleRemoveCode = useCallback(() => {
-    setOptimisticCode(null);
-    writeCsiCode(null);
-  }, [writeCsiCode]);
-
-  const hasCode = !!displayCode;
-  const subEntry = hasCode ? CSI_SUBDIVISION_MAP.get(displayCode!) : null;
 
   return (
     <Box
       sx={{
-        flex: 1,
+        width: 360,
         display: 'flex',
         flexDirection: 'column',
         bgcolor: 'background.paper',
         minWidth: 0,
-        maxHeight: '85vh',
-        animation: 'slideInRight 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
-        '@keyframes slideInRight': {
-          from: { opacity: 0, transform: 'translateX(12px)' },
-          to: { opacity: 1, transform: 'translateX(0)' },
-        },
+        maxHeight: 480,
       }}
     >
-      {/* ── Header ── */}
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: '16px', py: '12px' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
-          <Tag size={14} weight="bold" color="var(--text-secondary)" style={{ flexShrink: 0 }} />
-          <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, color: 'text.primary', lineHeight: 1 }}>
-            CSI Classification
-          </Typography>
-        </Box>
-        <Box
-          component="button"
-          onClick={onClose}
-          sx={{
-            width: 26,
-            height: 26,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            borderRadius: '6px',
-            border: 'none',
-            bgcolor: 'transparent',
-            cursor: 'pointer',
-            color: 'text.secondary',
-            flexShrink: 0,
-            '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
-            transition: 'background-color 0.15s, color 0.15s',
-          }}
-          aria-label="Close CSI panel"
-        >
-          <X size={13} />
-        </Box>
-      </Box>
-
-      {/* ── Current selection ── */}
-      {hasCode && subEntry && (
-        <Box
-          sx={{
-            mx: '16px',
-            mb: 1.5,
-            px: 1.5,
-            py: 1.25,
-            borderRadius: '8px',
-            bgcolor: 'action.selected',
-            border: '1px solid',
-            borderColor: 'divider',
-            display: 'flex',
-            alignItems: 'flex-start',
-            gap: 1,
-          }}
-        >
-          <Check size={13} weight="bold" color="var(--sidebar-indicator)" style={{ flexShrink: 0, marginTop: 1 }} />
-          <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: '3px' }}>
-            <Typography
-              sx={{
-                fontSize: '0.6875rem',
-                fontWeight: 700,
-                color: 'text.primary',
-                lineHeight: 1,
-                fontVariantNumeric: 'tabular-nums',
-                letterSpacing: '0.02em',
-              }}
-            >
-              {displayCode}
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: '0.75rem',
-                fontWeight: 500,
-                color: 'text.secondary',
-                lineHeight: 1.3,
-              }}
-            >
-              {subEntry.subdivision.name}
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: '0.5625rem',
-                fontWeight: 500,
-                color: 'text.secondary',
-                lineHeight: 1,
-                textTransform: 'uppercase',
-                letterSpacing: '0.06em',
-                mt: '1px',
-              }}
-            >
-              {subEntry.division.name}
-            </Typography>
-          </Box>
-          <Box
-            component="button"
-            onClick={handleRemoveCode}
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 22,
-              height: 22,
-              borderRadius: '5px',
-              border: 'none',
-              bgcolor: 'transparent',
-              cursor: 'pointer',
-              color: 'text.secondary',
-              flexShrink: 0,
-              '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
-              transition: 'background-color 0.15s, color 0.15s',
-            }}
-            aria-label="Remove classification"
-          >
-            <Prohibit size={12} weight="bold" />
-          </Box>
-        </Box>
-      )}
-
-      <Divider />
-
       {/* ── Search bar ── */}
       <Box
         sx={{
           px: 1.5,
           py: 1,
-          position: 'sticky',
-          top: 0,
           bgcolor: 'background.paper',
-          zIndex: 1,
           borderBottom: '1px solid',
           borderColor: 'divider',
           display: 'flex',

--- a/src/components/bryntum/components/task-popover/CsiCodePanel.tsx
+++ b/src/components/bryntum/components/task-popover/CsiCodePanel.tsx
@@ -2,13 +2,15 @@
 
 import { useState, useEffect, useMemo, memo, useCallback } from 'react';
 import {
+  Tag,
   CaretDown,
   CaretRight,
   MagnifyingGlass,
   Check,
   X,
+  Prohibit,
 } from '@phosphor-icons/react';
-import { Box, Typography, IconButton, InputBase } from '@mui/material';
+import { Box, Typography, IconButton, InputBase, Divider } from '@mui/material';
 import { useSnackbar } from '@/hooks/useSnackbar';
 import {
   CSI_MASTERFORMAT,
@@ -117,7 +119,12 @@ interface CsiCodePanelProps {
   csiCode: string | null | undefined;
   taskId: string;
   ganttInstance: BryntumGanttInstance | null;
-  /** Called after a code is selected (auto-close) or when the picker should dismiss. */
+  /**
+   * Called with the newly-written code the moment it's set on the Bryntum
+   * record, so the parent can show an optimistic + saving state on the chip
+   * while autoSync persists it. `null` signals a removal.
+   */
+  onCodeChange?: (code: string | null) => void;
   onClose: () => void;
 }
 
@@ -125,6 +132,7 @@ export default function CsiCodePanel({
   csiCode,
   taskId,
   ganttInstance,
+  onCodeChange,
   onClose,
 }: CsiCodePanelProps) {
   const { showSnackbar } = useSnackbar();
@@ -199,30 +207,166 @@ export default function CsiCodePanel({
     (code: string) => {
       setOptimisticCode(code);
       const ok = writeCsiCode(code);
-      // Auto-close the picker — the selection is committed via Bryntum autoSync,
-      // and the chip in TaskHeader already reflects the new value.
-      if (ok) onClose();
+      // Notify the parent so the chip shows the new code with a saving spinner,
+      // then slide the panel away — no manual close needed.
+      if (ok) {
+        onCodeChange?.(code);
+        onClose();
+      }
     },
-    [writeCsiCode, onClose],
+    [writeCsiCode, onCodeChange, onClose],
   );
+
+  // Removal keeps the panel open so the user can pick a replacement; the chip
+  // still reflects the cleared state via onCodeChange.
+  const handleRemoveCode = useCallback(() => {
+    setOptimisticCode(null);
+    const ok = writeCsiCode(null);
+    if (ok) onCodeChange?.(null);
+  }, [writeCsiCode, onCodeChange]);
+
+  const hasCode = !!displayCode;
+  const subEntry = hasCode ? CSI_SUBDIVISION_MAP.get(displayCode!) : null;
 
   return (
     <Box
       sx={{
-        width: 360,
+        flex: 1,
         display: 'flex',
         flexDirection: 'column',
         bgcolor: 'background.paper',
         minWidth: 0,
-        maxHeight: 480,
+        maxHeight: '85vh',
+        animation: 'slideInRight 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+        '@keyframes slideInRight': {
+          from: { opacity: 0, transform: 'translateX(12px)' },
+          to: { opacity: 1, transform: 'translateX(0)' },
+        },
       }}
     >
+      {/* ── Header ── */}
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: '16px', py: '12px' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+          <Tag size={14} weight="bold" color="var(--text-secondary)" style={{ flexShrink: 0 }} />
+          <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, color: 'text.primary', lineHeight: 1 }}>
+            CSI Classification
+          </Typography>
+        </Box>
+        <Box
+          component="button"
+          onClick={onClose}
+          sx={{
+            width: 26,
+            height: 26,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: '6px',
+            border: 'none',
+            bgcolor: 'transparent',
+            cursor: 'pointer',
+            color: 'text.secondary',
+            flexShrink: 0,
+            '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
+            transition: 'background-color 0.15s, color 0.15s',
+          }}
+          aria-label="Close CSI panel"
+        >
+          <X size={13} />
+        </Box>
+      </Box>
+
+      {/* ── Current selection ── */}
+      {hasCode && subEntry && (
+        <Box
+          sx={{
+            mx: '16px',
+            mb: 1.5,
+            px: 1.5,
+            py: 1.25,
+            borderRadius: '8px',
+            bgcolor: 'action.selected',
+            border: '1px solid',
+            borderColor: 'divider',
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 1,
+          }}
+        >
+          <Check size={13} weight="bold" color="var(--sidebar-indicator)" style={{ flexShrink: 0, marginTop: 1 }} />
+          <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: '3px' }}>
+            <Typography
+              sx={{
+                fontSize: '0.6875rem',
+                fontWeight: 700,
+                color: 'text.primary',
+                lineHeight: 1,
+                fontVariantNumeric: 'tabular-nums',
+                letterSpacing: '0.02em',
+              }}
+            >
+              {displayCode}
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: '0.75rem',
+                fontWeight: 500,
+                color: 'text.secondary',
+                lineHeight: 1.3,
+              }}
+            >
+              {subEntry.subdivision.name}
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: '0.5625rem',
+                fontWeight: 500,
+                color: 'text.secondary',
+                lineHeight: 1,
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                mt: '1px',
+              }}
+            >
+              {subEntry.division.name}
+            </Typography>
+          </Box>
+          <Box
+            component="button"
+            onClick={handleRemoveCode}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 22,
+              height: 22,
+              borderRadius: '5px',
+              border: 'none',
+              bgcolor: 'transparent',
+              cursor: 'pointer',
+              color: 'text.secondary',
+              flexShrink: 0,
+              '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
+              transition: 'background-color 0.15s, color 0.15s',
+            }}
+            aria-label="Remove classification"
+          >
+            <Prohibit size={12} weight="bold" />
+          </Box>
+        </Box>
+      )}
+
+      <Divider />
+
       {/* ── Search bar ── */}
       <Box
         sx={{
           px: 1.5,
           py: 1,
+          position: 'sticky',
+          top: 0,
           bgcolor: 'background.paper',
+          zIndex: 1,
           borderBottom: '1px solid',
           borderColor: 'divider',
           display: 'flex',

--- a/src/components/bryntum/components/task-popover/TaskHeader.tsx
+++ b/src/components/bryntum/components/task-popover/TaskHeader.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { Box, ClickAwayListener, Popper, Skeleton, Typography } from '@mui/material';
+import { Box, CircularProgress, Skeleton, Typography } from '@mui/material';
 import { X, CalendarBlank, Timer, Tag, CaretRight, Plus, Check } from '@phosphor-icons/react';
 import type { Theme } from '@mui/material/styles';
 import { useTheme } from '@mui/material/styles';
 import { CSI_SUBDIVISION_MAP } from '@/lib/constants/csiCodes';
-import type { BryntumGanttInstance } from '../../types';
-import CsiCodePanel from './CsiCodePanel';
 
 type Status = 'not-started' | 'in-progress' | 'complete';
 
@@ -108,9 +105,13 @@ interface TaskHeaderProps {
     hasChildren?: boolean;
   } | null | undefined;
   taskDetailLoading: boolean;
-  taskId?: string;
-  ganttInstance: BryntumGanttInstance | null;
+  /** Optimistic CSI code (pending value if a save is in flight, else the saved value). */
+  effectiveCsiCode: string | null;
+  /** True while a CSI change is being persisted — drives the chip spinner. */
+  isSavingCsi: boolean;
   onClose: () => void;
+  /** Opens the CSI picker side panel. */
+  onOpenCsiPanel: () => void;
   onScrollToRequirements?: () => void;
   /**
    * Open the Manage submittals/inspections drawer. When provided, the empty
@@ -128,9 +129,10 @@ export default function TaskHeader({
   taskName,
   taskDetail,
   taskDetailLoading,
-  taskId,
-  ganttInstance,
+  effectiveCsiCode,
+  isSavingCsi,
   onClose,
+  onOpenCsiPanel,
   onScrollToRequirements,
   onOpenRequirementsDrawer,
   submittalsCurrent = 0,
@@ -138,25 +140,6 @@ export default function TaskHeader({
 }: TaskHeaderProps) {
   const emptyCtaAction = onOpenRequirementsDrawer ?? onScrollToRequirements;
   const theme = useTheme();
-
-  // ── CSI popover state ──
-  // The chip is both the anchor and the trigger. Esc is caught at capture
-  // phase so it closes the picker without bubbling to the outer TaskDetailsPopover.
-  const csiAnchorRef = useRef<HTMLButtonElement | null>(null);
-  const [csiOpen, setCsiOpen] = useState(false);
-  const closeCsi = () => setCsiOpen(false);
-
-  useEffect(() => {
-    if (!csiOpen) return;
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.stopPropagation();
-        setCsiOpen(false);
-      }
-    };
-    document.addEventListener('keydown', handleEsc, true);
-    return () => document.removeEventListener('keydown', handleEsc, true);
-  }, [csiOpen]);
 
   // Progress derived from requirements
   const requiredSubmittals = taskDetail?.requiredSubmittals ?? 0;
@@ -194,8 +177,9 @@ export default function TaskHeader({
   const subLine =
     status === 'complete' ? 'All requirements complete' : subPending.join(' · ');
 
-  // CSI lookup
-  const csiEntry = taskDetail?.csiCode ? CSI_SUBDIVISION_MAP.get(taskDetail.csiCode) : null;
+  // CSI lookup — uses the effective (optimistic) code so the chip reflects the
+  // just-picked value before the server round-trip lands.
+  const csiEntry = effectiveCsiCode ? CSI_SUBDIVISION_MAP.get(effectiveCsiCode) : null;
   const csiName = csiEntry?.subdivision.name ?? null;
 
   const metaDateRange = [
@@ -357,12 +341,17 @@ export default function TaskHeader({
                 )}
 
                 {/* CSI inline chip — code + truncated name (or dashed empty) */}
-                {taskDetail?.csiCode ? (
+                {effectiveCsiCode ? (
                   <Box
                     component="button"
-                    ref={csiAnchorRef}
-                    onClick={() => setCsiOpen((o) => !o)}
-                    title={csiName ? `${taskDetail.csiCode} — ${csiName}` : taskDetail.csiCode}
+                    onClick={onOpenCsiPanel}
+                    title={
+                      isSavingCsi
+                        ? 'Saving CSI code…'
+                        : csiName
+                          ? `${effectiveCsiCode} — ${csiName}`
+                          : effectiveCsiCode
+                    }
                     sx={{
                       display: 'inline-flex',
                       alignItems: 'center',
@@ -371,21 +360,30 @@ export default function TaskHeader({
                       px: '7px',
                       borderRadius: '5px',
                       border: '1px solid',
-                      borderColor: 'divider',
+                      borderColor: isSavingCsi ? 'primary.main' : 'divider',
                       bgcolor: 'transparent',
                       color: 'text.secondary',
                       cursor: 'pointer',
                       lineHeight: 1,
                       maxWidth: '100%',
-                      transition: 'background-color 0.15s, color 0.15s, border-color 0.15s',
+                      opacity: isSavingCsi ? 0.85 : 1,
+                      transition: 'background-color 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s',
                       '&:hover': {
                         bgcolor: 'action.hover',
-                        borderColor: 'text.disabled',
+                        borderColor: isSavingCsi ? 'primary.main' : 'text.disabled',
                         color: 'text.primary',
                       },
                     }}
                   >
-                    <Tag size={11} weight="fill" color="currentColor" style={{ flexShrink: 0 }} />
+                    {isSavingCsi ? (
+                      <CircularProgress
+                        size={10}
+                        thickness={6}
+                        sx={{ color: 'primary.main', flexShrink: 0 }}
+                      />
+                    ) : (
+                      <Tag size={11} weight="fill" color="currentColor" style={{ flexShrink: 0 }} />
+                    )}
                     <Typography
                       component="span"
                       sx={{
@@ -397,7 +395,7 @@ export default function TaskHeader({
                         letterSpacing: '0.02em',
                       }}
                     >
-                      {taskDetail.csiCode}
+                      {effectiveCsiCode}
                     </Typography>
                     {csiName && (
                       <Typography
@@ -421,8 +419,7 @@ export default function TaskHeader({
                 ) : (
                   <Box
                     component="button"
-                    ref={csiAnchorRef}
-                    onClick={() => setCsiOpen((o) => !o)}
+                    onClick={onOpenCsiPanel}
                     sx={{
                       display: 'inline-flex',
                       alignItems: 'center',
@@ -603,43 +600,6 @@ export default function TaskHeader({
           </Box>
         ) : null}
       </Box>
-
-      {/* ── CSI picker popover ── */}
-      {taskId && (
-        <Popper
-          open={csiOpen}
-          anchorEl={csiAnchorRef.current}
-          placement="bottom-start"
-          // Render above the parent Popover's paper. MUI's Popover uses the
-          // tooltip z-index (1500); push the popper one above so the picker
-          // floats over the task body and isn't clipped.
-          sx={{ zIndex: 1501 }}
-          modifiers={[
-            { name: 'offset', options: { offset: [0, 6] } },
-            { name: 'preventOverflow', options: { padding: 8 } },
-          ]}
-        >
-          <ClickAwayListener onClickAway={closeCsi}>
-            <Box
-              sx={{
-                borderRadius: '10px',
-                border: '1px solid',
-                borderColor: 'divider',
-                boxShadow: '0 12px 32px -8px rgba(0,0,0,0.18), 0 4px 12px -4px rgba(0,0,0,0.08)',
-                overflow: 'hidden',
-                bgcolor: 'background.paper',
-              }}
-            >
-              <CsiCodePanel
-                csiCode={taskDetail?.csiCode}
-                taskId={taskId}
-                ganttInstance={ganttInstance}
-                onClose={closeCsi}
-              />
-            </Box>
-          </ClickAwayListener>
-        </Popper>
-      )}
     </Box>
   );
 }

--- a/src/components/bryntum/components/task-popover/TaskHeader.tsx
+++ b/src/components/bryntum/components/task-popover/TaskHeader.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import { Box, Typography, Skeleton } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+import { Box, ClickAwayListener, Popper, Skeleton, Typography } from '@mui/material';
 import { X, CalendarBlank, Timer, Tag, CaretRight, Plus, Check } from '@phosphor-icons/react';
 import type { Theme } from '@mui/material/styles';
 import { useTheme } from '@mui/material/styles';
 import { CSI_SUBDIVISION_MAP } from '@/lib/constants/csiCodes';
+import type { BryntumGanttInstance } from '../../types';
+import CsiCodePanel from './CsiCodePanel';
 
 type Status = 'not-started' | 'in-progress' | 'complete';
 
@@ -105,8 +108,9 @@ interface TaskHeaderProps {
     hasChildren?: boolean;
   } | null | undefined;
   taskDetailLoading: boolean;
+  taskId?: string;
+  ganttInstance: BryntumGanttInstance | null;
   onClose: () => void;
-  onOpenCsiPanel: () => void;
   onScrollToRequirements?: () => void;
   /**
    * Open the Manage submittals/inspections drawer. When provided, the empty
@@ -124,8 +128,9 @@ export default function TaskHeader({
   taskName,
   taskDetail,
   taskDetailLoading,
+  taskId,
+  ganttInstance,
   onClose,
-  onOpenCsiPanel,
   onScrollToRequirements,
   onOpenRequirementsDrawer,
   submittalsCurrent = 0,
@@ -133,6 +138,25 @@ export default function TaskHeader({
 }: TaskHeaderProps) {
   const emptyCtaAction = onOpenRequirementsDrawer ?? onScrollToRequirements;
   const theme = useTheme();
+
+  // ── CSI popover state ──
+  // The chip is both the anchor and the trigger. Esc is caught at capture
+  // phase so it closes the picker without bubbling to the outer TaskDetailsPopover.
+  const csiAnchorRef = useRef<HTMLButtonElement | null>(null);
+  const [csiOpen, setCsiOpen] = useState(false);
+  const closeCsi = () => setCsiOpen(false);
+
+  useEffect(() => {
+    if (!csiOpen) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setCsiOpen(false);
+      }
+    };
+    document.addEventListener('keydown', handleEsc, true);
+    return () => document.removeEventListener('keydown', handleEsc, true);
+  }, [csiOpen]);
 
   // Progress derived from requirements
   const requiredSubmittals = taskDetail?.requiredSubmittals ?? 0;
@@ -336,7 +360,8 @@ export default function TaskHeader({
                 {taskDetail?.csiCode ? (
                   <Box
                     component="button"
-                    onClick={onOpenCsiPanel}
+                    ref={csiAnchorRef}
+                    onClick={() => setCsiOpen((o) => !o)}
                     title={csiName ? `${taskDetail.csiCode} — ${csiName}` : taskDetail.csiCode}
                     sx={{
                       display: 'inline-flex',
@@ -396,7 +421,8 @@ export default function TaskHeader({
                 ) : (
                   <Box
                     component="button"
-                    onClick={onOpenCsiPanel}
+                    ref={csiAnchorRef}
+                    onClick={() => setCsiOpen((o) => !o)}
                     sx={{
                       display: 'inline-flex',
                       alignItems: 'center',
@@ -577,6 +603,43 @@ export default function TaskHeader({
           </Box>
         ) : null}
       </Box>
+
+      {/* ── CSI picker popover ── */}
+      {taskId && (
+        <Popper
+          open={csiOpen}
+          anchorEl={csiAnchorRef.current}
+          placement="bottom-start"
+          // Render above the parent Popover's paper. MUI's Popover uses the
+          // tooltip z-index (1500); push the popper one above so the picker
+          // floats over the task body and isn't clipped.
+          sx={{ zIndex: 1501 }}
+          modifiers={[
+            { name: 'offset', options: { offset: [0, 6] } },
+            { name: 'preventOverflow', options: { padding: 8 } },
+          ]}
+        >
+          <ClickAwayListener onClickAway={closeCsi}>
+            <Box
+              sx={{
+                borderRadius: '10px',
+                border: '1px solid',
+                borderColor: 'divider',
+                boxShadow: '0 12px 32px -8px rgba(0,0,0,0.18), 0 4px 12px -4px rgba(0,0,0,0.08)',
+                overflow: 'hidden',
+                bgcolor: 'background.paper',
+              }}
+            >
+              <CsiCodePanel
+                csiCode={taskDetail?.csiCode}
+                taskId={taskId}
+                ganttInstance={ganttInstance}
+                onClose={closeCsi}
+              />
+            </Box>
+          </ClickAwayListener>
+        </Popper>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
Adds a saving indicator to the CSI code picker: when a code is selected, the chip now updates optimistically and shows a spinner with a primary-color border while the change is persisted through Bryntum autoSync, closing the ~1.5s window where the chip previously displayed the stale value (cleared when the refetched value matches, or after a 6s failsafe). The picker keeps its slide-in side panel (widening the task popover from the right) and auto-closes the moment a code is picked, so no manual dismiss is needed. The optimistic/saving state lives in `TaskDetailsPopover`, the common owner of the chip-host `TaskHeader` and the panel. This PR also syncs the checked-in `public/bryntum/stockholm-dark.css` to the licensed Bryntum Gantt 7.2.2 theme, regenerated by the `sync-bryntum-theme.mjs` postinstall after preview (#166) switched the Gantt dependency off the trial package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)