### PR TITLE
Add dedicated per-task cover image upload for Gantt tasks

### DIFF
--- a/claudedocs/components-guide.md
+++ b/claudedocs/components-guide.md
@@ -171,8 +171,9 @@ Both live in the private `construction-uploads` store. Raw blob URLs are **never
 |---|---|---|---|
 | `Document.blobUrl` | `/api/blob/[documentId]` | project member | any tRPC document query or `/api/upload` |
 | `Project.imageUrl` | `/api/blob/project-image/[projectId]` | org member | `project.list/getById/getBySlug/getActive/setActive/update` + `[orgSlug]/projects/[projectSlug]/layout.tsx` |
+| `GanttTask.coverImageUrl` | `/api/blob/task-cover/[taskId]` | org member | `gantt.taskDetail` |
 
-Gantt task covers are no longer a separate blob — a "cover" is just a photo in the task's Photos folder that's been pinned via `gantt.pinPhoto` (sets `GanttTask.coverDocumentId`, an FK to `Document`). The cover renders through the normal `/api/blob/[documentId]` proxy. See `CoverImageBanner.tsx` for the gallery UI and pinning flow.
+Each Gantt task has its own dedicated cover image — a standalone upload, **not** tied to the Photos folder or the `Document` table. The cover is a private blob whose URL is stored directly on `GanttTask.coverImageUrl` (mirrors the `Project.imageUrl` pattern). Upload/replace go through `POST /api/upload/task-cover` (which persists `coverImageUrl` immediately and cleans up the previous blob), removal through `DELETE` on the same route; both are gated on `canManageProjects`. `gantt.taskDetail` rewrites the stored URL to the `/api/blob/task-cover/[taskId]` proxy. See `CoverImageBanner.tsx` — it uploads via `trackUpload` (so the global toast chip shows progress) and supports drag-and-drop, replace, and remove. The legacy `gantt.pinPhoto` / `coverDocumentId` pin-from-Photos mechanism has been removed (the `coverDocumentId` column is left in place, unused).
 
 Client code uses these like any other URL (`<img src>`, `<iframe src>`, `<a href>`, `fetch()`, `window.open()`); the browser sends its session cookie and the proxy enforces tenancy. Never attempt to render the raw blob CDN URL — it will 403.
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -180,7 +180,7 @@ model Document {
     uploadedBy    User                 @relation(fields: [uploadedById], references: [id], onDelete: Cascade)
     approvedBy    User?                @relation("ApprovedByUser", fields: [approvedById], references: [id], onDelete: SetNull)
     slot          TaskRequirementSlot? @relation(fields: [slotId], references: [id], onDelete: SetNull)
-    coverForTasks GanttTask[]          @relation("TaskCoverDocument")
+    coverForTasks GanttTask[]          @relation("TaskCoverDocument") // Deprecated: task covers now use GanttTask.coverImageUrl
 
     @@index([projectId, taskId, folderId])
     @@index([projectId])
@@ -285,8 +285,8 @@ model GanttTask {
     note               String?
     csiCode            String?
     baselines          Json?
-    coverImageUrl          String?
-    coverDocumentId        String?
+    coverImageUrl          String?   // task cover image (private blob URL) — see claudedocs/components-guide.md
+    coverDocumentId        String?   // Deprecated: superseded by coverImageUrl; unused, pending a follow-up drop migration
     requiredSubmittals     Int?
     requiredInspections    Int?
     updatedAt              DateTime  @default(now()) @updatedAt
@@ -297,7 +297,7 @@ model GanttTask {
     assignments  GanttAssignment[]
     dependenciesFrom GanttDependency[] @relation("FromTask")
     dependenciesTo   GanttDependency[] @relation("ToTask")
-    coverDocument    Document? @relation("TaskCoverDocument", fields: [coverDocumentId], references: [id], onDelete: SetNull)
+    coverDocument    Document? @relation("TaskCoverDocument", fields: [coverDocumentId], references: [id], onDelete: SetNull) // Deprecated with coverDocumentId — pending drop
     requirementSlots TaskRequirementSlot[]
 
     @@index([projectId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -180,7 +180,7 @@ model Document {
     uploadedBy    User                 @relation(fields: [uploadedById], references: [id], onDelete: Cascade)
     approvedBy    User?                @relation("ApprovedByUser", fields: [approvedById], references: [id], onDelete: SetNull)
     slot          TaskRequirementSlot? @relation(fields: [slotId], references: [id], onDelete: SetNull)
-    coverForTasks GanttTask[]          @relation("TaskCoverDocument") // Deprecated: task covers now use GanttTask.coverImageUrl
+    coverForTasks GanttTask[]          @relation("TaskCoverDocument")
 
     @@index([projectId, taskId, folderId])
     @@index([projectId])
@@ -285,8 +285,8 @@ model GanttTask {
     note               String?
     csiCode            String?
     baselines          Json?
-    coverImageUrl          String?   // task cover image (private blob URL) — see claudedocs/components-guide.md
-    coverDocumentId        String?   // Deprecated: superseded by coverImageUrl; unused, pending a follow-up drop migration
+    coverImageUrl          String?
+    coverDocumentId        String?
     requiredSubmittals     Int?
     requiredInspections    Int?
     updatedAt              DateTime  @default(now()) @updatedAt
@@ -297,7 +297,7 @@ model GanttTask {
     assignments  GanttAssignment[]
     dependenciesFrom GanttDependency[] @relation("FromTask")
     dependenciesTo   GanttDependency[] @relation("ToTask")
-    coverDocument    Document? @relation("TaskCoverDocument", fields: [coverDocumentId], references: [id], onDelete: SetNull) // Deprecated with coverDocumentId — pending drop
+    coverDocument    Document? @relation("TaskCoverDocument", fields: [coverDocumentId], references: [id], onDelete: SetNull)
     requirementSlots TaskRequirementSlot[]
 
     @@index([projectId])

--- a/public/bryntum/stockholm-dark.css
+++ b/public/bryntum/stockholm-dark.css
@@ -1,4 +1,328 @@
 @charset "UTF-8";
+/*!
+ *
+ * Bryntum Gantt 7.2.2
+ *
+ * Copyright(c) 2026 Bryntum AB
+ * https://bryntum.com/contact
+ * https://bryntum.com/license
+ *
+ * Bryntum incorporates third-party code licensed under the MIT and Apache-2.0 licenses.
+ * See the licenses below or visit https://bryntum.com/products/gantt/docs/guide/Gantt/licenses
+ *
+ * # Third Party Notices
+ * 
+ * Bryntum uses the following third party libraries:
+ * 
+ * * [Font Awesome 6 Free](https://fontawesome.com/license/free) (MIT/SIL OFL 1.1)
+ * * [Roboto font (for Material theme only)](https://github.com/google/roboto) (Apache-2.0)
+ * * [Styling Cross-Browser Compatible Range Inputs with Sass](https://github.com/darlanrod/input-range-sass) (MIT)
+ * * [Tree Walker polyfill (only applies to Salesforce)](https://github.com/Krinkle/dom-TreeWalker-polyfill) (MIT)
+ * * [chronograph](https://github.com/bryntum/chronograph) (MIT)
+ * * [later.js](https://github.com/bunkat/later) (MIT)
+ * * [Monaco editor (only used in our demos)](https://microsoft.github.io/monaco-editor) (MIT)
+ * * Map/Set polyfill to fix performance issues for Salesforce LWS (MIT)
+ * * [Chart.js (when using Chart package)](https://github.com/chartjs/Chart.js) (MIT)
+ * 
+ * Note: the **chronograph** and **later.js** libraries are used in Bryntum Scheduler Pro and Bryntum Gantt, but they are
+ * listed for all Bryntum products since the distribution contains trial versions of the thin bundles for all other
+ * products. TreeWalker is only used in the LWC bundle for Salesforce. Roboto font is only used in the material theme.
+ * 
+ * ## Font Awesome 6 Free
+ * 
+ * [Font Awesome Free 6 by @fontawesome](https://fontawesome.com/)
+ * 
+ * Font Awesome Free is free, open source, and GPL friendly. You can use it for commercial projects, open source projects,
+ * or really almost whatever you want.
+ * 
+ * [Full Font Awesome Free license](https://fontawesome.com/license/free)
+ * 
+ * ## Roboto font
+ * 
+ * [Apache License Version 2.0, January 2004](https://www.apache.org/licenses/LICENSE-2.0)
+ * 
+ * TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ * 
+ * 1. Definitions.
+ * 
+ * "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9
+ * of this document.
+ * 
+ * "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+ * 
+ * "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are
+ * under common control with that entity. For the purposes of this definition,
+ * "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by
+ * contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+ * ownership of such entity.
+ * 
+ * "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+ * 
+ * "Source" form shall mean the preferred form for making modifications, including but not limited to software source code,
+ * documentation source, and configuration files.
+ * 
+ * "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including
+ * but not limited to compiled object code, generated documentation, and conversions to other media types.
+ * 
+ * "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as
+ * indicated by a copyright notice that is included in or attached to the work
+ * (an example is provided in the Appendix below).
+ * 
+ * "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work
+ * and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an
+ * original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain
+ * separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+ * 
+ * "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or
+ * additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the
+ * Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner.
+ * For the purposes of this definition, "submitted"
+ * means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including
+ * but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems
+ * that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding
+ * communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a
+ * Contribution."
+ * 
+ * "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received
+ * by Licensor and subsequently incorporated within the Work.
+ * 
+ * 2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to
+ *    You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce,
+ *    prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such
+ *    Derivative Works in Source or Object form.
+ * 
+ * 3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a
+ *    perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+ *    (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise
+ *    transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are
+ *    necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s)
+ *    with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (
+ *    including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within
+ *    the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this
+ *    License for that Work shall terminate as of the date such litigation is filed.
+ * 
+ * 4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with
+ *    or without modifications, and in Source or Object form, provided that You meet the following conditions:
+ * 
+ * (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+ * 
+ * (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+ * 
+ * (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark,
+ * and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the
+ * Derivative Works; and
+ * 
+ * (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute
+ * must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that
+ * do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file
+ * distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the
+ * Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices
+ * normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You
+ * may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the
+ * NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the
+ * License.
+ * 
+ * You may add Your own copyright statement to Your modifications and may provide additional or different license terms and
+ * conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole,
+ * provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this
+ * License.
+ * 
+ * 5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for
+ *    inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any
+ *    additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any
+ *    separate license agreement you may have executed with Licensor regarding such Contributions.
+ * 
+ * 6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product
+ *    names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and
+ *    reproducing the content of the NOTICE file.
+ * 
+ * 7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and
+ *    each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *    either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ *    MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness
+ *    of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this
+ *    License.
+ * 
+ * 8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or
+ *    otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing,
+ *    shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or
+ *    consequential damages of any character arising as a result of this License or out of the use or inability to use the
+ *    Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+ *    any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such
+ *    damages.
+ * 
+ * 9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose
+ *    to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or
+ *    rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and
+ *    on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and
+ *    hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason
+ *    of your accepting any such warranty or additional liability.
+ * 
+ * END OF TERMS AND CONDITIONS
+ * 
+ * APPENDIX: How to apply the Apache License to your work.
+ * 
+ * To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by
+ * brackets "[]"
+ * replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the
+ * appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose
+ * be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+ * 
+ * Copyright [yyyy] [name of copyright owner]
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * [APACHE LICENSE, VERSION 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "
+ * AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ * 
+ * ## Styling Cross-Browser Compatible Range Inputs with Sass
+ * 
+ * Github: [input-range-sass](https://github.com/darlanrod/input-range-sass)
+ * 
+ * Author: [Darlan Rod](https://github.com/darlanrod)
+ * 
+ * Version 1.4.1
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016 Darlan Rod
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## Tree Walker polyfill
+ * 
+ * The MIT License (MIT)
+ * 
+ * [Copyright 2013–2017 Timo Tijhof](https://github.com/Krinkle/dom-TreeWalker-polyfill)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## chronograph
+ * 
+ * GitHub: [chronograph](https://github.com/bryntum/chronograph)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2023 Bryntum
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## later.js
+ * 
+ * GitHub: [later.js](https://github.com/bunkat/later)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright © 2013 BunKat
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## Monaco editor
+ * 
+ * GitHub: [Monaco editor](https://microsoft.github.io/monaco-editor) (MIT)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016 - present Microsoft Corporation
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## Map/Set polyfill to fix performance issues for Salesforce LWS
+ * 
+ * Copyright © 2024 Certinia Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * 
+ * ## Chart.js
+ * 
+ * GitHub: [Chart.js](https://github.com/chartjs/Chart.js)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2014-2022 Chart.js Contributors
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
 
 /* Themes need more specific rules than Widgets etc. to make sure the values are applied no matter the import order */
 :root:not(.b-nothing), :host(:not(.b-nothing)) {
@@ -111,22 +435,6 @@
     /* TaskBoard */
     --b-task-board-card-background            : var(--b-neutral-95);
     --b-task-board-card-hover-background      : var(--b-neutral-92);
-
-    /* Heat map values ranging from lowest to highest intensity to create
-     * background colors to indicate how "hot" an element is, for example
-     * based on the number of events in a calendar cell.
-     */
-     /*
-      * Start color for the heatmap, representing the lowest intensity (e.g. 1 event in a calendar cell).
-      */
-    --b-heatmap-start          : oklab(0.53 -0.03 0.1);
-
-    /*
-     * End color for the heatmap, representing the highest intensity (e.g. 10 or more events in a calendar cell).
-     */
-    --b-heatmap-end            : oklab(0.38 0.13 0.03);
-
-    --b-heatmap-mix-blend-mode : hard-light;
 }
 
 /* Shades of primary color have to be specified per widget, for color-mix to work as intended */

--- a/src/app/api/blob/task-cover/[taskId]/route.ts
+++ b/src/app/api/blob/task-cover/[taskId]/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/server/db";
+import { serveBlob } from "../../_serveBlob";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ taskId: string }> },
+) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session?.user) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const { taskId } = await params;
+
+  const task = await db.ganttTask.findUnique({
+    where: { id: taskId },
+    select: {
+      coverImageUrl: true,
+      project: { select: { organizationId: true } },
+    },
+  });
+
+  if (!task || !task.coverImageUrl) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  const orgMembership = await db.membership.findUnique({
+    where: {
+      userId_organizationId: {
+        userId: session.user.id,
+        organizationId: task.project.organizationId,
+      },
+    },
+    select: { id: true },
+  });
+
+  if (!orgMembership) {
+    return new NextResponse("Forbidden", { status: 403 });
+  }
+
+  return serveBlob(req, { blobUrl: task.coverImageUrl, fallbackContentType: "image/jpeg" });
+}

--- a/src/app/api/upload/task-cover/route.ts
+++ b/src/app/api/upload/task-cover/route.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from "next/server";
+import { put, del } from "@vercel/blob";
+import { db } from "@/server/db";
+import { auth } from "@/lib/auth";
+import { canManageProjects } from "@/lib/permissions";
+import { taskCoverProxyUrl } from "@/lib/blobProxy";
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+const ALLOWED_IMAGE_TYPES = [
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+];
+
+/**
+ * Resolve the task + its project, verify the caller can manage the project,
+ * and return the task's current cover URL (for cleanup on replace/remove).
+ */
+async function authorizeTaskCover(
+  userId: string,
+  projectId: string,
+  taskId: string,
+): Promise<
+  | { ok: true; coverImageUrl: string | null }
+  | { ok: false; status: number; error: string }
+> {
+  const task = await db.ganttTask.findFirst({
+    where: { id: taskId, projectId },
+    select: {
+      coverImageUrl: true,
+      project: { select: { organizationId: true } },
+    },
+  });
+
+  if (!task) {
+    return { ok: false, status: 404, error: "Task not found" };
+  }
+
+  const membership = await db.membership.findUnique({
+    where: {
+      userId_organizationId: {
+        userId,
+        organizationId: task.project.organizationId,
+      },
+    },
+    select: { role: true },
+  });
+
+  if (!membership) {
+    return { ok: false, status: 403, error: "Access denied" };
+  }
+
+  if (!canManageProjects(membership.role)) {
+    return {
+      ok: false,
+      status: 403,
+      error: "You don't have permission to change the task cover",
+    };
+  }
+
+  return { ok: true, coverImageUrl: task.coverImageUrl };
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await auth.api.getSession({ headers: req.headers });
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const formData = await req.formData();
+    const file = formData.get("file") as File | null;
+    const projectId = formData.get("projectId") as string | null;
+    const taskId = formData.get("taskId") as string | null;
+
+    if (!file || !projectId || !taskId) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ error: "File size exceeds 10MB limit" }, { status: 400 });
+    }
+
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+      return NextResponse.json(
+        { error: "Only image files are allowed (JPEG, PNG, WebP, GIF)" },
+        { status: 400 },
+      );
+    }
+
+    const authResult = await authorizeTaskCover(session.user.id, projectId, taskId);
+    if (!authResult.ok) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+    }
+
+    const blob = await put(
+      `projects/${projectId}/_covers/${taskId}/${file.name}`,
+      file,
+      { access: "private", addRandomSuffix: true, contentType: file.type },
+    );
+
+    await db.ganttTask.update({
+      where: { id: taskId },
+      data: { coverImageUrl: blob.url },
+    });
+
+    // Best-effort cleanup of the previous cover blob to avoid orphans.
+    if (authResult.coverImageUrl) {
+      try {
+        await del(authResult.coverImageUrl);
+      } catch {
+        // Old blob may already be gone — ignore.
+      }
+    }
+
+    return NextResponse.json({ imageUrl: taskCoverProxyUrl(taskId) });
+  } catch (error) {
+    console.error("Task cover upload error:", error);
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const session = await auth.api.getSession({ headers: req.headers });
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { projectId, taskId } = (await req.json()) as {
+      projectId?: string;
+      taskId?: string;
+    };
+
+    if (!projectId || !taskId) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
+
+    const authResult = await authorizeTaskCover(session.user.id, projectId, taskId);
+    if (!authResult.ok) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+    }
+
+    await db.ganttTask.update({
+      where: { id: taskId },
+      data: { coverImageUrl: null },
+    });
+
+    if (authResult.coverImageUrl) {
+      try {
+        await del(authResult.coverImageUrl);
+      } catch {
+        // Blob may already be gone — ignore.
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Task cover delete error:", error);
+    return NextResponse.json({ error: "Delete failed" }, { status: 500 });
+  }
+}

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -21,7 +21,7 @@ import FolderRow from './task-popover/FolderRow';
 import FilePreviewPanel from './task-popover/FilePreviewPanel';
 import CsiCodePanel from './task-popover/CsiCodePanel';
 import SubmittalDrawer from './SubmittalDrawer';
