### PR TITLE
Fix Gantt Enter key spawning a new task during cell edit

### DIFF
--- a/public/bryntum/stockholm-dark.css
+++ b/public/bryntum/stockholm-dark.css
@@ -1,4 +1,328 @@
 @charset "UTF-8";
+/*!
+ *
+ * Bryntum Gantt 7.2.2
+ *
+ * Copyright(c) 2026 Bryntum AB
+ * https://bryntum.com/contact
+ * https://bryntum.com/license
+ *
+ * Bryntum incorporates third-party code licensed under the MIT and Apache-2.0 licenses.
+ * See the licenses below or visit https://bryntum.com/products/gantt/docs/guide/Gantt/licenses
+ *
+ * # Third Party Notices
+ * 
+ * Bryntum uses the following third party libraries:
+ * 
+ * * [Font Awesome 6 Free](https://fontawesome.com/license/free) (MIT/SIL OFL 1.1)
+ * * [Roboto font (for Material theme only)](https://github.com/google/roboto) (Apache-2.0)
+ * * [Styling Cross-Browser Compatible Range Inputs with Sass](https://github.com/darlanrod/input-range-sass) (MIT)
+ * * [Tree Walker polyfill (only applies to Salesforce)](https://github.com/Krinkle/dom-TreeWalker-polyfill) (MIT)
+ * * [chronograph](https://github.com/bryntum/chronograph) (MIT)
+ * * [later.js](https://github.com/bunkat/later) (MIT)
+ * * [Monaco editor (only used in our demos)](https://microsoft.github.io/monaco-editor) (MIT)
+ * * Map/Set polyfill to fix performance issues for Salesforce LWS (MIT)
+ * * [Chart.js (when using Chart package)](https://github.com/chartjs/Chart.js) (MIT)
+ * 
+ * Note: the **chronograph** and **later.js** libraries are used in Bryntum Scheduler Pro and Bryntum Gantt, but they are
+ * listed for all Bryntum products since the distribution contains trial versions of the thin bundles for all other
+ * products. TreeWalker is only used in the LWC bundle for Salesforce. Roboto font is only used in the material theme.
+ * 
+ * ## Font Awesome 6 Free
+ * 
+ * [Font Awesome Free 6 by @fontawesome](https://fontawesome.com/)
+ * 
+ * Font Awesome Free is free, open source, and GPL friendly. You can use it for commercial projects, open source projects,
+ * or really almost whatever you want.
+ * 
+ * [Full Font Awesome Free license](https://fontawesome.com/license/free)
+ * 
+ * ## Roboto font
+ * 
+ * [Apache License Version 2.0, January 2004](https://www.apache.org/licenses/LICENSE-2.0)
+ * 
+ * TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ * 
+ * 1. Definitions.
+ * 
+ * "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9
+ * of this document.
+ * 
+ * "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+ * 
+ * "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are
+ * under common control with that entity. For the purposes of this definition,
+ * "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by
+ * contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+ * ownership of such entity.
+ * 
+ * "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+ * 
+ * "Source" form shall mean the preferred form for making modifications, including but not limited to software source code,
+ * documentation source, and configuration files.
+ * 
+ * "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including
+ * but not limited to compiled object code, generated documentation, and conversions to other media types.
+ * 
+ * "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as
+ * indicated by a copyright notice that is included in or attached to the work
+ * (an example is provided in the Appendix below).
+ * 
+ * "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work
+ * and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an
+ * original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain
+ * separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+ * 
+ * "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or
+ * additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the
+ * Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner.
+ * For the purposes of this definition, "submitted"
+ * means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including
+ * but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems
+ * that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding
+ * communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a
+ * Contribution."
+ * 
+ * "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received
+ * by Licensor and subsequently incorporated within the Work.
+ * 
+ * 2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to
+ *    You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce,
+ *    prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such
+ *    Derivative Works in Source or Object form.
+ * 
+ * 3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a
+ *    perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+ *    (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise
+ *    transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are
+ *    necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s)
+ *    with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (
+ *    including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within
+ *    the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this
+ *    License for that Work shall terminate as of the date such litigation is filed.
+ * 
+ * 4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with
+ *    or without modifications, and in Source or Object form, provided that You meet the following conditions:
+ * 
+ * (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+ * 
+ * (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+ * 
+ * (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark,
+ * and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the
+ * Derivative Works; and
+ * 
+ * (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute
+ * must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that
+ * do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file
+ * distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the
+ * Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices
+ * normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You
+ * may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the
+ * NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the
+ * License.
+ * 
+ * You may add Your own copyright statement to Your modifications and may provide additional or different license terms and
+ * conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole,
+ * provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this
+ * License.
+ * 
+ * 5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for
+ *    inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any
+ *    additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any
+ *    separate license agreement you may have executed with Licensor regarding such Contributions.
+ * 
+ * 6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product
+ *    names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and
+ *    reproducing the content of the NOTICE file.
+ * 
+ * 7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and
+ *    each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *    either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ *    MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness
+ *    of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this
+ *    License.
+ * 
+ * 8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or
+ *    otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing,
+ *    shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or
+ *    consequential damages of any character arising as a result of this License or out of the use or inability to use the
+ *    Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+ *    any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such
+ *    damages.
+ * 
+ * 9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose
+ *    to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or
+ *    rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and
+ *    on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and
+ *    hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason
+ *    of your accepting any such warranty or additional liability.
+ * 
+ * END OF TERMS AND CONDITIONS
+ * 
+ * APPENDIX: How to apply the Apache License to your work.
+ * 
+ * To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by
+ * brackets "[]"
+ * replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the
+ * appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose
+ * be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+ * 
+ * Copyright [yyyy] [name of copyright owner]
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * [APACHE LICENSE, VERSION 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "
+ * AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ * 
+ * ## Styling Cross-Browser Compatible Range Inputs with Sass
+ * 
+ * Github: [input-range-sass](https://github.com/darlanrod/input-range-sass)
+ * 
+ * Author: [Darlan Rod](https://github.com/darlanrod)
+ * 
+ * Version 1.4.1
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016 Darlan Rod
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## Tree Walker polyfill
+ * 
+ * The MIT License (MIT)
+ * 
+ * [Copyright 2013–2017 Timo Tijhof](https://github.com/Krinkle/dom-TreeWalker-polyfill)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## chronograph
+ * 
+ * GitHub: [chronograph](https://github.com/bryntum/chronograph)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2023 Bryntum
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## later.js
+ * 
+ * GitHub: [later.js](https://github.com/bunkat/later)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright © 2013 BunKat
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## Monaco editor
+ * 
+ * GitHub: [Monaco editor](https://microsoft.github.io/monaco-editor) (MIT)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016 - present Microsoft Corporation
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * ## Map/Set polyfill to fix performance issues for Salesforce LWS
+ * 
+ * Copyright © 2024 Certinia Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * 
+ * ## Chart.js
+ * 
+ * GitHub: [Chart.js](https://github.com/chartjs/Chart.js)
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2014-2022 Chart.js Contributors
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
 
 /* Themes need more specific rules than Widgets etc. to make sure the values are applied no matter the import order */
 :root:not(.b-nothing), :host(:not(.b-nothing)) {
@@ -111,22 +435,6 @@
     /* TaskBoard */
     --b-task-board-card-background            : var(--b-neutral-95);
     --b-task-board-card-hover-background      : var(--b-neutral-92);
-
-    /* Heat map values ranging from lowest to highest intensity to create
-     * background colors to indicate how "hot" an element is, for example
-     * based on the number of events in a calendar cell.
-     */
-     /*
-      * Start color for the heatmap, representing the lowest intensity (e.g. 1 event in a calendar cell).
-      */
-    --b-heatmap-start          : oklab(0.53 -0.03 0.1);
-
-    /*
-     * End color for the heatmap, representing the highest intensity (e.g. 10 or more events in a calendar cell).
-     */
-    --b-heatmap-end            : oklab(0.38 0.13 0.03);
-
-    --b-heatmap-mix-blend-mode : hard-light;
 }
 
 /* Shades of primary color have to be specified per widget, for color-mix to work as intended */

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -770,6 +770,14 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
             ref={ganttRef}
             {...ganttConfig}
             taskMenuFeature={taskMenuFeature}
