### PR TITLE
Fix Gantt submittal progress bar to reflect approval status

### DIFF
--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -705,11 +705,13 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
           cursor: default;
         }
         /* Task-bar inner layout — used when a leaf task has any submittal /
-           inspection requirements. Renders the task name on the left and a
-           donut-in-chip indicator on the right (a tiny SVG progress donut + the
-           filled/total ratio). States: empty (faint chip, hollow ring), partial
-           (white chip, partial arc, indigo text), done (green chip, white check
-           circle, white text). */
+           inspection requirements. While the task is incomplete it renders the
+           task name on the left and a donut-in-chip indicator on the right (a
+           tiny SVG progress donut + the filled/total ratio). Chip states: empty
+           (faint chip, hollow ring) and partial (white chip, partial arc, indigo
+           text). Once every requirement is approved the chip is replaced by the
+           "Complete" pill (.gantt-task-bar-pill) and the whole bar turns green
+           via .gantt-task-done — see globals.css. */
         .gantt-task-bar-inner {
           display: flex;
           align-items: center;
@@ -742,10 +744,6 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
           box-shadow: 0 1px 2px rgba(0, 0, 0, 0.10);
           cursor: default;
         }
-        .gantt-task-bar-chip.is-done {
-          background: #16a34a;
-          color: #fff;
-        }
         .gantt-task-bar-chip.is-empty {
           background: rgba(255, 255, 255, 0.18);
           color: rgba(255, 255, 255, 0.95);
@@ -758,6 +756,31 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         }
         .gantt-task-bar-chip-donut svg { display: block; }
         .gantt-task-bar-chip-text { line-height: 1; }