-import { canApproveDocuments } from '@/lib/permissions';
+import { canApproveDocuments, canManageProjects } from '@/lib/permissions';
 import type { SlotKind } from '@/lib/validations/gantt';
 
 type RightPanel = { type: 'preview'; doc: PreviewDoc } | { type: 'csi' } | null;
@@ -47,6 +47,7 @@ export function TaskDetailsPopover({
   const { memberRole } = useOrgContext();
   const canManageRequirements = memberRole === 'owner' || memberRole === 'admin';
   const canManageSlots = canApproveDocuments(memberRole);
+  const canManageCover = canManageProjects(memberRole);
 
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
   const [uploadTarget, setUploadTarget] = useState<{ folder: { id: string; name: string }; slotId?: string } | null>(null);
@@ -262,10 +263,7 @@ export function TaskDetailsPopover({
   const submittalsCurrent = submittalsCounts.approved;
   const inspectionsCurrent = inspectionsCounts.approved;
 
-  const coverDocumentId = taskDetail?.coverDocumentId ?? null;
-  const photos = ((allDocs ?? []) as DocumentItem[]).filter(
-    (d) => d.folderId === 'photos' && d.mimeType.startsWith('image/')
-  );
+  const coverImageUrl = taskDetail?.coverImageUrl ?? null;
   const hasRightPanel = rightPanel !== null;
   const previewDoc = rightPanel?.type === 'preview' ? rightPanel.doc : null;
   const selectedDocId = previewDoc?.id ?? null;
@@ -353,8 +351,8 @@ export function TaskDetailsPopover({
               taskId={taskId}
               projectId={projectId}
               organizationId={organizationId}
-              coverDocumentId={coverDocumentId}
-              photos={photos}
+              coverImageUrl={coverImageUrl}
+              canManage={canManageCover}
             />
 
             <Divider sx={{ mx: 2 }} />
@@ -486,7 +484,6 @@ export function TaskDetailsPopover({
                       projectId={projectId}
                       taskId={taskId}
                       organizationId={organizationId}
-                      pinnedDocId={coverDocumentId}
                       onManage={
                         folder.trackable && canManageSlots
                           ? () => setDrawerKind(folder.id === 'submittals' ? 'submittal' : 'inspection')

--- a/src/components/bryntum/components/task-popover/CoverImageBanner.tsx
+++ b/src/components/bryntum/components/task-popover/CoverImageBanner.tsx
@@ -1,89 +1,150 @@
 'use client';
 
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { useDropzone } from 'react-dropzone';
 import { Box, Typography } from '@mui/material';
-import { ImageSquare, PushPin } from '@phosphor-icons/react';
+import { ImageSquare, UploadSimple, ArrowsClockwise, Trash } from '@phosphor-icons/react';
 import { api } from '@/trpc/react';
 import { useSnackbar } from '@/hooks/useSnackbar';
-import type { DocumentItem } from './types';
+import { trackUpload } from '@/store/uploadStatusStore';
 
 interface CoverImageBannerProps {
   taskId?: string;
   projectId: string;
   organizationId: string;
-  coverDocumentId: string | null;
-  photos: DocumentItem[];
+  coverImageUrl: string | null;
+  canManage: boolean;
 }
 
-const STRIP_MAX = 5;
 const HERO_HEIGHT = 160;
-const THUMB_SIZE = 44;
-const EMPTY_HEIGHT = HERO_HEIGHT + 4 + THUMB_SIZE;
+const MAX_BYTES = 10 * 1024 * 1024; // 10MB — matches /api/upload/task-cover
 
 export default function CoverImageBanner({
   taskId,
   projectId,
   organizationId,
-  coverDocumentId,
-  photos,
+  coverImageUrl,
+  canManage,
 }: CoverImageBannerProps) {
   const { showSnackbar } = useSnackbar();
   const utils = api.useUtils();
-  const [viewedId, setViewedId] = useState<string | null>(null);
   const [heroLoaded, setHeroLoaded] = useState(false);
+  const [busy, setBusy] = useState(false);
+  // Cache-bust token bumped on each successful upload. taskCoverProxyUrl is
+  // version-less, so without this the replaced cover keeps the same <img src>
+  // and the browser never refetches the new blob.
+  const [coverVersion, setCoverVersion] = useState(0);
 
-  const pinMutation = api.gantt.pinPhoto.useMutation({
-    onSuccess: () => {
-      if (taskId) {
-        void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId });
-      }
-    },
-    onError: (err) => showSnackbar(err.message || 'Failed to pin photo', 'error'),
-  });
-
-  // Reset local "viewed" state when task or pinned photo changes
+  // Reset the load shimmer whenever the cover source changes.
   useEffect(() => {
-    setViewedId(null);
     setHeroLoaded(false);
-  }, [taskId, coverDocumentId]);
+  }, [coverImageUrl]);
 
-  // Order photos: pinned first, then newest-first. `photos` arrives newest-first from listByTask.
-  const orderedPhotos = useMemo(() => {
-    if (!coverDocumentId) return photos;
-    const pinned = photos.find((p) => p.id === coverDocumentId);
-    if (!pinned) return photos;
-    return [pinned, ...photos.filter((p) => p.id !== coverDocumentId)];
-  }, [photos, coverDocumentId]);
+  const refreshCover = useCallback(() => {
+    if (!taskId) return;
+    void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId });
+  }, [organizationId, projectId, taskId, utils]);
 
-  const defaultHero = orderedPhotos[0] ?? null;
-  const hero = viewedId
-    ? (orderedPhotos.find((p) => p.id === viewedId) ?? defaultHero)
-    : defaultHero;
-
-  const stripPhotos = orderedPhotos.filter((p) => p.id !== hero?.id);
-  const visibleStrip = stripPhotos.slice(0, STRIP_MAX);
-  const overflowCount = stripPhotos.length - visibleStrip.length;
-
-  const handlePin = useCallback(
-    (documentId: string) => {
-      if (!taskId) return;
-      pinMutation.mutate({ projectId, taskId, documentId });
+  const uploadFile = useCallback(
+    async (file: File) => {
+      if (!taskId || busy) return;
+      setBusy(true);
+      const result = await trackUpload<{ imageUrl: string }>(
+        file,
+        () => {
+          const formData = new FormData();
+          formData.append('file', file);
+          formData.append('projectId', projectId);
+          formData.append('taskId', taskId);
+          return fetch('/api/upload/task-cover', { method: 'POST', body: formData });
+        },
+        { doneLabel: 'Cover image ready', maxBytes: MAX_BYTES },
+      );
+      setBusy(false);
+      if (result.ok) {
+        setCoverVersion((v) => v + 1);
+        refreshCover();
+      } else if (result.error) showSnackbar(result.error, 'error');
     },
-    [taskId, projectId, pinMutation]
+    [taskId, projectId, busy, refreshCover, showSnackbar],
   );
 
-  // Empty state: no photos yet — show guidance pointing to the Photos folder
-  if (photos.length === 0) {
+  const handleRemove = useCallback(async () => {
+    if (!taskId || busy) return;
+    setBusy(true);
+    try {
+      const res = await fetch('/api/upload/task-cover', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ projectId, taskId }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? 'Failed to remove cover');
+      }
+      refreshCover();
+      showSnackbar('Cover image removed', 'success');
+    } catch (err) {
+      showSnackbar(err instanceof Error ? err.message : 'Failed to remove cover', 'error');
+    } finally {
+      setBusy(false);
+    }
+  }, [taskId, projectId, busy, refreshCover, showSnackbar]);
+
+  const { getRootProps, getInputProps, open, isDragActive } = useDropzone({
+    onDrop: (accepted) => {
+      const file = accepted[0];
+      if (file) void uploadFile(file);
+    },
+    accept: { 'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.webp'] },
+    maxFiles: 1,
+    multiple: false,
+    noClick: true,
+    noKeyboard: true,
+    disabled: !canManage || busy,
+  });
+
+  // ── Empty state ──
+  if (!coverImageUrl) {
+    // Viewers without manage permission just see a quiet placeholder.
+    if (!canManage) {
+      return (
+        <Box
+          sx={{
+            mx: '14px',
+            mb: '4px',
+            height: HERO_HEIGHT,
+            borderRadius: '10px',
+            border: '1.5px dashed',
+            borderColor: 'divider',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 0.75,
+            color: 'text.disabled',
+          }}
+        >
+          <ImageSquare size={18} />
+          <Typography sx={{ fontSize: '0.75rem', fontWeight: 500, color: 'text.secondary', lineHeight: 1.2 }}>
+            No cover image
+          </Typography>
+        </Box>
+      );
+    }
+
     return (
       <Box
+        {...getRootProps()}
+        onClick={busy ? undefined : open}
         sx={{
           mx: '14px',
           mb: '4px',
-          height: EMPTY_HEIGHT,
+          height: HERO_HEIGHT,
           borderRadius: '10px',
           border: '1.5px dashed',
-          borderColor: 'divider',
-          color: 'text.disabled',
+          borderColor: isDragActive ? 'primary.main' : 'divider',
+          bgcolor: isDragActive ? 'action.hover' : 'transparent',
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
@@ -91,218 +152,176 @@ export default function CoverImageBanner({
           gap: 0.75,
           textAlign: 'center',
           px: 3,
+          cursor: 'pointer',
+          color: 'text.disabled',
+          transition: 'border-color 0.2s, background-color 0.2s, color 0.2s',
+          '&:hover': { borderColor: 'primary.main', color: 'primary.main' },
         }}
       >
-        <ImageSquare size={18} />
-        <Typography sx={{ fontSize: '0.75rem', fontWeight: 500, color: 'text.secondary', lineHeight: 1.2 }}>
-          No cover image
+        <input {...getInputProps()} />
+        <UploadSimple size={20} weight="bold" />
+        <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, color: 'text.secondary', lineHeight: 1.2 }}>
+          {isDragActive ? 'Drop image to set cover' : 'Upload cover image'}
         </Typography>
         <Typography sx={{ fontSize: '0.6875rem', fontWeight: 400, color: 'text.disabled', lineHeight: 1.4, maxWidth: 260 }}>
-          Upload a photo in the Photos folder below, then pin it to feature it here.
+          Drag & drop or click to add a cover for this task. PNG, JPG, WebP, or GIF up to 10MB.
         </Typography>
       </Box>
     );
   }
 
-  const isPinned = hero?.id === coverDocumentId;
+  // ── Filled state ──
+  const heroSrc = coverVersion > 0 ? `${coverImageUrl}?v=${coverVersion}` : coverImageUrl;
 
   return (
-    <Box sx={{ mx: '14px', mb: '4px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
-      {/* ─── HERO ─── */}
+    <Box sx={{ mx: '14px', mb: '4px' }}>
       <Box
+        {...(canManage ? getRootProps() : {})}
         sx={{
           position: 'relative',
           height: HERO_HEIGHT,
           borderRadius: '10px',
           overflow: 'hidden',
           bgcolor: 'background.default',
-          '&:hover .hero-actions': { opacity: 1 },
+          outline: isDragActive ? '2px solid' : 'none',
+          outlineColor: 'primary.main',
+          '&:hover .cover-actions': { opacity: 1 },
         }}
       >
-        {hero ? (
-          <>
-            {!heroLoaded && (
-              <Box
-                sx={{
-                  position: 'absolute',
-                  inset: 0,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  '@keyframes shimmer': {
-                    '0%': { backgroundPosition: '-200% 0' },
-                    '100%': { backgroundPosition: '200% 0' },
-                  },
-                  background:
-                    'linear-gradient(90deg, var(--bg-primary) 25%, var(--border-color) 50%, var(--bg-primary) 75%)',
-                  backgroundSize: '200% 100%',
-                  animation: 'shimmer 1.8s ease-in-out infinite',
-                }}
-              >
-                <ImageSquare size={18} color="var(--text-secondary)" />
-              </Box>
-            )}
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              key={hero.id}
-              src={hero.blobUrl}
-              alt={hero.name}
-              onLoad={() => setHeroLoaded(true)}
-              style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+        {canManage && <input {...getInputProps()} />}
+
+        {!heroLoaded && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              '@keyframes shimmer': {
+                '0%': { backgroundPosition: '-200% 0' },
+                '100%': { backgroundPosition: '200% 0' },
+              },
+              background:
+                'linear-gradient(90deg, var(--bg-primary) 25%, var(--border-color) 50%, var(--bg-primary) 75%)',
+              backgroundSize: '200% 100%',
+              animation: 'shimmer 1.8s ease-in-out infinite',
+            }}
+          >
+            <ImageSquare size={18} color="var(--text-secondary)" />
+          </Box>
+        )}
+
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={heroSrc}
+          alt="Task cover"
+          onLoad={() => setHeroLoaded(true)}
+          style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+        />
+
+        {/* Drag-to-replace hint */}
+        {isDragActive && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              bgcolor: 'rgba(0,0,0,0.45)',
+              backdropFilter: 'blur(2px)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.75,
+              color: 'white',
+              fontSize: '0.75rem',
+              fontWeight: 600,
+            }}
+          >
+            <UploadSimple size={16} weight="bold" />
+            Drop to replace cover
+          </Box>
+        )}
+
+        {/* Hover actions: replace + remove (managers only) */}
+        {canManage && (
+          <Box
+            className="cover-actions"
+            sx={{
+              position: 'absolute',
+              bottom: 8,
+              right: 8,
+              display: 'flex',
+              gap: 0.5,
+              opacity: 0,
+              transition: 'opacity 0.2s',
+            }}
+          >
+            <CoverActionButton
+              icon={<ArrowsClockwise size={12} weight="bold" />}
+              label="Replace"
+              disabled={busy}
+              onClick={(e) => {
+                e.stopPropagation();
+                open();
+              }}
             />
-
-            {/* Pinned badge (visible always when showing the pinned photo) */}
-            {isPinned && (
-              <Box
-                sx={{
-                  position: 'absolute',
-                  top: 8,
-                  left: 8,
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 0.5,
-                  height: 22,
-                  px: 0.75,
-                  bgcolor: 'rgba(0,0,0,0.55)',
-                  backdropFilter: 'blur(8px)',
-                  borderRadius: '6px',
-                  color: 'white',
-                  fontSize: '0.625rem',
-                  fontWeight: 500,
-                  letterSpacing: '0.01em',
-                  lineHeight: 1,
-                }}
-              >
-                <PushPin size={11} weight="fill" />
-                Pinned
-              </Box>
-            )}
-
-            {/* Hover actions: pin only (no uploads from here) */}
-            {!isPinned && hero && (
-              <Box
-                className="hero-actions"
-                sx={{
-                  position: 'absolute',
-                  bottom: 8,
-                  right: 8,
-                  display: 'flex',
-                  gap: 0.5,
-                  opacity: 0,
-                  transition: 'opacity 0.2s',
-                }}
-              >
-                <Box
-                  component="button"
-                  disabled={pinMutation.isPending}
-                  onClick={(e: React.MouseEvent) => {
-                    e.stopPropagation();
-                    handlePin(hero.id);
-                  }}
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 0.5,
-                    color: 'white',
-                    height: 26,
-                    px: 1,
-                    bgcolor: 'rgba(0,0,0,0.5)',
-                    backdropFilter: 'blur(8px)',
-                    borderRadius: '6px',
-                    border: 'none',
-                    cursor: 'pointer',
-                    fontSize: '0.625rem',
-                    fontWeight: 500,
-                    fontFamily: 'inherit',
-                    letterSpacing: '0.01em',
-                    lineHeight: 1,
-                    '&:hover': { bgcolor: 'rgba(0,0,0,0.65)' },
-                    '&:disabled': { opacity: 0.6, cursor: 'wait' },
-                    transition: 'background-color 0.15s',
-                  }}
-                  aria-label="Pin as cover"
-                >
-                  <PushPin size={12} weight="fill" />
-                  Pin as cover
-                </Box>
-              </Box>
-            )}
-          </>
-        ) : null}
+            <CoverActionButton
+              icon={<Trash size={12} weight="bold" />}
+              label="Remove"
+              disabled={busy}
+              onClick={(e) => {
+                e.stopPropagation();
+                void handleRemove();
+              }}
+            />
+          </Box>
+        )}
       </Box>
