### PR TITLE
Restrict project settings to owners and admins

### DIFF
--- a/claudedocs/auth-and-permissions.md
+++ b/claudedocs/auth-and-permissions.md
@@ -29,6 +29,8 @@ Members can view projects they are invited to and upload documents. They cannot 
 
 `APPROVE_DOCS` gates the submittal/inspection approval toggle and the Review Queue mutations. Members see read-only badges.
 
+`MANAGE_PROJ` gates the **Project Settings** surface entirely (owners/admins only). Members do not see the "Project Settings" sidebar/mobile-drawer item, and a server-side gate at `src/app/(app)/[orgSlug]/projects/[projectSlug]/settings/layout.tsx` redirects any non-owner/admin who navigates directly to `/settings` back to the project timeline. The nav surfaces resolve the caller's effective project role via the `projectMember.myRole` procedure; the settings layout resolves it directly from the DB (explicit `ProjectMember` row, falling back to implicit access for org owners/admins).
+
 ## Permission Utilities
 
 **Source**: `src/lib/permissions.ts`

--- a/public/bryntum/stockholm-dark.css
+++ b/public/bryntum/stockholm-dark.css
@@ -1,4 +1,328 @@
 @charset "UTF-8";
+/*!
+ *
+ * Bryntum Gantt 7.2.2
+ *
+ * Copyright(c) 2026 Bryntum AB
+ * https://bryntum.com/contact
+ * https://bryntum.com/license
+ *
+ * Bryntum incorporates third-party code licensed under the MIT and Apache-2.0 licenses.
+ * See the licenses below or visit https://bryntum.com/products/gantt/docs/guide/Gantt/licenses
+ *
+ * # Third Party Notices
+ * 
+ * Bryntum uses the following third party libraries:
+ * 
+ * * [Font Awesome 6 Free](https://fontawesome.com/license/free) (MIT/SIL OFL 1.1)
+ * * [Roboto font (for Material theme only)](https://github.com/google/roboto) (Apache-2.0)
+ * * [Styling Cross-Browser Compatible Range Inputs with Sass](https://github.com/darlanrod/input-range-sass) (MIT)
+ * * [Tree Walker polyfill (only applies to Salesforce)](https://github.com/Krinkle/dom-TreeWalker-polyfill) (MIT)
+ * * [chronograph](https://github.com/bryntum/chronograph) (MIT)
+ * * [later.js](https://github.com/bunkat/later) (MIT)
+ * * [Monaco editor (only used in our demos)](https://microsoft.github.io/monaco-editor) (MIT)
+ * * Map/Set polyfill to fix performance issues for Salesforce LWS (MIT)
+ * * [Chart.js (when using Chart package)](https://github.com/chartjs/Chart.js) (MIT)
+ * 
+ * Note: the **chronograph** and **later.js** libraries are used in Bryntum Scheduler Pro and Bryntum Gantt, but they are
+ * listed for all Bryntum products since the distribution contains trial versions of the thin bundles for all other
+ * products. TreeWalker is only used in the LWC bundle for Salesforce. Roboto font is only used in the material theme.
+ * 
+ * ## Font Awesome 6 Free
+ * 
+ * [Font Awesome Free 6 by @fontawesome](https://fontawesome.com/)
+ * 
+ * Font Awesome Free is free, open source, and GPL friendly. You can use it for commercial projects, open source projects,
+ * or really almost whatever you want.
+ * 
+ * [Full Font Awesome Free license](https://fontawesome.com/license/free)
+ * 
+ * ## Roboto font
+ * 
+ * [Apache License Version 2.0, January 2004](https://www.apache.org/licenses/LICENSE-2.0)
+ * 
+ * TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ * 
+ * 1. Definitions.
+ * 
+ * "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9
+ * of this document.
+ * 
+ * "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+ * 
+ * "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are
+ * under common control with that entity. For the purposes of this definition,
+ * "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by
+ * contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+ * ownership of such entity.
+ * 
+ * "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+ * 
+ * "Source" form shall mean the preferred form for making modifications, including but not limited to software source code,
+ * documentation source, and configuration files.
+ * 
+ * "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including
+ * but not limited to compiled object code, generated documentation, and conversions to other media types.
+ * 
+ * "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as
+ * indicated by a copyright notice that is included in or attached to the work
+ * (an example is provided in the Appendix below).
+ * 
+ * "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work
+ * and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an
+ * original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain
+ * separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+ * 
+ * "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or
+ * additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the
+ * Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner.
+ * For the purposes of this definition, "submitted"
+ * means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including
+ * but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems
+ * that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding
+ * communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a
+ * Contribution."
+ * 
+ * "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received
+ * by Licensor and subsequently incorporated within the Work.
+ * 
+ * 2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to
+ *    You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce,
+ *    prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such
+ *    Derivative Works in Source or Object form.
+ * 
+ * 3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a
+ *    perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+ *    (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise
+ *    transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are
+ *    necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s)
+ *    with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (
+ *    including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within
+ *    the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this
+ *    License for that Work shall terminate as of the date such litigation is filed.
+ * 
+ * 4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with
+ *    or without modifications, and in Source or Object form, provided that You meet the following conditions:
+ * 
+ * (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+ * 
+ * (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+ * 
+ * (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark,
+ * and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the
+ * Derivative Works; and
+ * 
+ * (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute
+ * must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that
+ * do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file
+ * distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the
+ * Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices
+ * normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You
+ * may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the
+ * NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the
+ * License.
+ * 
+ * You may add Your own copyright statement to Your modifications and may provide additional or different license terms and
+ * conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole,
+ * provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this
+ * License.
+ * 
+ * 5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for
+ *    inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any
+ *    additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any
+ *    separate license agreement you may have executed with Licensor regarding such Contributions.
+ * 
+ * 6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product
+ *    names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and
+ *    reproducing the content of the NOTICE file.
+ * 
+ * 7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and
+ *    each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *    either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ *    MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness
+ *    of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this
+ *    License.
+ * 
+ * 8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or
+ *    otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing,
+ *    shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or
+ *    consequential damages of any character arising as a result of this License or out of the use or inability to use the
+ *    Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+ *    any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such
+ *    damages.
+ * 
+ * 9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose
+ *    to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or
+ *    rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and
+ *    on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and
+ *    hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason
+ *    of your accepting any such warranty or additional liability.
+ * 
+ * END OF TERMS AND CONDITIONS
+ * 
+ * APPENDIX: How to apply the Apache License to your work.
+ * 
+ * To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by
+ * brackets "[]"
+ * replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the
+ * appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose
+ * be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+ * 
+ * Copyright [yyyy] [name of copyright owner]
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * [APACHE LICENSE, VERSION 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "
+ * AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ * 
+ * ## Styling Cross-Browser Compatible Range Inputs with Sass
+ * 
+ * Github: [input-range-sass](https://github.com/darlanrod/input-range-sass)
+ * 
+ * Author: [Darlan Rod](https://github.com/darlanrod)
+ * 
+ * Version 1.4.1
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016 Darlan Rod
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## Tree Walker polyfill
+ * 
+ * The MIT License (MIT)
+ * 
+ * [Copyright 2013–2017 Timo Tijhof](https://github.com/Krinkle/dom-TreeWalker-polyfill)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## chronograph
+ * 
+ * GitHub: [chronograph](https://github.com/bryntum/chronograph)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2023 Bryntum
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## later.js
+ * 
+ * GitHub: [later.js](https://github.com/bunkat/later)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright © 2013 BunKat
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## Monaco editor
+ * 
+ * GitHub: [Monaco editor](https://microsoft.github.io/monaco-editor) (MIT)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016 - present Microsoft Corporation
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## Map/Set polyfill to fix performance issues for Salesforce LWS
+ * 
+ * Copyright © 2024 Certinia Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * 
+ * ## Chart.js
+ * 
+ * GitHub: [Chart.js](https://github.com/chartjs/Chart.js)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2014-2022 Chart.js Contributors
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
 
 /* Themes need more specific rules than Widgets etc. to make sure the values are applied no matter the import order */
 :root:not(.b-nothing), :host(:not(.b-nothing)) {
@@ -111,22 +435,6 @@
     /* TaskBoard */
     --b-task-board-card-background            : var(--b-neutral-95);
     --b-task-board-card-hover-background      : var(--b-neutral-92);
-
-    /* Heat map values ranging from lowest to highest intensity to create
-     * background colors to indicate how "hot" an element is, for example
-     * based on the number of events in a calendar cell.
-     */
-     /*
-      * Start color for the heatmap, representing the lowest intensity (e.g. 1 event in a calendar cell).
-      */
-    --b-heatmap-start          : oklab(0.53 -0.03 0.1);
-
-    /*
-     * End color for the heatmap, representing the highest intensity (e.g. 10 or more events in a calendar cell).
-     */
-    --b-heatmap-end            : oklab(0.38 0.13 0.03);
-
-    --b-heatmap-mix-blend-mode : hard-light;
 }
 
 /* Shades of primary color have to be specified per widget, for color-mix to work as intended */

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/settings/layout.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/settings/layout.tsx
@@ -1,0 +1,79 @@
+import { redirect } from "next/navigation";
+import { headers } from "next/headers";
+import { auth } from "@/lib/auth";
+import { db } from "@/server/db";
+import { canManageProjects, hasImplicitProjectAccess } from "@/lib/permissions";
+
+/**
+ * Server-side gate for the project settings route.
+ *
+ * Only owners and admins (MANAGE_PROJECTS) may view project settings — members
+ * are redirected to the project timeline. This is the authoritative check;
+ * hiding the sidebar link is only cosmetic.
+ *
+ * The role is resolved the same way projectProcedure does (explicit ProjectMember
+ * row, falling back to implicit access for org owners/admins) but without the
+ * side-effecting auto-create, since this is a read-only access check.
+ */
+export default async function ProjectSettingsLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ orgSlug: string; projectSlug: string }>;
+}) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) {
+    redirect("/sign-in");
+  }
+
+  const { orgSlug, projectSlug } = await params;
+
+  const organization = await db.organization.findUnique({
+    where: { slug: orgSlug },
+    select: { id: true },
+  });
+  if (!organization) {
+    redirect(`/${orgSlug}`);
+  }
+
+  const project = await db.project.findUnique({
+    where: {
+      organizationId_slug: { organizationId: organization.id, slug: projectSlug },
+    },
+    select: { id: true },
+  });
+  if (!project) {
+    redirect(`/${orgSlug}`);
+  }
+
+  const projectMember = await db.projectMember.findUnique({
+    where: {
+      userId_projectId: { userId: session.user.id, projectId: project.id },
+    },
+    select: { role: true },
+  });
+
+  let role: string | null = projectMember?.role ?? null;
+  if (!role) {
+    const orgMembership = await db.membership.findUnique({
+      where: {
+        userId_organizationId: {
+          userId: session.user.id,
+          organizationId: organization.id,
+        },
+      },
+      select: { role: true },
+    });
+    role =
+      orgMembership && hasImplicitProjectAccess(orgMembership.role)
+        ? orgMembership.role
+        : null;
+  }
+
+  if (!role || !canManageProjects(role)) {
+    redirect(`/${orgSlug}/projects/${projectSlug}/gantt`);
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/(app)/[orgSlug]/projects/[projectSlug]/settings/page.tsx
+++ b/src/app/(app)/[orgSlug]/projects/[projectSlug]/settings/page.tsx
@@ -281,7 +281,15 @@ function ProjectSettingsForm({
   const hasChanges = isDirty || imageChanged;
 
   return (
-    <>
+    <Paper
+      elevation={0}
+      sx={{
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: '12px',
+        overflow: 'hidden',
+      }}
+    >
       {GOOGLE_PLACES_API_KEY && (
         <Script
           src={`https://maps.googleapis.com/maps/api/js?key=${GOOGLE_PLACES_API_KEY}&libraries=places`}
@@ -290,9 +298,13 @@ function ProjectSettingsForm({
         />
       )}
 
-      <Box sx={{ px: 3, py: 2.5 }}>
-        {/* Preview */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2.5 }}>
+      {/* Card header — title + live preview on the left, Save action on the right */}
+      <Box sx={{
+        px: 3, py: 2.5, display: 'flex', alignItems: 'center',
+        justifyContent: 'space-between', gap: 2,
+        borderBottom: '1px solid', borderColor: 'divider',
+      }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, minWidth: 0 }}>
           <Box sx={{
             width: 48, height: 48, borderRadius: '12px',
             bgcolor: displayImageUrl ? 'transparent' : alpha(theme.palette.primary.main, 0.08),
@@ -308,7 +320,7 @@ function ProjectSettingsForm({
               color={theme.palette.primary.main}
             />
           </Box>
-          <Box>
+          <Box sx={{ minWidth: 0 }}>
             <Typography sx={{ fontSize: '1rem', fontWeight: 600, color: 'text.primary', lineHeight: 1.3 }}>
               Project Details
             </Typography>
@@ -317,16 +329,40 @@ function ProjectSettingsForm({
             </Typography>
           </Box>
         </Box>
+        <Button type="submit" form="settings-form" variant="contained"
+          disabled={!hasChanges || isUploading}
+          loading={updateMutation.isPending}
+          startIcon={<FloppyDisk size={15} />}
+          sx={{
+            flexShrink: 0, borderRadius: '8px', fontWeight: 600, fontSize: '0.8125rem',
+            px: 2.5, py: 1, textTransform: 'none',
+            boxShadow: `0 1px 3px ${alpha(theme.palette.primary.main, 0.3)}`,
+            '&:hover': { boxShadow: `0 4px 12px ${alpha(theme.palette.primary.main, 0.35)}` },
+          }}>
+          Save Changes
+        </Button>
+      </Box>
 
-        <form onSubmit={handleSubmit(onSubmit)} id="settings-form">
-          {/* Picker Mode Toggle */}
-          <Box
-            role="radiogroup" aria-label="Project image type"
-            sx={{
-              display: 'inline-flex', borderRadius: '8px',
-              bgcolor: alpha(theme.palette.divider, 0.08), p: '3px', mb: 1.5,
-            }}
-          >
+      <Box component="form" onSubmit={handleSubmit(onSubmit)} id="settings-form" sx={{ px: 3, py: 3 }}>
+        {/* Two-column body — identity picker on the left, text fields on the right */}
+        <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: { xs: 3, md: 5 } }}>
+          {/* Left column — image / icon identity */}
+          <Box sx={{ width: { xs: '100%', md: 300 }, flexShrink: 0 }}>
+            <Typography sx={{
+              fontSize: '0.6875rem', fontWeight: 600, color: 'text.secondary',
+              textTransform: 'uppercase', letterSpacing: '0.06em', mb: 1, userSelect: 'none',
+            }}>
+              Project Image
+            </Typography>
+
+            {/* Picker Mode Toggle */}
+            <Box
+              role="radiogroup" aria-label="Project image type"
+              sx={{
+                display: 'inline-flex', borderRadius: '8px',
+                bgcolor: alpha(theme.palette.divider, 0.08), p: '3px', mb: 1.5,
+              }}
+            >
             {(['icon', 'photo'] as const).map((mode) => {
               const isActive = pickerMode === mode;
               const Icon = mode === 'icon' ? Swatches : ImageIcon;
@@ -481,58 +517,44 @@ function ProjectSettingsForm({
               )}
             </Box>
           )}
-
-          {/* Project Name */}
-          <Controller name="name" control={control} render={({ field }) => (
-            <TextField {...field} id="settings-name-input"
-              label="Project Name"
-              placeholder="e.g. Downtown Tower Construction"
-              error={!!errors.name} helperText={errors.name?.message}
-              fullWidth autoComplete="off" />
-          )} />
-
-          {/* Location */}
-          <Box sx={{ mt: 2 }}>
-          <Controller name="location" control={control} render={({ field }) =>
-            useGooglePlaces ? (
-              <LocationAutocompleteField
-                value={field.value ?? ''}
-                onChange={(v, coords) => {
-                  field.onChange(v);
-                  if (coords) {
-                    setValue('latitude', coords.lat, { shouldDirty: true });
-                    setValue('longitude', coords.lng, { shouldDirty: true });
-                  } else {
-                    setValue('latitude', undefined, { shouldDirty: true });
-                    setValue('longitude', undefined, { shouldDirty: true });
-                  }
-                }}
-                error={!!errors.location} helperText={errors.location?.message} />
-            ) : (
-              <PlainLocationField value={field.value ?? ''} onChange={field.onChange}
-                error={!!errors.location} helperText={errors.location?.message} />
-            )
-          } />
           </Box>
 
-          {/* Save Button */}
-          <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2.5 }}>
-            <Button type="submit" form="settings-form" variant="contained"
-              disabled={!hasChanges || isUploading}
-              loading={updateMutation.isPending}
-              startIcon={<FloppyDisk size={15} />}
-              sx={{
-                borderRadius: '8px', fontWeight: 600, fontSize: '0.8125rem',
-                px: 2.5, py: 1, textTransform: 'none',
-                boxShadow: `0 1px 3px ${alpha(theme.palette.primary.main, 0.3)}`,
-                '&:hover': { boxShadow: `0 4px 12px ${alpha(theme.palette.primary.main, 0.35)}` },
-              }}>
-              Save Changes
-            </Button>
+          {/* Right column — name + location */}
+          <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2.5 }}>
+            {/* Project Name */}
+            <Controller name="name" control={control} render={({ field }) => (
+              <TextField {...field} id="settings-name-input"
+                label="Project Name"
+                placeholder="e.g. Downtown Tower Construction"
+                error={!!errors.name} helperText={errors.name?.message}
+                fullWidth autoComplete="off" />
+            )} />
+
+            {/* Location */}
+            <Controller name="location" control={control} render={({ field }) =>
+              useGooglePlaces ? (
+                <LocationAutocompleteField
+                  value={field.value ?? ''}
+                  onChange={(v, coords) => {
+                    field.onChange(v);
+                    if (coords) {
+                      setValue('latitude', coords.lat, { shouldDirty: true });
+                      setValue('longitude', coords.lng, { shouldDirty: true });
+                    } else {
+                      setValue('latitude', undefined, { shouldDirty: true });
+                      setValue('longitude', undefined, { shouldDirty: true });
+                    }
+                  }}
+                  error={!!errors.location} helperText={errors.location?.message} />
+              ) : (
+                <PlainLocationField value={field.value ?? ''} onChange={field.onChange}
+                  error={!!errors.location} helperText={errors.location?.message} />
+              )
+            } />
           </Box>
-        </form>
+        </Box>
       </Box>
-    </>
+    </Paper>
   );
 }
 
@@ -561,7 +583,7 @@ export default function ProjectSettingsPage() {
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4 }}
-      sx={{ p: 3, maxWidth: 800, mx: 'auto' }}
+      sx={{ p: 3 }}
     >
       {/* Header */}
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
@@ -575,71 +597,71 @@ export default function ProjectSettingsPage() {
         </Box>
       </Box>
 
-      <Paper
-        elevation={0}
-        sx={{
-          border: 1,
-          borderColor: 'divider',
-          borderRadius: '12px',
-          overflow: 'hidden',
-          transition: 'border-color 0.2s ease',
-        }}
-      >
-        {/* Project Details — edit form */}
-        {canEdit ? (
-          <ProjectSettingsForm projectId={projectId} organizationId={organizationId} />
-        ) : (
-          <Box sx={{ px: 3, py: 2.5 }}>
-            <Typography sx={{ color: 'text.secondary', fontSize: '0.875rem' }}>
-              Only project owners and admins can edit project settings.
+      {/* Project Details — edit form */}
+      {canEdit ? (
+        <ProjectSettingsForm projectId={projectId} organizationId={organizationId} />
+      ) : (
+        <Paper
+          elevation={0}
+          sx={{ border: 1, borderColor: 'divider', borderRadius: '12px', px: 3, py: 2.5 }}
+        >
+          <Typography sx={{ color: 'text.secondary', fontSize: '0.875rem' }}>
+            Only project owners and admins can edit project settings.
+          </Typography>
+        </Paper>
+      )}
+
+      {/* Danger Zone — delete */}
+      {canDelete && (
+        <Paper
+          elevation={0}
+          sx={{
+            mt: 3,
+            border: 1,
+            borderColor: alpha(theme.palette.error.main, 0.25),
+            borderRadius: '12px',
+            overflow: 'hidden',
+          }}
+        >
+          <Box sx={{
+            px: 3, py: 1.5,
+            bgcolor: alpha(theme.palette.error.main, 0.04),
+            borderBottom: '1px solid',
+            borderColor: alpha(theme.palette.error.main, 0.15),
+            display: 'flex', alignItems: 'center', gap: 1,
+          }}>
+            <Warning size={14} color={theme.palette.error.main} />
+            <Typography sx={{
+              fontSize: '0.75rem', fontWeight: 600, color: 'error.main',
+              textTransform: 'uppercase', letterSpacing: '0.05em',
+            }}>
+              Danger Zone
             </Typography>
           </Box>
-        )}
-
-        {/* Danger Zone — delete */}
-        {canDelete && (
-          <>
-            <Box sx={{
-              px: 3, py: 1.5,
-              bgcolor: alpha(theme.palette.error.main, 0.04),
-              borderTop: '1px solid',
-              borderBottom: '1px solid',
-              borderColor: alpha(theme.palette.error.main, 0.15),
-              display: 'flex', alignItems: 'center', gap: 1,
-            }}>
-              <Warning size={14} color={theme.palette.error.main} />
-              <Typography sx={{
-                fontSize: '0.75rem', fontWeight: 600, color: 'error.main',
-                textTransform: 'uppercase', letterSpacing: '0.05em',
-              }}>
-                Danger Zone
+          <Box sx={{
+            px: 3, py: 2.5, display: 'flex', alignItems: 'center',
+            justifyContent: 'space-between', gap: 2,
+          }}>
+            <Box>
+              <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary', mb: 0.25 }}>
+                Delete this project
+              </Typography>
+              <Typography sx={{ fontSize: '0.8125rem', color: 'text.secondary', lineHeight: 1.5 }}>
+                Permanently delete this project and all its data. This cannot be undone.
               </Typography>
             </Box>
-            <Box sx={{
-              px: 3, py: 2.5, display: 'flex', alignItems: 'center',
-              justifyContent: 'space-between', gap: 2,
-            }}>
-              <Box>
-                <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary', mb: 0.25 }}>
-                  Delete this project
-                </Typography>
-                <Typography sx={{ fontSize: '0.8125rem', color: 'text.secondary', lineHeight: 1.5 }}>
-                  Permanently delete this project and all its data. This cannot be undone.
-                </Typography>
-              </Box>
-              <Button variant="outlined" color="error"
-                onClick={() => setDeleteDialogOpen(true)}
-                startIcon={<Trash size={14} />}
-                sx={{
-                  flexShrink: 0, borderRadius: '8px', fontWeight: 600,
-                  fontSize: '0.8125rem', textTransform: 'none',
-                }}>
-                Delete
-              </Button>
-            </Box>
-          </>
-        )}
-      </Paper>
+            <Button variant="outlined" color="error"
+              onClick={() => setDeleteDialogOpen(true)}
+              startIcon={<Trash size={14} />}
+              sx={{
+                flexShrink: 0, borderRadius: '8px', fontWeight: 600,
+                fontSize: '0.8125rem', textTransform: 'none',
+              }}>
+              Delete
+            </Button>
+          </Box>
+        </Paper>
+      )}
 
       {/* Delete Project Dialog */}
       <DeleteProjectDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -16,6 +16,7 @@ import { projectNavItems, orgNavItems, getProjectNavHref, getOrgNavHref, SIDEBAR
 import OrgSwitcher from './OrgSwitcher';
 
 import { api } from '@/trpc/react';
+import { canManageProjects } from '@/lib/permissions';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
 import { useProjectSwitcher } from '@/hooks/useProjectSwitcher';
 import { authClient, signOut } from '@/lib/auth-client';
@@ -65,6 +66,16 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
     { enabled: !!projectId, retry: false },
   );
   const memberCount = projectMembers.length;
+
+  // Only owners/admins may see project settings — hide the nav item otherwise.
+  const { data: myProjectRole } = api.projectMember.myRole.useQuery(
+    { projectId },
+    { enabled: !!projectId, retry: false },
+  );
+  const canManageProject = myProjectRole ? canManageProjects(myProjectRole.role) : false;
+  const visibleProjectNavItems = projectNavItems.filter(
+    (i) => i.id !== 'project-settings' || canManageProject,
+  );
 
   const [profileOpen, setProfileOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
@@ -178,7 +189,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
         {SIDEBAR_SECTIONS.map((section, sectionIdx) => {
           const items: NavItem[] = [
             ...orgNavItems.filter((i) => i.section === section.id),
-            ...projectNavItems.filter((i) => i.section === section.id),
+            ...visibleProjectNavItems.filter((i) => i.section === section.id),
           ];
           if (items.length === 0) return null;
 

--- a/src/components/layout/OrgSwitcher.tsx
+++ b/src/components/layout/OrgSwitcher.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useLoading } from '@/components/providers/LoadingProvider';
 import OrgAvatar from '@/components/ui/OrgAvatar';
+import { formatMembership } from '@/lib/utils/formatting';
 
 export default function OrgSwitcher({ collapsed = false }: { collapsed?: boolean }) {
   const [orgMenuOpen, setOrgMenuOpen] = useState(false);
@@ -104,19 +105,13 @@ export default function OrgSwitcher({ collapsed = false }: { collapsed?: boolean
                 sx={{
                   display: 'inline-flex',
                   alignItems: 'center',
-                  fontSize: '0.5625rem',
-                  fontWeight: 600,
-                  letterSpacing: '0.08em',
-                  textTransform: 'uppercase',
+                  fontSize: '0.6875rem',
+                  fontWeight: 500,
                   color: 'text.secondary',
-                  bgcolor: 'action.selected',
-                  px: 0.625,
-                  py: '2px',
-                  borderRadius: '4px',
                   lineHeight: 1.2,
                 }}
               >
-                {currentOrg.role}
+                {formatMembership(currentOrg.role)}
               </Box>
             )}
           </>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -9,6 +9,7 @@ import { projectNavItems, orgNavItems, getProjectNavHref, getOrgNavHref, SIDEBAR
 import OrgSwitcher from './OrgSwitcher';
 
 import { api } from '@/trpc/react';
+import { canManageProjects } from '@/lib/permissions';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
 import { useProjectSwitcher } from '@/hooks/useProjectSwitcher';
 import { LogoIcon } from '@/components/ui/Logo';
@@ -48,6 +49,16 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
     { enabled: !!projectId, retry: false },
   );
   const memberCount = projectMembers.length;
+
+  // Only owners/admins may see project settings — hide the nav item otherwise.
+  const { data: myProjectRole } = api.projectMember.myRole.useQuery(
+    { projectId },
+    { enabled: !!projectId, retry: false },
+  );
+  const canManageProject = myProjectRole ? canManageProjects(myProjectRole.role) : false;
+  const visibleProjectNavItems = projectNavItems.filter(
+    (i) => i.id !== 'project-settings' || canManageProject,
+  );
 
   const [isMac, setIsMac] = useState(false);
 
@@ -197,7 +208,7 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
         {SIDEBAR_SECTIONS.map((section, sectionIdx) => {
           const sectionItems: NavItem[] = [
             ...orgNavItems.filter((i) => i.section === section.id),
-            ...projectNavItems.filter((i) => i.section === section.id),
+            ...visibleProjectNavItems.filter((i) => i.section === section.id),
           ];
           if (sectionItems.length === 0) return null;
 

--- a/src/lib/utils/formatting.ts
+++ b/src/lib/utils/formatting.ts
@@ -10,6 +10,20 @@ export function formatRole(role: string): string {
 }
 
 /**
+ * Frames an org role as an explicit first-person membership statement,
+ * making it clear the role describes the current user — not the org.
+ * e.g. "owner" → "You're the owner", "member" → "You're a member"
+ */
+export function formatMembership(role: string): string {
+  const phrases: Record<string, string> = {
+    owner: "You're the owner",
+    admin: "You're an admin",
+    member: "You're a member",
+  };
+  return phrases[role.toLowerCase()] ?? `You're ${formatRole(role)}`;
+}
+
+/**
  * Extracts initials from a name string.
  * e.g. "John Doe" → "JD", "Alice" → "A", null → "?"
  */

--- a/src/server/api/routers/projectMember.ts
+++ b/src/server/api/routers/projectMember.ts
@@ -9,6 +9,13 @@ import {
 import { bulkAddProjectMembersSchema } from "@/lib/validations/projectMember";
 
 export const projectMemberRouter = createTRPCRouter({
+  // Returns the calling user's effective role on this project. projectProcedure
+  // resolves the role authoritatively, including auto-creating a ProjectMember
+  // row for org owners/admins who have implicit access but no explicit row.
+  myRole: projectProcedure.query(({ ctx }) => {
+    return { role: ctx.projectMember.role };
+  }),
+
   list: projectProcedure.query(async ({ ctx, input }) => {
     const members = await ctx.db.projectMember.findMany({
       where: {


### PR DESCRIPTION
Gates the Project Settings surface to `MANAGE_PROJECTS`: a new server-side layout (`settings/layout.tsx`) redirects members away from the `/settings` route, and the sidebar and mobile drawer hide the "Project Settings" nav item using a new `projectMember.myRole` query that resolves the caller's effective project role (including implicit access for org owners/admins). This branch also bundles in-progress polish: a two-column redesign of the settings form, the org role badge reworded as a first-person membership statement (`formatMembership`, e.g. "You're the owner"), and the synced Bryntum `stockholm-dark` theme CSS. `auth-and-permissions.md` is updated to document the new gate. Verified with `tsc --noEmit` (clean) and `npm test` (224/224 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)