### PR TITLE
Requirements drawer: draft editor with explicit Save + confirmation banner

### DIFF
--- a/claudedocs/components-guide.md
+++ b/claudedocs/components-guide.md
@@ -300,7 +300,7 @@ bryntum/
     ganttConfig.ts          ← Bryntum config object
   components/
     TaskDetailsPopover.tsx
-    SubmittalDrawer.tsx       ← right-side drawer for managing per-slot submittals/inspections
+    SubmittalDrawer.tsx       ← right-side drawer for managing per-slot submittals/inspections. Draft editor: count/name/due-date edits stay local until the user clicks Save (commits the whole list via gantt.saveSlots), with a Save/Discard bar, a discard guard on close/tab-switch, and uploads disabled on unsaved draft slots. On Save it flashes "Saved ✓", then fires onSaved → the popover auto-closes the drawer and shows a transient confirmation banner (RequirementsSavedBanner in TaskDetailsPopover)
     BryntumPanelHeader.tsx
     task-popover/             ← extracted sub-components for TaskDetailsPopover
       types.ts

--- a/claudedocs/trpc-guide.md
+++ b/claudedocs/trpc-guide.md
@@ -214,9 +214,19 @@ await ctx.db.$transaction(async (tx) => {
 A few procedures deal with data that was migrated additively — a new table sits next to a legacy column without backfilling rows in the migration itself. The pattern is to backfill **on first read** inside the read procedure:
 
 - `gantt.listSlots` lazily creates `TaskRequirementSlot` rows the first time a task with a non-zero `requiredSubmittals` / `requiredInspections` is read. The legacy count column remains the source of truth for the count; the new table holds the per-slot metadata (`name`, `dueDate`).
-- Mutations that change the count (`gantt.setSlotCount`) keep the legacy column synced inside the same `$transaction` so existing readers (`gantt.taskDetail`, `gantt.requirementStats`, the inline popover progress) don't need to change.
+- Mutations that change the count (`gantt.setSlotCount`, the inline popover stepper) keep the legacy column synced inside the same `$transaction` so existing readers (`gantt.taskDetail`, `gantt.requirementStats`, the inline popover progress) don't need to change.
 
 Use this pattern when a migration is purely additive and the read path can self-heal — it avoids destructive bulk-write migrations on the shared dev DB.
+
+### Batch reconcile for draft editors (`gantt.saveSlots`)
+
+The requirements drawer (`SubmittalDrawer`) is a **draft editor**: count, names, and due dates are edited in local React state and committed in one shot via `gantt.saveSlots` (not auto-saved per keystroke). The mutation takes the desired ordered list — `{ id, name, dueDate }[]` where `id: null` is a new slot — and reconciles it against current rows inside a single `$transaction`:
+
+- **Reconcile by id, never delete-and-recreate.** Kept rows are `update`d in place so their bound `Document.slotId` FK (received uploads / approvals) survives. Only rows whose id is absent from the list are deleted (FK is `ON DELETE SET NULL`, so the files persist, just unbound).
+- Index is set to array position. The drawer only adds/removes **trailing** slots (no reorder), so kept rows keep their index — in-place index updates can't collide on `@@unique([taskId, kind, index])`.
+- The legacy count column is synced to the list length (same invariant as `setSlotCount`), so popover readers stay in step.
+
+The inline popover stepper still uses `gantt.setSlotCount` (immediate); only the drawer defers to `saveSlots`. Both keep the legacy column in sync, so the two surfaces interoperate.
 
 ---
 

--- a/src/__tests__/lib/slot-validations.test.ts
+++ b/src/__tests__/lib/slot-validations.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   setSlotCountSchema,
   updateSlotSchema,
+  saveSlotsSchema,
   slotKindSchema,
 } from "@/lib/validations/gantt";
 
@@ -64,5 +65,45 @@ describe("updateSlotSchema", () => {
 
   it("accepts null dueDate to clear it", () => {
     expect(updateSlotSchema.parse({ slotId: "s1", dueDate: null }).dueDate).toBeNull();
+  });
+});
+
+describe("saveSlotsSchema", () => {
+  const valid = {
+    taskId: "t1",
+    kind: "submittal",
+    slots: [
+      { id: "s1", name: "Shop Drawing", dueDate: "2026-05-12" },
+      { id: null, name: "Product Data", dueDate: null },
+    ],
+  } as const;
+
+  it("accepts a mix of existing (id) and new (id: null) slots", () => {
+    const result = saveSlotsSchema.parse(valid);
+    expect(result.slots).toHaveLength(2);
+    expect(result.slots[0]!.id).toBe("s1");
+    expect(result.slots[1]!.id).toBeNull();
+  });
+
+  it("accepts an empty list (clears all requirements)", () => {
+    expect(saveSlotsSchema.parse({ taskId: "t1", kind: "submittal", slots: [] }).slots).toEqual([]);
+  });
+
+  it("trims slot names", () => {
+    const result = saveSlotsSchema.parse({
+      taskId: "t1",
+      kind: "submittal",
+      slots: [{ id: null, name: "  Cert  ", dueDate: null }],
+    });
+    expect(result.slots[0]!.name).toBe("Cert");
+  });
+
+  it("rejects more than 50 slots", () => {
+    const slots = Array.from({ length: 51 }, () => ({ id: null, name: null, dueDate: null }));
+    expect(() => saveSlotsSchema.parse({ taskId: "t1", kind: "submittal", slots })).toThrow();
+  });
+
+  it("rejects an invalid kind", () => {
+    expect(() => saveSlotsSchema.parse({ ...valid, kind: "rfi" })).toThrow();
   });
 });

--- a/src/__tests__/server/gantt-slot-sync.test.ts
+++ b/src/__tests__/server/gantt-slot-sync.test.ts
@@ -47,6 +47,8 @@ type MockTx = {
     findMany: ReturnType<typeof vi.fn>;
     createMany: ReturnType<typeof vi.fn>;
     deleteMany: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
   };
   ganttTask: {
     update: ReturnType<typeof vi.fn>;
@@ -55,6 +57,7 @@ type MockTx = {
 
 function makeCtx(existingSlots: Array<{ id: string; index: number; name: string | null }> = []) {
   const finalSlots = [...existingSlots];
+  let createSeq = 0;
 
   const tx: MockTx = {
     taskRequirementSlot: {
@@ -84,6 +87,19 @@ function makeCtx(existingSlots: Array<{ id: string; index: number; name: string 
           if (ids.has(finalSlots[i]!.id)) finalSlots.splice(i, 1);
         }
         return Promise.resolve({ count: ids.size });
+      }),
+      create: vi.fn().mockImplementation(({ data }: { data: { index: number; name: string | null } }) => {
+        const created = { id: `created-${createSeq++}`, index: data.index, name: data.name };
+        finalSlots.push(created);
+        return Promise.resolve(created);
+      }),
+      update: vi.fn().mockImplementation(({ where, data }: { where: { id: string }; data: { index?: number; name?: string | null } }) => {
+        const row = finalSlots.find((s) => s.id === where.id);
+        if (row) {
+          if (data.index !== undefined) row.index = data.index;
+          if (data.name !== undefined) row.name = data.name;
+        }
+        return Promise.resolve(row ?? {});
       }),
     },
     ganttTask: {
@@ -226,5 +242,87 @@ describe("gantt router — slot/count invariant", () => {
       data: Array<{ kind: string }>;
     };
     expect(createArgs.data.every((d) => d.kind === "inspection")).toBe(true);
+  });
+
+  it("saveSlots updates kept rows, creates new ones, and syncs the count column", async () => {
+    const ctx = makeCtx([
+      { id: "slot-0", index: 0, name: "Shop Drawing" },
+      { id: "slot-1", index: 1, name: "Product Data" },
+    ]);
+
+    await router.saveSlots!._handler({
+      ctx,
+      input: {
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        taskId: TASK_ID,
+        kind: "submittal",
+        slots: [
+          { id: "slot-0", name: "Shop Drawing (rev B)", dueDate: null }, // edited
+          { id: "slot-1", name: "Product Data", dueDate: "2026-06-14" }, // edited (due)
+          { id: null, name: "Warranty", dueDate: null }, // new
+        ],
+      },
+    });
+
+    // Two existing rows updated in place (bound docs preserved — never recreated).
+    expect(ctx.tx.taskRequirementSlot.update).toHaveBeenCalledTimes(2);
+    // One brand-new row created.
+    expect(ctx.tx.taskRequirementSlot.create).toHaveBeenCalledTimes(1);
+    const createArgs = ctx.tx.taskRequirementSlot.create.mock.calls[0]![0] as {
+      data: { taskId: string; kind: string; index: number; name: string | null };
+    };
+    expect(createArgs.data).toMatchObject({ taskId: TASK_ID, kind: "submittal", index: 2, name: "Warranty" });
+    // Nothing removed → no deleteMany.
+    expect(ctx.tx.taskRequirementSlot.deleteMany).not.toHaveBeenCalled();
+    // Legacy count column synced to the new length.
+    const updateArgs = ctx.tx.ganttTask.update.mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(updateArgs.data).toEqual({ requiredSubmittals: 3 });
+  });
+
+  it("saveSlots deletes rows dropped from the draft", async () => {
+    const ctx = makeCtx([
+      { id: "slot-0", index: 0, name: "Shop Drawing" },
+      { id: "slot-1", index: 1, name: "Product Data" },
+      { id: "slot-2", index: 2, name: "Cert" },
+    ]);
+
+    await router.saveSlots!._handler({
+      ctx,
+      input: {
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        taskId: TASK_ID,
+        kind: "submittal",
+        slots: [{ id: "slot-0", name: "Shop Drawing", dueDate: null }],
+      },
+    });
+
+    expect(ctx.tx.taskRequirementSlot.deleteMany).toHaveBeenCalledTimes(1);
+    const deleteArgs = ctx.tx.taskRequirementSlot.deleteMany.mock.calls[0]![0] as {
+      where: { id: { in: string[] } };
+    };
+    expect(deleteArgs.where.id.in.sort()).toEqual(["slot-1", "slot-2"]);
+    const updateArgs = ctx.tx.ganttTask.update.mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(updateArgs.data).toEqual({ requiredSubmittals: 1 });
+  });
+
+  it("saveSlots clears the count column when the draft is emptied", async () => {
+    const ctx = makeCtx([{ id: "slot-0", index: 0, name: "Shop Drawing" }]);
+
+    await router.saveSlots!._handler({
+      ctx,
+      input: {
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        taskId: TASK_ID,
+        kind: "inspection",
+        slots: [],
+      },
+    });
+
+    expect(ctx.tx.taskRequirementSlot.deleteMany).toHaveBeenCalledTimes(1);
+    const updateArgs = ctx.tx.ganttTask.update.mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(updateArgs.data).toEqual({ requiredInspections: null });
   });
 });

--- a/src/components/bryntum/components/SubmittalDrawer.tsx
+++ b/src/components/bryntum/components/SubmittalDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Box,
   Drawer,
@@ -19,10 +19,11 @@ import {
   CloudArrowUp,
   WarningCircle,
   Tray,
+  PencilSimple,
 } from '@phosphor-icons/react';
 import { format, isBefore, startOfDay } from 'date-fns';
 
-import { api } from '@/trpc/react';
+import { api, type RouterOutputs } from '@/trpc/react';
 import type { SlotKind } from '@/lib/validations/gantt';
 import { nextSuggestedSlotName } from '@/lib/constants/slotNameLibrary';
 import UserAvatar from '@/components/ui/UserAvatar';
@@ -34,12 +35,6 @@ const SUBMITTAL_COLOR = '#2563EB';
 // pill convention used by FolderRow in the task popover, and intentionally
 // differs from the solid green used for "approved".
 const RECEIVED_COLOR = '#4f46e5';
-
-// Optimistic slot IDs are tagged with this prefix so any code path that would
-// otherwise send the placeholder ID to the server (uploads, slot updates) can
-// short-circuit until the real row arrives.
-const OPTIMISTIC_SLOT_ID_PREFIX = 'optimistic-';
-const isOptimisticSlotId = (id: string): boolean => id.startsWith(OPTIMISTIC_SLOT_ID_PREFIX);
 const INSPECTION_COLOR = '#8E44AD';
 
 const KIND_META: Record<SlotKind, {
@@ -81,6 +76,11 @@ interface SubmittalDrawerProps {
   /** Documents already uploaded under this task — used for the tab badge counts. */
   docsByKind: Record<SlotKind, DocumentItem[]>;
   /**
+   * Fired after a successful Save with the saved kind + slot count. The parent
+   * uses this to auto-close the drawer and surface a confirmation on the popover.
+   */
+  onSaved: (info: { kind: SlotKind; count: number }) => void;
+  /**
    * Open the upload dialog for a given folder. Pass a `slotId` to bind the
    * upload to a specific slot; omit it to let the server auto-link to the
    * first empty slot.
@@ -98,20 +98,51 @@ export default function SubmittalDrawer({
   memberRole,
   initialKind = 'submittal',
   docsByKind,
+  onSaved,
   onUploadToFolder,
 }: SubmittalDrawerProps) {
   const [activeKind, setActiveKind] = useState<SlotKind>(initialKind);
+  // Lifted from DrawerContent so the parent can guard tab-switch / close while
+  // there are uncommitted draft edits.
+  const [dirty, setDirty] = useState(false);
+  // A pending navigation intent that's blocked behind the discard confirm.
+  const [guard, setGuard] = useState<{ type: 'close' } | { type: 'switch'; kind: SlotKind } | null>(null);
 
   // Reset to the requested kind whenever the drawer (re)opens.
   useEffect(() => {
     if (open) setActiveKind(initialKind);
   }, [open, initialKind]);
 
+  const requestClose = () => {
+    if (dirty) setGuard({ type: 'close' });
+    else onClose();
+  };
+
+  const requestSwitch = (kind: SlotKind) => {
+    if (kind === activeKind) return;
+    if (dirty) setGuard({ type: 'switch', kind });
+    else setActiveKind(kind);
+  };
+
+  const confirmGuard = () => {
+    if (!guard) return;
+    // Switching kinds re-initializes DrawerContent's draft from server, so the
+    // pending edits are dropped — clear dirty eagerly to keep the bar honest.
+    setDirty(false);
+    if (guard.type === 'close') {
+      setGuard(null);
+      onClose();
+    } else {
+      setActiveKind(guard.kind);
+      setGuard(null);
+    }
+  };
+
   return (
     <Drawer
       anchor="right"
       open={open}
-      onClose={onClose}
+      onClose={requestClose}
       // Sit above the task popover (MUI Popover default is 1300).
       sx={{ zIndex: 1500 }}
       PaperProps={{
@@ -125,12 +156,12 @@ export default function SubmittalDrawer({
       <DrawerHeader
         kind={activeKind}
         taskName={taskName}
-        onClose={onClose}
+        onClose={requestClose}
       />
 
       <KindTabs
         activeKind={activeKind}
-        onChange={setActiveKind}
+        onChange={requestSwitch}
         countSubmittal={docsByKind.submittal.length}
         countInspection={docsByKind.inspection.length}
       />
@@ -141,8 +172,24 @@ export default function SubmittalDrawer({
         taskId={taskId}
         memberRole={memberRole}
         kind={activeKind}
+        onDirtyChange={setDirty}
+        onSaved={(info) => {
+          setDirty(false);
+          onSaved(info);
+        }}
         onUploadToFolder={(slotId) => onUploadToFolder(KIND_META[activeKind].folderId, slotId)}
       />
+
+      {guard && (
+        <ConfirmDialog
+          title="Discard unsaved changes?"
+          description="You have requirement edits that haven't been saved. Leaving now will discard them."
+          cancelLabel="Keep editing"
+          confirmLabel="Discard"
+          onCancel={() => setGuard(null)}
+          onConfirm={confirmGuard}
+        />
+      )}
     </Drawer>
   );
 }
@@ -303,14 +350,38 @@ function KindTab({
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Body — required count stepper + slot list
+// Body — draft editor: stepper + slot list, committed only on Save
 // ────────────────────────────────────────────────────────────────────────────
+
+// A local, uncommitted slot definition. `serverId` is null until the row has
+// been persisted — that's also what gates uploads (you can't attach a file to
+// a slot that doesn't exist server-side yet).
+type DraftSlot = {
+  key: string;
+  serverId: string | null;
+  name: string;
+  dueDate: string; // '' or yyyy-MM-dd
+};
+
+type ServerSlot = RouterOutputs['gantt']['listSlots'][number];
+
+function toDraft(slot: ServerSlot): DraftSlot {
+  return {
+    key: slot.id,
+    serverId: slot.id,
+    name: slot.name ?? '',
+    dueDate: slot.dueDate ? toInputDate(slot.dueDate) : '',
+  };
+}
+
 function DrawerContent({
   organizationId,
   projectId,
   taskId,
   memberRole,
   kind,
+  onDirtyChange,
+  onSaved,
   onUploadToFolder,
 }: {
   organizationId: string;
@@ -318,6 +389,8 @@ function DrawerContent({
   taskId: string;
   memberRole: string;
   kind: SlotKind;
+  onDirtyChange: (dirty: boolean) => void;
+  onSaved: (info: { kind: SlotKind; count: number }) => void;
   onUploadToFolder: (slotId?: string) => void;
 }) {
   const meta = KIND_META[kind];
@@ -327,103 +400,179 @@ function DrawerContent({
     { organizationId, projectId, taskId, kind },
     { enabled: !!organizationId && !!projectId && !!taskId },
   );
-  const slots = slotsQuery.data ?? [];
 
-  const setCountMutation = api.gantt.setSlotCount.useMutation({
-    // Optimistically reshape the slot list so the UI updates instantly instead
-    // of waiting for the server round trip + three query invalidations.
-    onMutate: async ({ count }) => {
-      const queryKey = { organizationId, projectId, taskId, kind };
-      await utils.gantt.listSlots.cancel(queryKey);
-      const previous = utils.gantt.listSlots.getData(queryKey);
+  // `baseline` is the last-known-saved definition; `draft` is what the user is
+  // editing. Both are local — nothing hits the server until Save. Documents
+  // (the "received" binding) are always read live from the query, so an upload
+  // landing while the drawer is open is reflected without clobbering edits.
+  const [baseline, setBaseline] = useState<DraftSlot[] | null>(null);
+  const [draft, setDraft] = useState<DraftSlot[] | null>(null);
+  const newKeyCounter = useRef(0);
+  const nextKey = () => `new-${newKeyCounter.current++}`;
 
-      utils.gantt.listSlots.setData(queryKey, (current) => {
-        const prev = current ?? [];
-        if (count === prev.length) return prev;
-        if (count < prev.length) return prev.slice(0, count);
-        // Mirror the server's name-picking so the placeholder matches the
-        // value that will arrive on reconcile (no visible name flip).
-        const existingNames: (string | null)[] = prev.map((s) => s.name);
-        const now = new Date();
-        const baseId = `${OPTIMISTIC_SLOT_ID_PREFIX}${now.getTime()}`;
-        const additions = Array.from({ length: count - prev.length }, (_, i) => {
-          const name = nextSuggestedSlotName(kind, existingNames);
-          existingNames.push(name);
-          return {
-            id: `${baseId}-${i}`,
-            taskId,
-            kind,
-            index: prev.length + i,
-            name,
-            dueDate: null,
-            createdAt: now,
-            updatedAt: now,
-            document: null,
-          };
-        });
-        return [...prev, ...additions];
-      });
+  // Seed baseline + draft from the server, once per kind. `seededKind` guards
+  // against reseeding on later refetches (e.g. an upload binding a doc), which
+  // would clobber the user's in-progress edits. Switching kind clears it so
+  // the new kind's data seeds a fresh draft; the parent already guards that
+  // switch behind the discard confirm when there are unsaved changes.
+  const seededKind = useRef<SlotKind | null>(null);
+  useEffect(() => {
+    if (seededKind.current !== kind) {
+      seededKind.current = null;
+      setBaseline(null);
+      setDraft(null);
+    }
+    if (slotsQuery.data && seededKind.current !== kind) {
+      seededKind.current = kind;
+      const initial = slotsQuery.data.map(toDraft);
+      setBaseline(initial);
+      setDraft(initial);
+    }
+  }, [kind, slotsQuery.data]);
 
-      return { previous };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.previous) {
-        utils.gantt.listSlots.setData(
-          { organizationId, projectId, taskId, kind },
-          ctx.previous,
-        );
-      }
-    },
-    onSettled: () => {
+  const docByServerId = useMemo(() => {
+    const map = new Map<string, ServerSlot['document']>();
+    (slotsQuery.data ?? []).forEach((s) => {
+      if (s.document) map.set(s.id, s.document);
+    });
+    return map;
+  }, [slotsQuery.data]);
+
+  const docFor = (row: DraftSlot) => (row.serverId ? docByServerId.get(row.serverId) ?? null : null);
+
+  const changeCount = useMemo(() => {
+    if (!draft || !baseline) return 0;
+    const draftServerIds = new Set(draft.filter((d) => d.serverId).map((d) => d.serverId));
+    const baseById = new Map(baseline.filter((b) => b.serverId).map((b) => [b.serverId, b] as const));
+    let count = draft.filter((d) => !d.serverId).length; // added
+    count += baseline.filter((b) => b.serverId && !draftServerIds.has(b.serverId)).length; // removed
+    draft.forEach((d) => {
+      if (!d.serverId) return;
+      const b = baseById.get(d.serverId);
+      if (b && (d.name.trim() !== b.name.trim() || d.dueDate !== b.dueDate)) count += 1; // edited
+    });
+    return count;
+  }, [draft, baseline]);
+
+  const isDirty = changeCount > 0;
+
+  useEffect(() => {
+    onDirtyChange(isDirty);
+  }, [isDirty, onDirtyChange]);
+
+  // ── Save ──────────────────────────────────────────────────────────────
+  const [showSaved, setShowSaved] = useState(false);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (closeTimer.current) clearTimeout(closeTimer.current); }, []);
+
+  const saveMutation = api.gantt.saveSlots.useMutation({
+    onSuccess: (saved) => {
+      // Adopt the canonical server result so brand-new rows pick up their real
+      // ids (and dirty resets to clean → the close below won't trip the guard).
+      const next = saved.map((s) => ({
+        key: s.id,
+        serverId: s.id,
+        name: s.name ?? '',
+        dueDate: s.dueDate ? toInputDate(s.dueDate) : '',
+      }));
+      setBaseline(next);
+      setDraft(next);
       void utils.gantt.listSlots.invalidate({ organizationId, projectId, taskId, kind });
       void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId });
       void utils.gantt.requirementStats.invalidate({ projectId });
+      // Flash "Saved ✓" on the button so the click feels confirmed, then hand
+      // off to the parent to auto-close the drawer + surface the confirmation
+      // banner on the popover underneath.
+      setShowSaved(true);
+      if (closeTimer.current) clearTimeout(closeTimer.current);
+      closeTimer.current = setTimeout(() => {
+        onSaved({ kind, count: next.length });
+      }, 650);
     },
   });
 
-  const updateSlotMutation = api.gantt.updateSlot.useMutation({
-    onSuccess: () => {
-      void utils.gantt.listSlots.invalidate({ organizationId, projectId, taskId, kind });
-    },
-  });
-
-  // Decrement-with-data confirm state.
-  const [confirmRemove, setConfirmRemove] = useState<null | { trailingFilled: number; nextCount: number }>(null);
-
-  // "Filled" now means a slot has a bound document via Document.slotId — no
-  // more docs[i]↔slot[i] positional pairing.
-  const filledCount = slots.reduce((n, s) => n + (s.document ? 1 : 0), 0);
-
-  const handleStepCount = (next: number) => {
-    if (next < 0 || next > 50) return;
-    if (next < slots.length) {
-      // Removing trailing slots — warn if any are bound. The FK is ON DELETE
-      // SET NULL, so the documents survive (just become unbound); the warning
-      // is about the user's intent, not data loss.
-      const trailingFilled = slots
-        .slice(next)
-        .reduce((n, s) => n + (s.document ? 1 : 0), 0);
-      if (trailingFilled > 0) {
-        setConfirmRemove({ trailingFilled, nextCount: next });
-        return;
-      }
-    }
-    setCountMutation.mutate({ organizationId, projectId, taskId, kind, count: next });
-  };
-
-  const confirmAndShrink = () => {
-    if (!confirmRemove) return;
-    setCountMutation.mutate({
+  const handleSave = () => {
+    if (!draft || !isDirty || saveMutation.isPending) return;
+    saveMutation.mutate({
       organizationId,
       projectId,
       taskId,
       kind,
-      count: confirmRemove.nextCount,
+      slots: draft.map((d) => ({
+        id: d.serverId,
+        name: d.name.trim() || null,
+        dueDate: d.dueDate || null,
+      })),
     });
+  };
+
+  const handleDiscard = () => {
+    if (baseline) setDraft(baseline);
+  };
+
+  // ── Draft mutators ────────────────────────────────────────────────────
+  const addSlots = (n: number) => {
+    setDraft((prev) => {
+      const rows = prev ?? [];
+      const names: (string | null)[] = rows.map((r) => r.name || null);
+      const additions: DraftSlot[] = [];
+      for (let i = 0; i < n; i++) {
+        const suggested = nextSuggestedSlotName(kind, names) ?? '';
+        names.push(suggested || null);
+        additions.push({ key: nextKey(), serverId: null, name: suggested, dueDate: '' });
+      }
+      return [...rows, ...additions];
+    });
+  };
+
+  // Decrement-with-data confirm state.
+  const [confirmRemove, setConfirmRemove] = useState<null | { trailingFilled: number; nextCount: number }>(null);
+
+  const handleStepCount = (next: number) => {
+    if (!draft || next < 0 || next > 50) return;
+    if (next > draft.length) {
+      addSlots(next - draft.length);
+    } else if (next < draft.length) {
+      // Removing trailing slots — warn if any removed slot has a bound document.
+      // The file survives (FK is ON DELETE SET NULL), but the user should know
+      // the upload will detach when they save.
+      const trailingFilled = draft.slice(next).filter((d) => docFor(d)).length;
+      if (trailingFilled > 0) {
+        setConfirmRemove({ trailingFilled, nextCount: next });
+        return;
+      }
+      setDraft(draft.slice(0, next));
+    }
+  };
+
+  const confirmAndShrink = () => {
+    if (!confirmRemove || !draft) return;
+    setDraft(draft.slice(0, confirmRemove.nextCount));
     setConfirmRemove(null);
   };
 
-  const isLoading = slotsQuery.isLoading;
+  const setRowName = (key: string, name: string) => {
+    setDraft((prev) => (prev ? prev.map((r) => (r.key === key ? { ...r, name } : r)) : prev));
+  };
+  const setRowDue = (key: string, dueDate: string) => {
+    setDraft((prev) => (prev ? prev.map((r) => (r.key === key ? { ...r, dueDate } : r)) : prev));
+  };
+
+  const isLoading = slotsQuery.isLoading || draft === null;
+  const rows = draft ?? [];
+
+  // Summary counts across the draft.
+  const today = startOfDay(new Date());
+  let receivedCount = 0;
+  let draftCount = 0;
+  let overdueCount = 0;
+  rows.forEach((r) => {
+    const doc = docFor(r);
+    if (doc) { receivedCount += 1; return; }
+    if (!r.serverId) { draftCount += 1; return; }
+    if (r.dueDate && isBefore(new Date(r.dueDate), today)) overdueCount += 1;
+  });
+  const pendingCount = rows.length - receivedCount - draftCount - overdueCount;
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
@@ -456,9 +605,9 @@ function DrawerContent({
             </Typography>
           </Box>
           <Stepper
-            value={slots.length}
+            value={rows.length}
             onChange={handleStepCount}
-            disabled={isLoading}
+            disabled={isLoading || saveMutation.isPending}
           />
         </Box>
 
@@ -476,7 +625,12 @@ function DrawerContent({
             Slots
           </Typography>
           <Typography sx={{ ml: 'auto', fontSize: 11, color: 'text.secondary' }}>
-            <SlotSummary slots={slots} filledCount={filledCount} />
+            <SlotSummary
+              received={receivedCount}
+              draft={draftCount}
+              overdue={overdueCount}
+              pending={pendingCount}
+            />
           </Typography>
         </Box>
 
@@ -485,67 +639,198 @@ function DrawerContent({
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
             <CircularProgress size={16} />
           </Box>
-        ) : slots.length === 0 ? (
-          <EmptyState kind={kind} onSeed={(count) => setCountMutation.mutate({ organizationId, projectId, taskId, kind, count })} />
+        ) : rows.length === 0 ? (
+          <EmptyState kind={kind} onSeed={(count) => addSlots(count)} />
         ) : (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            {slots.map((slot) => {
-              const isPending = isOptimisticSlotId(slot.id);
-              return (
-                <SlotCard
-                  key={slot.id}
-                  slot={slot}
-                  kind={kind}
-                  doc={slot.document}
-                  organizationId={organizationId}
-                  memberRole={memberRole}
-                  // Optimistic rows hold placeholder IDs that don't exist on
-                  // the server yet — block any action that would send the ID.
-                  isPending={isPending}
-                  onRename={(name) => {
-                    if (isPending) return;
-                    updateSlotMutation.mutate({ organizationId, projectId, slotId: slot.id, name });
-                  }}
-                  onSetDueDate={(dueDate) => {
-                    if (isPending) return;
-                    updateSlotMutation.mutate({ organizationId, projectId, slotId: slot.id, dueDate });
-                  }}
-                  onUpload={() => {
-                    if (isPending) return;
-                    onUploadToFolder(slot.id);
-                  }}
-                />
-              );
-            })}
+            {rows.map((row, idx) => (
+              <SlotCard
+                key={row.key}
+                index={idx}
+                kind={kind}
+                row={row}
+                doc={docFor(row)}
+                isNew={!row.serverId}
+                organizationId={organizationId}
+                memberRole={memberRole}
+                onRename={(name) => setRowName(row.key, name)}
+                onSetDueDate={(dueDate) => setRowDue(row.key, dueDate)}
+                onUpload={() => {
+                  if (row.serverId) onUploadToFolder(row.serverId);
+                }}
+              />
+            ))}
           </Box>
         )}
       </Box>
 
-      <Box
-        sx={{
-          borderTop: '1px solid',
-          borderColor: 'divider',
-          px: 2.5,
-          py: 1.25,
-          // Match the drawer surface (like the header) so the footer reads as
-          // drawer chrome rather than a dark strip in dark mode.
-          bgcolor: 'background.paper',
-        }}
-      >
-        <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>
-          Changes save automatically · close to return to the task
-        </Typography>
-      </Box>
+      <SaveBar
+        dirty={isDirty}
+        changeCount={changeCount}
+        saving={saveMutation.isPending}
+        saved={showSaved}
+        onSave={handleSave}
+        onDiscard={handleDiscard}
+      />
 
       {/* Decrement confirm */}
       {confirmRemove && (
-        <ConfirmRemoveDialog
-          trailingFilled={confirmRemove.trailingFilled}
-          kind={kind}
+        <ConfirmDialog
+          title="Remove filled slot?"
+          description={
+            <>
+              {confirmRemove.trailingFilled === 1
+                ? '1 slot has'
+                : `${confirmRemove.trailingFilled} slots have`}{' '}
+              an uploaded {meta.label}. Removing will detach the file
+              {confirmRemove.trailingFilled === 1 ? '' : 's'} from the slot but keep
+              {confirmRemove.trailingFilled === 1 ? ' it' : ' them'} in the project&apos;s library.
+            </>
+          }
+          cancelLabel="Cancel"
+          confirmLabel="Remove"
           onCancel={() => setConfirmRemove(null)}
           onConfirm={confirmAndShrink}
         />
       )}
+    </Box>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Save bar — replaces the old "saves automatically" footer
+// ────────────────────────────────────────────────────────────────────────────
+function SaveBar({
+  dirty,
+  changeCount,
+  saving,
+  saved,
+  onSave,
+  onDiscard,
+}: {
+  dirty: boolean;
+  changeCount: number;
+  saving: boolean;
+  saved: boolean;
+  onSave: () => void;
+  onDiscard: () => void;
+}) {
+  const status: 'saving' | 'saved' | 'idle' = saving ? 'saving' : saved ? 'saved' : 'idle';
+  return (
+    <Box
+      sx={{
+        borderTop: '1px solid',
+        borderColor: 'divider',
+        px: 2.5,
+        py: 1.5,
+        bgcolor: 'background.default',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.25,
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.875, minWidth: 0 }}>
+        {dirty ? (
+          <>
+            <Box
+              sx={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                bgcolor: 'warning.main',
+                boxShadow: '0 0 0 3px rgba(217,119,6,0.18)',
+                flexShrink: 0,
+              }}
+            />
+            <Typography sx={{ fontSize: 12, fontWeight: 500, color: 'text.primary' }}>
+              {changeCount} unsaved {changeCount === 1 ? 'change' : 'changes'}
+            </Typography>
+          </>
+        ) : (
+          <Typography
+            sx={{
+              fontSize: 12,
+              fontWeight: 500,
+              color: status === 'saved' ? 'success.main' : 'text.secondary',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.625,
+            }}
+          >
+            {status === 'saved' && <CheckCircle size={13} weight="fill" />}
+            {status === 'saved' ? 'All changes saved' : 'No unsaved changes'}
+          </Typography>
+        )}
+      </Box>
+
+      {dirty && (
+        <Box
+          component="button"
+          type="button"
+          onClick={onDiscard}
+          disabled={saving}
+          sx={{
+            ml: 'auto',
+            background: 'transparent',
+            border: 'none',
+            fontFamily: 'inherit',
+            fontSize: 12,
+            fontWeight: 500,
+            color: 'text.secondary',
+            cursor: saving ? 'default' : 'pointer',
+            p: 0.5,
+            '&:hover': { color: 'text.primary' },
+          }}
+        >
+          Discard
+        </Box>
+      )}
+
+      <Box
+        component="button"
+        type="button"
+        onClick={onSave}
+        disabled={!dirty || saving}
+        aria-label="Save requirements"
+        sx={{
+          ml: dirty ? 0 : 'auto',
+          minWidth: 104,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 0.75,
+          px: 1.75,
+          py: 0.875,
+          borderRadius: '8px',
+          border: 'none',
+          fontFamily: 'inherit',
+          fontSize: 13,
+          fontWeight: 600,
+          cursor: !dirty || saving ? 'default' : 'pointer',
+          color: '#fff',
+          bgcolor: status === 'saved' ? 'success.main' : 'primary.main',
+          opacity: !dirty && status !== 'saved' ? 0.45 : 1,
+          transition: 'background-color 0.25s, transform 0.12s, opacity 0.2s',
+          transform: status === 'saved' ? 'scale(1.04)' : 'scale(1)',
+          '&:hover': {
+            bgcolor: status === 'saved' ? 'success.main' : 'primary.dark',
+          },
+        }}
+      >
+        {status === 'saving' ? (
+          <>
+            <CircularProgress size={13} thickness={5} sx={{ color: '#fff' }} />
+            Saving…
+          </>
+        ) : status === 'saved' ? (
+          <>
+            <CheckCircle size={15} weight="fill" />
+            Saved
+          </>
+        ) : (
+          'Save'
+        )}
+      </Box>
     </Box>
   );
 }
@@ -617,24 +902,28 @@ function Stepper({
 // Slot summary text
 // ────────────────────────────────────────────────────────────────────────────
 function SlotSummary({
-  slots,
-  filledCount,
+  received,
+  draft,
+  overdue,
+  pending,
 }: {
-  slots: { dueDate: Date | null; document: { id: string } | null }[];
-  filledCount: number;
+  received: number;
+  draft: number;
+  overdue: number;
+  pending: number;
 }) {
-  const today = startOfDay(new Date());
-  // FK semantics: a slot is overdue when its dueDate has passed and it has
-  // no bound document. Position no longer determines filled-ness.
-  const overdue = slots.filter(
-    (s) => !s.document && s.dueDate && isBefore(new Date(s.dueDate), today),
-  ).length;
-  const pending = slots.length - filledCount;
   const parts: React.ReactNode[] = [];
-  if (filledCount > 0) {
+  if (received > 0) {
     parts.push(
       <Box key="r" component="span" sx={{ color: RECEIVED_COLOR, fontWeight: 600 }}>
-        {filledCount} received
+        {received} received
+      </Box>,
+    );
+  }
+  if (draft > 0) {
+    parts.push(
+      <Box key="d" component="span" sx={{ color: SUBMITTAL_COLOR, fontWeight: 600 }}>
+        {draft} draft
       </Box>,
     );
   }
@@ -645,9 +934,9 @@ function SlotSummary({
       </Box>,
     );
   }
-  if (pending - overdue > 0) {
+  if (pending > 0) {
     parts.push(
-      <span key="p">{pending - overdue} pending</span>,
+      <span key="p">{pending} pending</span>,
     );
   }
   return (
@@ -666,12 +955,6 @@ function SlotSummary({
 // ────────────────────────────────────────────────────────────────────────────
 // Slot card
 // ────────────────────────────────────────────────────────────────────────────
-type SlotData = {
-  id: string;
-  index: number;
-  name: string | null;
-  dueDate: Date | null;
-};
 
 // SlotCard only renders the bound document's name + upload date in the
 // footer, so we type doc minimally to accept whatever listSlots returns.
@@ -685,58 +968,57 @@ type SlotBoundDoc = {
 };
 
 function SlotCard({
-  slot,
+  index,
   kind,
+  row,
   doc,
+  isNew,
   organizationId,
   memberRole,
-  isPending = false,
   onRename,
   onSetDueDate,
   onUpload,
 }: {
-  slot: SlotData;
+  index: number;
   kind: SlotKind;
+  row: DraftSlot;
   doc: SlotBoundDoc | null;
+  /** True for an uncommitted draft slot — uploads are gated until saved. */
+  isNew: boolean;
   organizationId: string;
   memberRole: string;
-  /** True while the slot row is an optimistic placeholder (server hasn't returned the real id yet). */
-  isPending?: boolean;
-  onRename: (name: string | null) => void;
-  onSetDueDate: (dueDate: string | null) => void;
+  onRename: (name: string) => void;
+  onSetDueDate: (dueDate: string) => void;
   onUpload: () => void;
 }) {
   const meta = KIND_META[kind];
   const isReceived = !!doc;
   const isApproved = isReceived && doc.approvalStatus === 'approved';
-  const isOverdue = !isReceived && slot.dueDate && isBefore(new Date(slot.dueDate), startOfDay(new Date()));
+  const isOverdue = !isReceived && !isNew && !!row.dueDate && isBefore(new Date(row.dueDate), startOfDay(new Date()));
 
-  // Local input state so typing doesn't fire a mutation per keystroke.
-  const [draftName, setDraftName] = useState(slot.name ?? '');
-  useEffect(() => setDraftName(slot.name ?? ''), [slot.name]);
+  // Local input state so typing doesn't re-render sibling cards per keystroke;
+  // the edit is committed to the parent draft on blur.
+  const [draftName, setDraftName] = useState(row.name);
+  useEffect(() => setDraftName(row.name), [row.name]);
 
   const commitName = () => {
-    const trimmed = draftName.trim();
-    const next = trimmed.length === 0 ? null : trimmed;
-    if (next === slot.name) return;
-    onRename(next);
+    if (draftName === row.name) return;
+    onRename(draftName);
   };
 
   // Native date input — local state so calendar picker doesn't fire mid-edit.
-  const [draftDue, setDraftDue] = useState(slot.dueDate ? toInputDate(slot.dueDate) : '');
-  useEffect(() => setDraftDue(slot.dueDate ? toInputDate(slot.dueDate) : ''), [slot.dueDate]);
+  const [draftDue, setDraftDue] = useState(row.dueDate);
+  useEffect(() => setDraftDue(row.dueDate), [row.dueDate]);
   const commitDue = () => {
-    const next = draftDue || null;
-    const current = slot.dueDate ? toInputDate(slot.dueDate) : null;
-    if (next === current) return;
-    onSetDueDate(next);
+    if (draftDue === row.dueDate) return;
+    onSetDueDate(draftDue);
   };
 
   // Due date is optional — collapsed to a "+ Add due date" button until the
   // user opts in or a value already exists on the slot.
   const [dueDateExpanded, setDueDateExpanded] = useState(false);
   const dueDateInputRef = useRef<HTMLInputElement | null>(null);
-  const showDueDateField = !!slot.dueDate || dueDateExpanded;
+  const showDueDateField = !!row.dueDate || dueDateExpanded;
 
   // Tint hierarchy: approved (green) > received (indigo) > overdue (amber).
   // Received-but-not-approved is intentionally distinct from approved so the
@@ -749,13 +1031,15 @@ function SlotCard({
         ? 'var(--mui-palette-warning-main, #d97706)'
         : null;
   // Only overdue gets a colored border — received/approved rely on tint + pill
-  // for their visual signal so the cards don't shout for attention.
+  // for their visual signal so the cards don't shout for attention. Draft
+  // (unsaved) slots get a dashed border to read as "not yet committed".
   const cardBorderColor = isOverdue ? 'warning.main' : 'divider';
 
   return (
     <Box
       sx={{
         border: '1px solid',
+        borderStyle: isNew ? 'dashed' : 'solid',
         borderColor: cardBorderColor,
         borderRadius: '10px',
         px: 1.75,
@@ -779,7 +1063,7 @@ function SlotCard({
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, mb: 1.25, position: 'relative' }}>
-        <SlotNumberBadge index={slot.index} kind={kind} isReceived={isReceived} isApproved={isApproved} />
+        <SlotNumberBadge index={index} kind={kind} isReceived={isReceived} isApproved={isApproved} />
         <SlotNameInput
           value={draftName}
           onChange={setDraftName}
@@ -787,7 +1071,7 @@ function SlotCard({
           placeholder={`Name this ${meta.label}…`}
           color={meta.color}
         />
-        <SlotStatusPill received={isReceived} overdue={!!isOverdue} approved={isApproved} />
+        <SlotStatusPill received={isReceived} overdue={!!isOverdue} approved={isApproved} draft={isNew} />
       </Box>
 
       <Box sx={{ position: 'relative' }}>
@@ -905,26 +1189,26 @@ function SlotCard({
             component="button"
             type="button"
             onClick={onUpload}
-            disabled={isPending}
-            aria-label={isPending ? 'Saving slot…' : meta.uploadCta}
+            disabled={isNew}
+            aria-label={isNew ? 'Save to enable upload' : meta.uploadCta}
+            title={isNew ? 'Save this requirement to enable uploads' : undefined}
             sx={{
               display: 'inline-flex',
               alignItems: 'center',
               gap: 0.75,
               border: 'none',
               background: 'transparent',
-              cursor: isPending ? 'wait' : 'pointer',
+              cursor: isNew ? 'default' : 'pointer',
               fontFamily: 'inherit',
               fontSize: 11,
               fontWeight: 500,
-              color: meta.color,
-              opacity: isPending ? 0.5 : 1,
+              color: isNew ? 'text.disabled' : meta.color,
               p: 0,
-              '&:hover': { textDecoration: isPending ? 'none' : 'underline' },
+              '&:hover': { textDecoration: isNew ? 'none' : 'underline' },
             }}
           >
             <CloudArrowUp size={13} />
-            {isPending ? 'Saving…' : meta.uploadCta}
+            {isNew ? `${meta.uploadCta} · Save first` : meta.uploadCta}
           </Box>
         )}
       </Box>
@@ -1089,6 +1373,7 @@ function FieldSlot({ label, children }: { label: string; children: React.ReactNo
 // Approved → solid green pill with ✓ (the "done" signal).
 // Received → indigo tint + border + inbox icon ("awaiting your decision",
 //   visually distinct from approved).
+// Draft → blue tint + pencil ("added but not saved yet").
 // Overdue → amber tint, no icon.
 // Pending → neutral gray, no icon.
 const PILL_CONFIG = {
@@ -1105,6 +1390,13 @@ const PILL_CONFIG = {
     color: RECEIVED_COLOR,
     borderColor: alpha(RECEIVED_COLOR, 0.30),
     icon: <Tray size={11} weight="bold" />,
+  },
+  draft: {
+    label: 'Draft',
+    bg: alpha(SUBMITTAL_COLOR, 0.10),
+    color: SUBMITTAL_COLOR,
+    borderColor: alpha(SUBMITTAL_COLOR, 0.30),
+    icon: <PencilSimple size={11} weight="bold" />,
   },
   overdue: {
     label: 'Overdue',
@@ -1126,12 +1418,22 @@ function SlotStatusPill({
   received,
   overdue,
   approved,
+  draft,
 }: {
   received: boolean;
   overdue: boolean;
   approved: boolean;
+  draft: boolean;
 }) {
-  const status = approved ? 'approved' : received ? 'received' : overdue ? 'overdue' : 'pending';
+  const status = approved
+    ? 'approved'
+    : received
+      ? 'received'
+      : draft
+        ? 'draft'
+        : overdue
+          ? 'overdue'
+          : 'pending';
   const config = PILL_CONFIG[status];
   return (
     <Box
@@ -1241,20 +1543,24 @@ function EmptyState({
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Confirm dialog for destructive shrink
+// Warning confirm dialog — shared by the destructive-shrink and discard-edits
+// prompts. Backdrop click cancels; the confirm button is amber.
 // ────────────────────────────────────────────────────────────────────────────
-function ConfirmRemoveDialog({
-  trailingFilled,
-  kind,
+function ConfirmDialog({
+  title,
+  description,
+  cancelLabel,
+  confirmLabel,
   onCancel,
   onConfirm,
 }: {
-  trailingFilled: number;
-  kind: SlotKind;
+  title: string;
+  description: React.ReactNode;
+  cancelLabel: string;
+  confirmLabel: string;
   onCancel: () => void;
   onConfirm: () => void;
 }) {
-  const meta = KIND_META[kind];
   return (
     <Box
       sx={{
@@ -1297,11 +1603,9 @@ function ConfirmRemoveDialog({
             <WarningCircle size={18} color="var(--mui-palette-warning-main, #d97706)" weight="fill" />
           </Box>
           <Box>
-            <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 0.5 }}>Remove filled slot?</Typography>
+            <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 0.5 }}>{title}</Typography>
             <Typography sx={{ fontSize: 12, color: 'text.secondary', lineHeight: 1.5 }}>
-              {trailingFilled === 1 ? '1 slot has' : `${trailingFilled} slots have`} an uploaded {meta.label}.
-              Removing will detach the file{trailingFilled === 1 ? '' : 's'} from the slot but keep
-              {trailingFilled === 1 ? ' it' : ' them'} in the project's library.
+              {description}
             </Typography>
           </Box>
         </Box>
@@ -1320,7 +1624,7 @@ function ConfirmRemoveDialog({
               cursor: 'pointer',
             }}
           >
-            Cancel
+            {cancelLabel}
           </Box>
           <Box
             component="button"
@@ -1338,7 +1642,7 @@ function ConfirmRemoveDialog({
               '&:hover': { filter: 'brightness(0.95)' },
             }}
           >
-            Remove
+            {confirmLabel}
           </Box>
         </Box>
       </Box>

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -14,7 +14,7 @@ import { trackUpload } from '@/store/uploadStatusStore';
 import type { PopoverPlacement, BryntumGanttInstance } from '../types';
 import type { PreviewDoc, DocumentItem } from './task-popover/types';
 
-import { ArrowsInSimple, ArrowsOutSimple } from '@phosphor-icons/react';
+import { ArrowsInSimple, ArrowsOutSimple, CheckCircle } from '@phosphor-icons/react';
 import TaskHeader from './task-popover/TaskHeader';
 import CoverImageBanner from './task-popover/CoverImageBanner';
 import FolderRow from './task-popover/FolderRow';
@@ -53,6 +53,16 @@ export function TaskDetailsPopover({
   const [uploadTarget, setUploadTarget] = useState<{ folder: { id: string; name: string }; slotId?: string } | null>(null);
   const [rightPanel, setRightPanel] = useState<RightPanel>(null);
   const [drawerKind, setDrawerKind] = useState<SlotKind | null>(null);
+  // Transient confirmation shown on the popover after the drawer saves + closes.
+  const [savedNotice, setSavedNotice] = useState<{ kind: SlotKind; count: number } | null>(null);
+  const savedNoticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (savedNoticeTimer.current) clearTimeout(savedNoticeTimer.current); }, []);
+  const handleRequirementsSaved = useCallback((info: { kind: SlotKind; count: number }) => {
+    setDrawerKind(null); // auto-close the drawer
+    setSavedNotice(info);
+    if (savedNoticeTimer.current) clearTimeout(savedNoticeTimer.current);
+    savedNoticeTimer.current = setTimeout(() => setSavedNotice(null), 2800);
+  }, []);
   // Per-slot upload tracking — drives the in-place "Uploading…" badge on
   // SlotDropzone rows so the user can see where the file is landing even
   // after the dialog closes. Both the dialog path and the DnD path feed
@@ -114,10 +124,12 @@ export function TaskDetailsPopover({
   );
 
   // ── Requirement mutation ──
-  // Routed through setSlotCount so the popover stepper, the drawer, and the
-  // slot table all share a single write path. Updating only the legacy column
-  // here used to leave orphan TaskRequirementSlot rows that silently reappeared
-  // on the next increment.
+  // The popover's inline stepper writes immediately through setSlotCount, which
+  // keeps the legacy count column and the TaskRequirementSlot rows in sync in
+  // one transaction. (The drawer is a deferred draft editor and commits via
+  // saveSlots instead; both paths keep the legacy column synced so the two
+  // surfaces interoperate.) Updating only the legacy column here used to leave
+  // orphan slot rows that silently reappeared on the next increment.
   const setSlotCountMutation = api.gantt.setSlotCount.useMutation({
     onSuccess: (_data, variables) => {
       void utils.gantt.taskDetail.invalidate({ organizationId, projectId, taskId: taskId! });
@@ -328,7 +340,8 @@ export function TaskDetailsPopover({
           },
         }}
       >
-        <Box sx={{ display: 'flex' }}>
+        <Box sx={{ display: 'flex', position: 'relative' }}>
+          <RequirementsSavedBanner notice={savedNotice} />
           {/* ── LEFT PANEL ── */}
           <Box sx={{ width: POPOVER_WIDTH, flexShrink: 0, bgcolor: 'background.paper', display: 'flex', flexDirection: 'column', maxHeight: '85vh', overflowY: 'auto' }}>
 
@@ -592,6 +605,7 @@ export function TaskDetailsPopover({
           taskName={taskName}
           memberRole={memberRole}
           initialKind={drawerKind}
+          onSaved={handleRequirementsSaved}
           docsByKind={{
             submittal: ((allDocs ?? []) as DocumentItem[]).filter((d) =>
               expandFolderIds('submittals').includes(d.folderId),
@@ -607,5 +621,49 @@ export function TaskDetailsPopover({
         />
       )}
     </>
+  );
+}
+
+// Transient "requirements saved" confirmation, overlaid at the top of the
+// popover after the drawer commits and auto-closes. Slides down, then the
+// parent unmounts it on a timer.
+function RequirementsSavedBanner({ notice }: { notice: { kind: SlotKind; count: number } | null }) {
+  if (!notice) return null;
+  const label = notice.kind === 'submittal' ? 'submittal' : 'inspection';
+  const message =
+    notice.count === 0
+      ? `${label === 'submittal' ? 'Submittal' : 'Inspection'} requirements cleared`
+      : `${notice.count} ${notice.count === 1 ? label : `${label}s`} required · saved`;
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        top: 8,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 6,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.75,
+        px: 1.5,
+        py: 0.875,
+        borderRadius: '999px',
+        bgcolor: 'success.main',
+        color: 'success.contrastText',
+        boxShadow: '0 8px 24px -6px rgba(0,0,0,0.25)',
+        fontSize: 12,
+        fontWeight: 600,
+        whiteSpace: 'nowrap',
+        pointerEvents: 'none',
+        animation: 'reqSavedIn 0.24s cubic-bezier(0.4, 0, 0.2, 1)',
+        '@keyframes reqSavedIn': {
+          from: { opacity: 0, transform: 'translate(-50%, -8px)' },
+          to: { opacity: 1, transform: 'translate(-50%, 0)' },
+        },
+      }}
+    >
+      <CheckCircle size={15} weight="fill" />
+      {message}
+    </Box>
   );
 }

--- a/src/lib/validations/gantt.ts
+++ b/src/lib/validations/gantt.ts
@@ -119,9 +119,30 @@ export const updateSlotSchema = z.object({
   dueDate: z.string().or(z.date()).nullable().optional(),
 });
 
+// Batch reconcile for the requirements drawer. The client edits a local draft
+// (count + names + due dates) and commits the whole list at once. `slots` is
+// the desired ordered list: a non-null `id` targets an existing row (update),
+// `id: null` is a brand-new slot (create), and any current row whose id is
+// absent from the list is deleted. The legacy count column is synced to the
+// list length so popover readers stay in step.
+export const saveSlotsSchema = z.object({
+  taskId: z.string(),
+  kind: slotKindSchema,
+  slots: z
+    .array(
+      z.object({
+        id: z.string().nullable(),
+        name: z.string().trim().max(200).nullable(),
+        dueDate: z.string().or(z.date()).nullable(),
+      }),
+    )
+    .max(50),
+});
+
 export type ListSlotsInput = z.infer<typeof listSlotsSchema>;
 export type SetSlotCountInput = z.infer<typeof setSlotCountSchema>;
 export type UpdateSlotInput = z.infer<typeof updateSlotSchema>;
+export type SaveSlotsInput = z.infer<typeof saveSlotsSchema>;
 
 // Type exports
 export type GanttLoadInput = z.infer<typeof ganttLoadInputSchema>;

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -8,6 +8,7 @@ import {
   listSlotsSchema,
   setSlotCountSchema,
   updateSlotSchema,
+  saveSlotsSchema,
   type SlotKind,
 } from "@/lib/validations/gantt";
 import { nextSuggestedSlotName } from "@/lib/constants/slotNameLibrary";
@@ -587,6 +588,81 @@ export const ganttRouter = createTRPCRouter({
       return ctx.db.taskRequirementSlot.update({
         where: { id: slotId },
         data,
+      });
+    }),
+
+  // Batch commit for the requirements drawer's draft. Reconciles the whole
+  // ordered list in one transaction: delete removed rows, update kept rows,
+  // create new ones, and sync the legacy count column. Kept rows preserve
+  // their bound documents (matched by id — never delete-and-recreate).
+  saveSlots: orgProcedure
+    .input(z.object({ projectId: z.string() }).merge(saveSlotsSchema))
+    .mutation(async ({ ctx, input }) => {
+      if (!canApproveDocuments(ctx.membership.role)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have permission to manage requirements",
+        });
+      }
+
+      const { projectId, taskId, kind, slots } = input;
+
+      const task = await ctx.db.ganttTask.findFirst({
+        where: { id: taskId, projectId, project: { organizationId: ctx.organization.id } },
+        select: { id: true },
+      });
+      if (!task) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Task not found" });
+      }
+
+      const legacyField = kind === "submittal" ? "requiredSubmittals" : "requiredInspections";
+
+      return ctx.db.$transaction(async (tx) => {
+        const current = await tx.taskRequirementSlot.findMany({
+          where: { taskId, kind },
+          select: { id: true },
+        });
+        const currentIds = new Set(current.map((s) => s.id));
+        const keepIds = new Set(
+          slots.map((s) => s.id).filter((id): id is string => id !== null),
+        );
+
+        // Delete rows the draft dropped. The Document.slotId FK is ON DELETE
+        // SET NULL, so any bound file survives in the library (just unbound).
+        const toDelete = current.filter((s) => !keepIds.has(s.id)).map((s) => s.id);
+        if (toDelete.length > 0) {
+          await tx.taskRequirementSlot.deleteMany({ where: { id: { in: toDelete } } });
+        }
+
+        // Reconcile in array order. index === array position. The drawer only
+        // adds/removes trailing slots (no reorder), so kept rows keep their
+        // existing index — updating index in place can't collide on the
+        // @@unique([taskId, kind, index]) constraint.
+        for (let i = 0; i < slots.length; i++) {
+          const slot = slots[i]!;
+          const data = {
+            index: i,
+            name: slot.name === null ? null : slot.name.trim() || null,
+            dueDate: slot.dueDate === null ? null : new Date(slot.dueDate),
+          };
+          if (slot.id !== null && currentIds.has(slot.id)) {
+            await tx.taskRequirementSlot.update({ where: { id: slot.id }, data });
+          } else {
+            await tx.taskRequirementSlot.create({ data: { taskId, kind, ...data } });
+          }
+        }
+
+        // Keep the legacy count column in sync so existing readers (popover
+        // header, requirementStats, TrackableFolderContent) don't change.
+        await tx.ganttTask.update({
+          where: { id: taskId },
+          data: { [legacyField]: slots.length === 0 ? null : slots.length },
+        });
+
+        return tx.taskRequirementSlot.findMany({
+          where: { taskId, kind },
+          orderBy: { index: "asc" },
+        });
       });
     }),
 });


### PR DESCRIPTION
## Summary

- Replaces the requirements drawer's auto-save-per-mutation model with a local draft editor: count, names, and due dates are edited in React state and committed as a batch via a new `gantt.saveSlots` tRPC mutation (reconcile by id — delete dropped rows, update kept rows, create new ones, sync legacy count column)
- Adds a `SaveBar` with dirty tracking, Discard, and save/saving/saved states; a discard guard (modal) on close or tab-switch when edits are pending; and a `RequirementsSavedBanner` that slides into the task popover after the drawer auto-closes
- Draft (unsaved) slots render with a dashed border and "Draft" pill; uploads are blocked on unsaved slots

## Test plan

- [ ] Open the requirements drawer, edit names/due dates, and verify the Save bar appears with the correct change count
- [ ] Click Discard and confirm edits are reverted; try closing or switching tabs with unsaved edits to confirm the guard dialog appears
- [ ] Save and confirm the "Saved ✓" flash, auto-close, and the confirmation banner on the popover
- [ ] Add new (draft) slots, verify dashed border + "Draft" pill + uploads disabled; save and confirm slots become real
- [ ] `npm test` passes (slot validation schema tests + router reconcile logic tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)