+    </Box>
+  );
+}
 
-      {/* ─── THUMBNAIL STRIP ─── */}
-      {visibleStrip.length > 0 && (
-        <Box sx={{ display: 'flex', gap: '4px', alignItems: 'stretch' }}>
-          {visibleStrip.map((photo, idx) => {
-            const isOverflowTile = idx === visibleStrip.length - 1 && overflowCount > 0;
-            return (
-              <Box
-                key={photo.id}
-                onClick={() => setViewedId(photo.id)}
-                sx={{
-                  position: 'relative',
-                  width: THUMB_SIZE,
-                  height: THUMB_SIZE,
-                  borderRadius: '6px',
-                  overflow: 'hidden',
-                  cursor: 'pointer',
-                  flexShrink: 0,
-                  bgcolor: 'action.hover',
-                  border: '2px solid',
-                  borderColor: 'transparent',
-                  transition: 'border-color 0.15s, transform 0.15s',
-                  '&:hover': { borderColor: 'divider', transform: 'scale(1.03)' },
-                }}
-              >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={photo.blobUrl}
-                  alt={photo.name}
-                  style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
-                />
-                {photo.id === coverDocumentId && (
-                  <Box
-                    sx={{
-                      position: 'absolute',
-                      top: 2,
-                      left: 2,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      width: 14,
-                      height: 14,
-                      borderRadius: '50%',
-                      bgcolor: 'rgba(0,0,0,0.6)',
-                      color: 'white',
-                    }}
-                  >
-                    <PushPin size={8} weight="fill" />
-                  </Box>
-                )}
-                {isOverflowTile && (
-                  <Box
-                    sx={{
-                      position: 'absolute',
-                      inset: 0,
-                      bgcolor: 'rgba(0,0,0,0.55)',
-                      color: 'white',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      fontSize: '0.75rem',
-                      fontWeight: 600,
-                      letterSpacing: '0.02em',
-                    }}
-                  >
-                    +{overflowCount + 1}
-                  </Box>
-                )}
-              </Box>
-            );
-          })}
-        </Box>
-      )}
+function CoverActionButton({
+  icon,
+  label,
+  disabled,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  disabled?: boolean;
+  onClick: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <Box
+      component="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.5,
+        color: 'white',
+        height: 26,
+        px: 1,
+        bgcolor: 'rgba(0,0,0,0.5)',
+        backdropFilter: 'blur(8px)',
+        borderRadius: '6px',
+        border: 'none',
+        cursor: 'pointer',
+        fontSize: '0.625rem',
+        fontWeight: 500,
+        fontFamily: 'inherit',
+        letterSpacing: '0.01em',
+        lineHeight: 1,
+        '&:hover': { bgcolor: 'rgba(0,0,0,0.65)' },
+        '&:disabled': { opacity: 0.6, cursor: 'wait' },
+        transition: 'background-color 0.15s',
+      }}
+    >
+      {icon}
+      {label}
     </Box>
   );
 }

