### PR TITLE
Remove deprecated sentry.client.config.ts (use instrumentation-client.ts)

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,8 +1,0 @@
-import * as Sentry from "@sentry/nextjs";
-
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-  enabled: process.env.NODE_ENV !== "development",
-  debug: false,
-});


### PR DESCRIPTION
## Summary

- Deletes the deprecated root-level `sentry.client.config.ts`, which no longer works with Turbopack and was generating a `@sentry/nextjs` deprecation warning on every dev server start.
- Client-side Sentry init was already migrated to `src/instrumentation-client.ts` (Next.js 15 convention) with a more complete config: replay integration, `replaysOnErrorSampleRate: 1.0`, and `onRouterTransitionStart` for router-transition performance spans.

## Test plan
- [ ] Dev server starts without the `sentry.client.config.ts` deprecation warning
- [ ] Sentry events still captured in production (DSN wired via `NEXT_PUBLIC_SENTRY_DSN`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)