+            // cellEdit config MUST be passed as this per-feature prop, not via
+            // `features.cellEdit` in ganttConfig — the React wrapper (v7.2.2)
+            // has no bulk `features` prop, so that nested config is dropped and
+            // CellEdit falls back to its default `addNewAtEnd: { duration: 1 }`,
+            // which makes Enter on the last row spawn a new task. Forcing
+            // `addNewAtEnd: false` here makes Enter only commit the edit; tasks
+            // are created exclusively via the "+ Add Task" button.
+            cellEditFeature={{ addNewAtEnd: false }}
           />
         </div>
 

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -158,11 +158,14 @@ export function createGanttConfig(
     ],
     features: {
       taskEdit: false,
-      // Inline cell editing (double-click the name cell to rename). Default
-      // `addNewAtEnd: true` creates a fresh task when Enter is pressed in the
-      // last row's editor — surprising for users who expect Enter to just
-      // commit the edit. New tasks are added via the "+ Add Task" button.
-      cellEdit: { addNewAtEnd: false },
+      // cellEdit (inline rename via double-click) is enabled by Bryntum's
+      // default. Its config — specifically `addNewAtEnd: false`, so Enter just
+      // commits instead of spawning a new task — is passed as the top-level
+      // `cellEditFeature` prop on <BryntumGantt> in BryntumGanttWrapper, NOT
+      // here. The React wrapper has no bulk `features` prop (see
+      // BryntumGanttProps), so feature config nested in this object is silently
+      // dropped; only the per-feature `${key}Feature` props are honored. New
+      // tasks are added exclusively via the "+ Add Task" button.
       columnLines: true,
       stripe: true,
       nonWorkingTime: true,

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -211,7 +211,9 @@ export type GanttConfig = {
   columns: GanttColumnConfig[];
   features: {
     taskEdit?: boolean;
-    cellEdit?: boolean | { addNewAtEnd?: boolean };
+    // cellEdit config is NOT set here — the React wrapper drops nested feature
+    // config from this object. It's passed via the `cellEditFeature` prop on
+    // <BryntumGantt> instead (see BryntumGanttWrapper).
     columnLines?: boolean | { renderer?: (...args: unknown[]) => void };
     stripe?: boolean;
     nonWorkingTime?: boolean;


### PR DESCRIPTION
Pressing Enter while editing a task cell created a new task because the intended `cellEdit: { addNewAtEnd: false }` override lived inside the `features` object spread onto `<BryntumGantt>`, but `@bryntum/gantt-react` 7.2.2 has no bulk `features` prop — so that nested config was silently dropped and CellEdit ran with its default `addNewAtEnd: { duration: 1 }`, appending a task on Enter at the last row. This passes the config via the recognized `cellEditFeature` prop instead (mirroring the existing `taskMenuFeature` workaround), so Enter now only commits the edit and tasks are created exclusively via the "+ Add Task" button. The dead `cellEdit` entry and its now-orphaned type field were removed and replaced with comments pointing to the prop. Also syncs the licensed Bryntum 7.2.2 `stockholm-dark` theme CSS that was already regenerated in the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)