--- a/src/components/bryntum/components/task-popover/FolderRow.tsx
+++ b/src/components/bryntum/components/task-popover/FolderRow.tsx
@@ -58,11 +58,10 @@ interface FolderRowProps {
   canManage?: boolean;
   onSaveRequirement?: (count: number | null) => void;
   isRequirementPending?: boolean;
-  // Pin context (only used by the Photos folder)
+  // Task/org context (used by trackable folders for slot mutations)
   projectId?: string;
   taskId?: string;
   organizationId?: string;
-  pinnedDocId?: string | null;
   // Drawer launch (only for trackable folders)
   onManage?: () => void;
   // Approval context (only used by trackable folders)
@@ -91,7 +90,6 @@ function FolderRowInner({
   projectId,
   taskId,
   organizationId,
-  pinnedDocId,
   onManage,
   memberRole,
   uploadingSlotIds,
@@ -111,7 +109,6 @@ function FolderRowInner({
     projectId,
     taskId,
     organizationId,
-    pinnedDocId,
     memberRole,
     uploadingSlotIds,
   };

--- a/src/components/bryntum/components/task-popover/PhotosFolderContent.tsx
+++ b/src/components/bryntum/components/task-popover/PhotosFolderContent.tsx
@@ -2,9 +2,7 @@
 
 import React, { useState } from 'react';
 import { Box, Typography } from '@mui/material';
-import { SquaresFour, List, FileText, PushPin, Plus } from '@phosphor-icons/react';
-import { api } from '@/trpc/react';
-import { useSnackbar } from '@/hooks/useSnackbar';
+import { SquaresFour, List, FileText, Plus } from '@phosphor-icons/react';
 import type { FolderContentProps, PreviewDoc } from './types';
 
 function PhotosFolderContentInner({
@@ -12,32 +10,8 @@ function PhotosFolderContentInner({
   onSelectDoc,
   selectedDocId,
   onUpload,
-  projectId,
-  taskId,
-  organizationId,
-  pinnedDocId,
 }: FolderContentProps) {
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
-  const { showSnackbar } = useSnackbar();
-  const utils = api.useUtils();
-  const canPin = !!projectId && !!taskId && !!organizationId;
-  const pinMutation = api.gantt.pinPhoto.useMutation({
-    onSuccess: () => {
-      if (canPin) {
-        void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId });
-      }
-    },
-    onError: (err) => showSnackbar(err.message || 'Failed to pin photo', 'error'),
-  });
-
-  const handlePin = (docId: string, currentlyPinned: boolean) => {
-    if (!canPin) return;
-    pinMutation.mutate({
-      projectId,
-      taskId,
-      documentId: currentlyPinned ? null : docId,
-    });
-  };
 
   const AddPhotoTile = (
     <Box
@@ -149,7 +123,6 @@ function PhotosFolderContentInner({
       {viewMode === 'grid' ? (
         <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '6px', pt: 0.5 }}>
           {docs.map((doc) => {
-            const isPinned = pinnedDocId === doc.id;
             const isImage = doc.mimeType.startsWith('image/');
             return (
               <Box
@@ -168,7 +141,6 @@ function PhotosFolderContentInner({
                   '&:hover': {
                     transform: 'scale(1.02)',
                     borderColor: selectedDocId === doc.id ? 'primary.main' : 'divider',
-                    '& .pin-toggle': { opacity: 1 },
                   },
                 }}
               >
@@ -182,42 +154,6 @@ function PhotosFolderContentInner({
                 ) : (
                   <Box sx={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                     <FileText size={20} color="var(--text-secondary)" />
-                  </Box>
-                )}
-
-                {/* Pin toggle — only for images, only when pin context is available */}
-                {canPin && isImage && (
-                  <Box
-                    className="pin-toggle"
-                    component="button"
-                    onClick={(e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      handlePin(doc.id, isPinned);
-                    }}
-                    disabled={pinMutation.isPending}
-                    aria-label={isPinned ? 'Unpin cover' : 'Pin as cover'}
-                    sx={{
-                      position: 'absolute',
-                      top: 4,
-                      right: 4,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      width: 22,
-                      height: 22,
-                      borderRadius: '50%',
-                      border: 'none',
-                      cursor: 'pointer',
-                      bgcolor: isPinned ? 'rgba(0,0,0,0.7)' : 'rgba(0,0,0,0.5)',
-                      backdropFilter: 'blur(6px)',
-                      color: 'white',
-                      opacity: isPinned ? 1 : 0,
-                      transition: 'opacity 0.15s, background-color 0.15s',
-                      '&:hover': { bgcolor: 'rgba(0,0,0,0.75)' },
-                      '&:disabled': { opacity: 0.6, cursor: 'wait' },
-                    }}
-                  >
-                    <PushPin size={11} weight={isPinned ? 'fill' : 'regular'} />
                   </Box>
                 )}
               </Box>
@@ -257,14 +193,6 @@ function PhotosFolderContentInner({
               >
                 {doc.name}
               </Typography>
-              {pinnedDocId === doc.id && (
-                <PushPin
-                  size={11}
-                  weight="fill"
-                  color="var(--text-secondary)"
-                  style={{ flexShrink: 0 }}
-                />
-              )}
               {doc.createdAt != null && (
                 <Typography sx={{ fontSize: 11, color: 'text.secondary', flexShrink: 0, opacity: 0.7 }}>
                   {new Date(doc.createdAt).toLocaleDateString(

--- a/src/components/bryntum/components/task-popover/types.ts
+++ b/src/components/bryntum/components/task-popover/types.ts
@@ -49,11 +49,10 @@ export interface FolderContentProps {
    */
   onUploadFile?: (slotId: string, file: File) => void;
   folderName: string;
-  // Optional pin context — only consumed by the Photos folder
+  // Task/org context — consumed by trackable folders for slot mutations
   projectId?: string;
   taskId?: string;
   organizationId?: string;
-  pinnedDocId?: string | null;
   // Approval context — only consumed by trackable folders (submittals, inspections)
   memberRole?: string;
   /**

--- a/src/components/bryntum/hooks/useTaskPopover.ts
+++ b/src/components/bryntum/hooks/useTaskPopover.ts
@@ -45,8 +45,8 @@ export function useTaskPopover() {
       if (taskRecord.isParent) return;
 
       // Bryntum-generated phantom IDs (newly added tasks not yet synced) don't
-      // exist in the DB, so popover mutations like setSlotCount / pinPhoto
-      // would throw NOT_FOUND. Wait for autoSync to assign a real id first.
+      // exist in the DB, so popover mutations like setSlotCount or the cover
+      // upload would throw NOT_FOUND. Wait for autoSync to assign a real id first.
       if (taskRecord.isPhantom) {
         showSnackbar('Saving task — try again in a moment', 'info');
         return;

--- a/src/lib/blobProxy.ts
+++ b/src/lib/blobProxy.ts
@@ -6,6 +6,10 @@ export function projectImageProxyUrl(projectId: string): string {
   return `/api/blob/project-image/${projectId}`;
 }
 
+export function taskCoverProxyUrl(taskId: string): string {
+  return `/api/blob/task-cover/${taskId}`;
+}
+
 export function withProxyImageUrl<T extends { id: string; imageUrl: string | null }>(project: T): T {
   return project.imageUrl
     ? { ...project, imageUrl: projectImageProxyUrl(project.id) }

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { createTRPCRouter, orgProcedure, projectProcedure } from "@/server/api/trpc";
-import { canManageProjects, canApproveDocuments } from "@/lib/permissions";
+import { createTRPCRouter, orgProcedure } from "@/server/api/trpc";
+import { canApproveDocuments } from "@/lib/permissions";
 import {
   ganttLoadInputSchema,
   ganttSyncInputSchema,
@@ -12,7 +12,7 @@ import {
 } from "@/lib/validations/gantt";
 import { nextSuggestedSlotName } from "@/lib/constants/slotNameLibrary";
 import { APPROVABLE_FOLDER_ID_LIST } from "@/lib/folders";
-import { documentProxyUrl } from "@/lib/blobProxy";
+import { documentProxyUrl, taskCoverProxyUrl } from "@/lib/blobProxy";
 import { buildTaskTree, mapDependencyToGantt, mapResourceToGantt, mapAssignmentToGantt, mapTimeRangeToGantt } from "@/server/api/helpers/ganttTree";
 import { syncTasks, syncDependencies, syncResources, syncAssignments, syncTimeRanges } from "@/server/api/helpers/ganttSync";
 
@@ -71,7 +71,7 @@ export const ganttRouter = createTRPCRouter({
           endDate: true,
           duration: true,
           durationUnit: true,
-          coverDocumentId: true,
+          coverImageUrl: true,
           csiCode: true,
           requiredSubmittals: true,
           requiredInspections: true,
@@ -104,7 +104,7 @@ export const ganttRouter = createTRPCRouter({
         endDate: task.endDate,
         duration: task.duration,
         durationUnit: task.durationUnit,
-        coverDocumentId: task.coverDocumentId,
+        coverImageUrl: task.coverImageUrl ? taskCoverProxyUrl(task.id) : null,
         csiCode: task.csiCode,
         requiredSubmittals: task.requiredSubmittals,
         requiredInspections: task.requiredInspections,
@@ -112,63 +112,6 @@ export const ganttRouter = createTRPCRouter({
         assignees: task.assignments.map((a) => a.resource),
         hasChildren: task._count.children > 0,
       };
-    }),
-
-  /**
-   * Pin (or unpin) a photo as the task's cover.
-   * Pass documentId: null to clear the pin.
-   */
-  pinPhoto: projectProcedure
-    .input(
-      z.object({
-        taskId: z.string(),
-        documentId: z.string().nullable(),
-      })
-    )
-    .mutation(async ({ ctx, input }) => {
-      if (!canManageProjects(ctx.projectMember.role)) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "You don't have permission to change the task cover",
-        });
-      }
-
-      const projectId = ctx.project.id;
-      const { taskId, documentId } = input;
-
-      const task = await ctx.db.ganttTask.findFirst({
-        where: { id: taskId, projectId },
-        select: { id: true },
-      });
-      if (!task) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Task not found" });
-      }
-
-      if (documentId) {
-        const document = await ctx.db.document.findFirst({
-          where: { id: documentId, projectId, taskId, folderId: "photos" },
-          select: { id: true, mimeType: true },
-        });
-        if (!document) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Photo not found in this task's Photos folder",
-          });
-        }
-        if (!document.mimeType.startsWith("image/")) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "Only image files can be pinned as a cover",
-          });
-        }
-      }
-
-      await ctx.db.ganttTask.update({
-        where: { id: taskId },
-        data: { coverDocumentId: documentId },
-      });
-
-      return { success: true };
     }),
 
   /**


### PR DESCRIPTION
Makes each Gantt task's cover photo a standalone uploaded image, fully decoupled from the Photos folder: the cover is now a private blob whose URL lives on `GanttTask.coverImageUrl` (mirroring the project-image pattern) and is served through a new authenticated `/api/blob/task-cover/[taskId]` proxy. Upload/replace go through `POST /api/upload/task-cover` and removal through its `DELETE` — both gated on `canManageProjects` and surfacing progress via the app's global upload toast chip, with the replaced image cache-busted on the client. This removes the old `gantt.pinPhoto` / `coverDocumentId` "pin a photo as cover" mechanism (the now-unused column and relations are left in place but marked deprecated for a follow-up drop) and strips the pin UI from the Photos folder. The `CoverImageBanner` was rewritten as a drag-and-drop / click uploader with replace + remove actions, and `claudedocs/components-guide.md` was updated to document the new model. Also includes an incidental sync of the bundled Bryntum `stockholm-dark.css` theme asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)