+        /* Complete pill — white pill with green check + "Complete" label,
+           sitting on the green completed bar (see .gantt-task-done in globals.css). */
+        .gantt-task-bar-pill {
+          flex-shrink: 0;
+          display: inline-flex;
+          align-items: center;
+          gap: 5px;
+          padding: 2px 9px 2px 6px;
+          border-radius: 999px;
+          background: rgba(255, 255, 255, 0.96);
+          color: #15803d;
+          font-size: 10px;
+          font-weight: 700;
+          letter-spacing: 0.02em;
+          line-height: 1.4;
+          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+          cursor: default;
+        }
+        .gantt-task-bar-pill-icon {
+          display: inline-flex;
+          align-items: center;
+          flex-shrink: 0;
+        }
+        .gantt-task-bar-pill-icon svg { display: block; }
+        .gantt-task-bar-pill-text { line-height: 1; }
       `}</style>
 
       <div

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -261,17 +261,41 @@ export function createGanttConfig(
       const isDone = filled >= total;
       const isEmpty = filled === 0;
 
+      // Complete state — the whole bar turns green (via the gantt-task-done class
+      // added below) and the count chip is replaced by an explicit "Complete"
+      // pill so the finished state reads clearly at any timeline zoom level.
+      if (isDone) {
+        if (typeof renderData.cls !== 'string') {
+          renderData.cls.add('gantt-task-done');
+        }
+        const checkSvg =
+          '<svg width="13" height="13" viewBox="0 0 14 14" aria-hidden="true">'
+          + '<circle cx="7" cy="7" r="6" fill="#16a34a"/>'
+          + '<path d="M4 7L6.2 9L10 5" stroke="#fff" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>'
+          + '</svg>';
+        return {
+          class: 'gantt-task-bar-inner',
+          children: [
+            { tag: 'span', class: 'gantt-task-bar-name', text: String(taskRecord.name ?? '') },
+            {
+              tag: 'span',
+              class: 'gantt-task-bar-pill is-complete',
+              title: `${total} of ${total} submittals and inspections complete`,
+              children: [
+                { tag: 'span', class: 'gantt-task-bar-pill-icon', html: checkSvg },
+                { tag: 'span', class: 'gantt-task-bar-pill-text', text: 'Complete' },
+              ],
+            },
+          ],
+        };
+      }
+
       // Donut math — viewBox 14x14, r=5.5, circumference = 2πr ≈ 34.56.
       // The fill arc uses stroke-dasharray/offset to draw a partial circle.
       const CIRCUMFERENCE = 34.56;
       const offset = CIRCUMFERENCE * (1 - filled / total);
 
-      const donutSvg = isDone
-        ? '<svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">'
-          + '<circle cx="7" cy="7" r="5.5" fill="#fff"/>'
-          + '<path d="M4 7L6.2 9L10 5" stroke="#16a34a" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>'
-          + '</svg>'
-        : isEmpty
+      const donutSvg = isEmpty
         ? '<svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">'
           + '<circle cx="7" cy="7" r="5.5" fill="none" stroke="rgba(255,255,255,0.30)" stroke-width="2"/>'
           + '</svg>'
@@ -280,7 +304,7 @@ export function createGanttConfig(
           + `<circle cx="7" cy="7" r="5.5" fill="none" stroke="#1e40af" stroke-width="2" stroke-dasharray="${CIRCUMFERENCE}" stroke-dashoffset="${offset.toFixed(2)}" transform="rotate(-90 7 7)" stroke-linecap="round"/>`
           + '</svg>';
 
-      const chipClass = `gantt-task-bar-chip${isDone ? ' is-done' : ''}${isEmpty ? ' is-empty' : ''}`;
+      const chipClass = `gantt-task-bar-chip${isEmpty ? ' is-empty' : ''}`;
 
       return {
         class: 'gantt-task-bar-inner',

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -11,7 +11,7 @@ import {
   type SlotKind,
 } from "@/lib/validations/gantt";
 import { nextSuggestedSlotName } from "@/lib/constants/slotNameLibrary";
-import { APPROVABLE_FOLDER_ID_LIST } from "@/lib/folders";
+import { APPROVABLE_FOLDER_ID_LIST, slotKindForFolder } from "@/lib/folders";
 import { documentProxyUrl, taskCoverProxyUrl } from "@/lib/blobProxy";
 import { buildTaskTree, mapDependencyToGantt, mapResourceToGantt, mapAssignmentToGantt, mapTimeRangeToGantt } from "@/server/api/helpers/ganttTree";
 import { syncTasks, syncDependencies, syncResources, syncAssignments, syncTimeRanges } from "@/server/api/helpers/ganttSync";
@@ -142,7 +142,7 @@ export const ganttRouter = createTRPCRouter({
         assignments,
         timeRanges,
         needsReviewRows,
-        filledSlotRows,
+        approvedDocRows,
       ] = await Promise.all([
         ctx.db.ganttTask.findMany({
           where: { projectId },
@@ -195,15 +195,18 @@ export const ganttRouter = createTRPCRouter({
           },
           _count: { _all: true },
         }),
-        // Count requirement slots that have at least one bound document, grouped by task.
-        // The partial unique index on Document.slotId enforces at-most-one doc per slot,
-        // so counting documents-with-slotId equals counting filled slots.
+        // Count APPROVED documents per task+folder. The task bar's completion
+        // ratio must match the popover, which treats "approved" (not merely
+        // "uploaded") as the source of truth — so we count approval status here
+        // rather than slot-bound documents. Grouping by folder lets us cap each
+        // requirement kind separately below.
         ctx.db.document.groupBy({
-          by: ["taskId"],
+          by: ["taskId", "folderId"],
           where: {
             projectId,
             taskId: { not: null },
-            slotId: { not: null },
+            approvalStatus: "approved",
+            folderId: { in: APPROVABLE_FOLDER_ID_LIST },
           },
           _count: { _all: true },
         }),
@@ -217,17 +220,33 @@ export const ganttRouter = createTRPCRouter({
         }
       }
 
-      // Build filled-slot count per task. requirementsTotal comes from each task's
-      // legacy required* columns (already selected). Bars show a % when total > 0.
-      const filledSlotCounts = new Map<string, number>();
-      for (const row of filledSlotRows) {
-        if (row.taskId) {
-          filledSlotCounts.set(row.taskId, row._count._all);
-        }
+      // Tally approved documents per task, split by requirement kind.
+      const approvedByTask = new Map<string, { submittal: number; inspection: number }>();
+      for (const row of approvedDocRows) {
+        if (!row.taskId) continue;
+        const kind = slotKindForFolder(row.folderId);
+        if (!kind) continue;
+        const bucket = approvedByTask.get(row.taskId) ?? { submittal: 0, inspection: 0 };
+        bucket[kind] += row._count._all;
+        approvedByTask.set(row.taskId, bucket);
+      }
+
+      // Build the per-task "filled" requirement count. Each kind is capped at its
+      // required count separately (matching the popover) so an over-fulfilled
+      // folder can't mask a short one. requirementsTotal comes from each task's
+      // required* columns; bars show a completion ratio when total > 0.
+      const filledRequirementCounts = new Map<string, number>();
+      for (const task of tasks) {
+        const approved = approvedByTask.get(task.id);
+        if (!approved) continue;
+        const filled =
+          Math.min(approved.submittal, task.requiredSubmittals ?? 0) +
+          Math.min(approved.inspection, task.requiredInspections ?? 0);
+        if (filled > 0) filledRequirementCounts.set(task.id, filled);
       }
 
       // Build hierarchical task tree
-      const taskTree = buildTaskTree(tasks, needsReviewCounts, filledSlotCounts);
+      const taskTree = buildTaskTree(tasks, needsReviewCounts, filledRequirementCounts);
 
       // Map other entities to Gantt format
       const ganttDependencies = dependencies.map(mapDependencyToGantt);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -475,6 +475,22 @@ body {
   background-color: var(--gantt-summary-fill) !important;
 }
 
+/* Completed leaf tasks — all submittal & inspection requirements approved.
+   The whole bar turns green (reusing the summary green) so completion reads at
+   a glance across a zoomed-out timeline. The taskRenderer adds .gantt-task-done
+   and swaps the count chip for a white "Complete" pill, which disambiguates a
+   completed leaf from a parent/summary bar. */
+.bryntum-gantt-container .b-gantt-task.gantt-task-done {
+  background-color: var(--gantt-summary-bg) !important;
+  border-color: var(--gantt-summary-border) !important;
+}
+.bryntum-gantt-container .b-gantt-task.gantt-task-done .b-gantt-task-content {
+  color: var(--gantt-summary-font) !important;
+}
+.bryntum-gantt-container .b-gantt-task.gantt-task-done .b-gantt-task-percent {
+  background-color: var(--gantt-summary-fill) !important;
+}
+
 /* ── Task Resize Handles ────────────────────────────────────── */
 
 /* Widen the invisible hit zone from 6px → 14px so handles are easy to grab,


### PR DESCRIPTION
## Summary

- The Gantt task-bar completion ratio now counts **approved** documents rather than slot-bound uploads, so the bar's filled/total state matches the popover's source of truth.
- Per-requirement-kind capping (submittal vs. inspection capped separately) prevents an over-fulfilled folder from masking a short one.
- The completed state no longer uses a green chip overlay; instead the entire task bar turns green (reusing the summary-bar palette) and displays a white "Complete" pill, making completion immediately readable at any timeline zoom level.
- CSS for the pill and the `gantt-task-done` bar color lives in `globals.css` and scoped inline styles in `BryntumGanttWrapper`.

## Test plan

- [ ] Open a project with tasks that have submittal/inspection requirements
- [ ] Verify the progress chip shows the correct filled/total ratio (matches the popover's counts)
- [ ] Approve all requirements for a task and confirm the bar turns green with a "Complete" pill
- [ ] Confirm partially-fulfilled tasks still show the donut chip with the correct ratio
- [ ] Check that over-approving one folder type doesn't incorrectly show "Complete" when another is short

🤖 Generated with [Claude Code](https://claude.com/claude-code)