### PR TITLE
Fix Gantt row ordering and add drag-to-reorder

### DIFF
--- a/src/__tests__/server/gantt-sync-add.test.ts
+++ b/src/__tests__/server/gantt-sync-add.test.ts
@@ -40,6 +40,7 @@ type MockTx = {
     deleteMany: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
     findUnique: ReturnType<typeof vi.fn>;
+    groupBy: ReturnType<typeof vi.fn>;
   };
   ganttDependency: { create: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn>; deleteMany: ReturnType<typeof vi.fn> };
   ganttResource: { create: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn>; deleteMany: ReturnType<typeof vi.fn> };
@@ -55,6 +56,8 @@ function makeCtx() {
       deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
       findMany: vi.fn().mockResolvedValue([]),
       findUnique: vi.fn().mockResolvedValue(null),
+      // Empty project by default → no per-parent rows → new tasks start at 0.
+      groupBy: vi.fn().mockResolvedValue([]),
     },
     ganttDependency: {
       create: vi.fn().mockResolvedValue({}),
@@ -306,6 +309,196 @@ describe("gantt.sync — add task", () => {
     }
     // Sanity: the update still ran against the DB.
     expect(ctx.tx.ganttTask.update).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression for the "rows reshuffle on refresh" bug: Bryntum never sends our
+  // custom orderIndex, so added root tasks must be appended after the root
+  // group's current max instead of all defaulting to 0 (which makes load
+  // ordering a non-deterministic tie). Here the root group already has tasks up
+  // to index 4, so the two new root tasks must get 5 and 6 in batch order.
+  it("appends new tasks after the existing max orderIndex (no 0-collision)", async () => {
+    const ctx = makeCtx();
+    ctx.tx.ganttTask.groupBy.mockResolvedValue([
+      { parentId: null, _max: { orderIndex: 4 } },
+    ]);
+
+    await sync._handler({
+      ctx,
+      input: {
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        tasks: {
+          added: [
+            { $PhantomId: "_a", name: "First added" },
+            { $PhantomId: "_b", name: "Second added" },
+          ],
+        },
+      },
+    });
+
+    const callsData = ctx.tx.ganttTask.create.mock.calls.map(
+      (c) => (c[0] as { data: Record<string, unknown> }).data,
+    );
+    const first = callsData.find((d) => d.name === "First added");
+    const second = callsData.find((d) => d.name === "Second added");
+
+    expect(first!.orderIndex).toBe(5);
+    expect(second!.orderIndex).toBe(6);
+  });
+
+  // The append index is scoped PER SIBLING GROUP (parentId), not project-wide.
+  // This is the core of the reorder-survives-reload fix: orderIndex must live
+  // in the same 0-based space as Bryntum's per-level position, so an un-moved
+  // sibling is never stranded with a project-scale index. Here the root group
+  // is at index 9 but the parent "P1" group only reaches 2, so a new child of
+  // P1 must get 3 — not 10.
+  it("scopes the append index to the task's own sibling group", async () => {
+    const ctx = makeCtx();
+    ctx.tx.ganttTask.groupBy.mockResolvedValue([
+      { parentId: null, _max: { orderIndex: 9 } },
+      { parentId: "P1", _max: { orderIndex: 2 } },
+    ]);
+    // P1 already exists, so it is not an orphan parent.
+    ctx.tx.ganttTask.findMany.mockResolvedValue([{ id: "P1" }]);
+
+    await sync._handler({
+      ctx,
+      input: {
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        tasks: { added: [{ $PhantomId: "_child", name: "Child of P1", parentId: "P1" }] },
+      },
+    });
+
+    const createArgs = ctx.tx.ganttTask.create.mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(createArgs.data.parentId).toBe("P1");
+    expect(createArgs.data.orderIndex).toBe(3);
+  });
+
+  // An empty project (no per-parent rows) must start new tasks at 0, not crash.
+  it("starts new tasks at orderIndex 0 in an empty project", async () => {
+    const ctx = makeCtx();
+    // groupBy already returns [] by default → root group starts at 0
+
+    await sync._handler({
+      ctx,
+      input: {
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        tasks: { added: [{ $PhantomId: "_first", name: "Only task" }] },
+      },
+    });
+
+    const createArgs = ctx.tx.ganttTask.create.mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(createArgs.data.orderIndex).toBe(0);
+  });
+
+  // Drag-to-reorder: Bryntum sends the moved sibling as an UPDATE carrying its
+  // recalculated tree position in `orderedParentIndex`. The server must map that
+  // onto the orderIndex column so the order survives reload.
+  it("maps orderedParentIndex onto orderIndex on a reorder", async () => {
+    const ctx = makeCtx();
+    ctx.tx.ganttTask.update.mockResolvedValue({ id: "task-moved" });
+
+    await sync._handler({
+      ctx,
+      input: {
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        tasks: {
+          updated: [{ id: "task-moved", orderedParentIndex: 2 }],
+        },
+      },
+    });
+
+    expect(ctx.tx.ganttTask.update).toHaveBeenCalledTimes(1);
+    const updateArgs = ctx.tx.ganttTask.update.mock.calls[0]![0] as {
+      where: { id: string };
+      data: Record<string, unknown>;
+    };
+    expect(updateArgs.where.id).toBe("task-moved");
+    expect(updateArgs.data.orderIndex).toBe(2);
+  });
+
+  // parentIndex is the structural fallback used when orderedParentIndex is absent
+  // (equal to it when no column sorter is active).
+  it("falls back to parentIndex when orderedParentIndex is absent", async () => {
+    const ctx = makeCtx();
+    ctx.tx.ganttTask.update.mockResolvedValue({ id: "task-moved" });
+
+    await sync._handler({
+      ctx,
+      input: {
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        tasks: {
+          updated: [{ id: "task-moved", parentIndex: 3 }],
+        },
+      },
+    });
+
+    const updateArgs = ctx.tx.ganttTask.update.mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(updateArgs.data.orderIndex).toBe(3);
+  });
+
+  // Bulletproof reorder: an un-moved sibling must not keep a stale orderIndex.
+  // Bryntum only re-sends the rows that moved (here C and B), never the row that
+  // stays put (A). The group is stored with non-0-based indices (6, 7, 8), so a
+  // per-row write alone would leave A at 6 and reload the group as C, B, A. The
+  // post-loop renumber must rebuild the whole group as a dense 0..N-1 sequence,
+  // pulling the un-moved A back to 0 → final order A, C, B.
+  it("renumbers the whole sibling group so an un-moved row isn't stranded", async () => {
+    const ctx = makeCtx();
+    ctx.tx.ganttTask.findMany.mockImplementation(
+      (args: { where?: { id?: { in?: string[] }; parentId?: string | null } }) => {
+        const where = args?.where ?? {};
+        // renumber step 1: final parents of the moved rows (both root → null)
+        if (where.id?.in) {
+          return Promise.resolve(where.id.in.map((id) => ({ id, parentId: null })));
+        }
+        // renumber step 2: current children of the root group, pre-reorder order
+        if ("parentId" in where) {
+          return Promise.resolve([
+            { id: "A", orderIndex: 6 },
+            { id: "B", orderIndex: 7 },
+            { id: "C", orderIndex: 8 },
+          ]);
+        }
+        return Promise.resolve([]);
+      },
+    );
+
+    await sync._handler({
+      ctx,
+      input: {
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        tasks: {
+          updated: [
+            { id: "C", orderedParentIndex: 1 },
+            { id: "B", orderedParentIndex: 2 },
+          ],
+        },
+      },
+    });
+
+    // Last orderIndex written per id across the tentative write + the renumber.
+    const finalOrder = new Map<string, number>();
+    for (const call of ctx.tx.ganttTask.update.mock.calls) {
+      const arg = call[0] as { where: { id: string }; data: { orderIndex?: number } };
+      if (typeof arg.data.orderIndex === "number") {
+        finalOrder.set(arg.where.id, arg.data.orderIndex);
+      }
+    }
+    expect(finalOrder.get("A")).toBe(0); // un-moved row rescued from its stale 6
+    expect(finalOrder.get("C")).toBe(1);
+    expect(finalOrder.get("B")).toBe(2);
   });
 
   it("nulls parentId when the referenced parent does not exist (orphan defense)", async () => {

--- a/src/__tests__/server/gantt-tree.test.ts
+++ b/src/__tests__/server/gantt-tree.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { buildTaskTree } from "@/server/api/helpers/ganttTree";
+
+// Minimal valid GanttTaskSelect factory — only the fields the sort/tree care
+// about are meaningful; the rest are filled with inert defaults.
+function task(id: string, orderIndex: number, parentId: string | null = null) {
+  return {
+    id,
+    parentId,
+    name: id,
+    percentDone: 0,
+    startDate: null,
+    endDate: null,
+    duration: null,
+    durationUnit: "day",
+    effort: null,
+    effortUnit: null,
+    expanded: false,
+    manuallyScheduled: false,
+    constraintType: null,
+    constraintDate: null,
+    rollup: false,
+    cls: null,
+    iconCls: null,
+    note: null,
+    csiCode: null,
+    baselines: null,
+    orderIndex,
+    requiredSubmittals: null,
+    requiredInspections: null,
+  };
+}
+
+const names = (rows: Record<string, unknown>[]) => rows.map((r) => r.id as string);
+
+describe("buildTaskTree — ordering", () => {
+  // Regression: buildTaskTree sorts by orderIndex. mapTaskToGantt must carry
+  // orderIndex onto the mapped object, otherwise the comparator ties every row
+  // at 0 and falls back to its id tiebreak — sorting the whole tree by id and
+  // silently ignoring the persisted order (reorders revert on refresh).
+  it("sorts by orderIndex even when it disagrees with id order", () => {
+    // orderIndex order is z(0), a(1), m(2); a pure-id sort would give a, m, z.
+    // They must differ so the regression (sorting purely by id) fails here.
+    const tree = buildTaskTree([task("z", 0), task("a", 1), task("m", 2)]);
+    expect(names(tree)).toEqual(["z", "a", "m"]);
+  });
+
+  it("falls back to id order only when orderIndex ties", () => {
+    // All tied at 0 → deterministic id order (this is the original
+    // reshuffle-stability guarantee).
+    const tree = buildTaskTree([task("m", 0), task("a", 0), task("z", 0)]);
+    expect(names(tree)).toEqual(["a", "m", "z"]);
+  });
+
+  it("sorts children within a parent by orderIndex", () => {
+    const tree = buildTaskTree([
+      task("parent", 0),
+      task("childB", 0, "parent"),
+      task("childA", 1, "parent"),
+    ]);
+    expect(names(tree)).toEqual(["parent"]);
+    const children = tree[0]!.children as Record<string, unknown>[];
+    // childB has orderIndex 0, childA has 1 → B before A despite id order.
+    expect(names(children)).toEqual(["childB", "childA"]);
+  });
+});

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -375,6 +375,14 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         id: t?.id,
         parentId: t?.parentId,
         name: t?.name,
+        // [Gantt:order DEBUG] Surface the order fields so we can see whether a
+        // routine update (e.g. a date edit or post-load scheduling pass) is
+        // dragging orderedParentIndex/parentIndex along — which would make the
+        // server treat it as a reorder and renumber the group. If these appear
+        // in `changedKeys` on a sync the user didn't reorder, that's the bug.
+        orderIndex: t?.orderIndex,
+        orderedParentIndex: t?.orderedParentIndex,
+        parentIndex: t?.parentIndex,
         changedKeys: t ? Object.keys(t).filter((k) => k !== 'id') : [],
       });
 
@@ -388,6 +396,29 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         updated: (p?.tasks?.updated ?? []).map(summarizeUpdated),
         removed: p?.tasks?.removed,
       });
+
+      // [Gantt:order DEBUG] Flat + stringified so console copy-paste keeps it
+      // (collapsed object-arrays get dropped on copy). The key question: does a
+      // sync the user did NOT trigger by dragging carry orderedParentIndex /
+      // parentIndex on its updated rows? If so, the server treats it as a
+      // reorder and renumbers the group.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const orderFields = (t: any) => ({
+        id: t?.id,
+        name: t?.name,
+        parentId: t?.parentId,
+        orderIndex: t?.orderIndex,
+        orderedParentIndex: t?.orderedParentIndex,
+        parentIndex: t?.parentIndex,
+        changed: t ? Object.keys(t).filter((k) => k !== 'id') : [],
+      });
+      console.log(
+        '[Gantt:order CLIENT] outgoing ' +
+          JSON.stringify({
+            added: (p?.tasks?.added ?? []).map(orderFields),
+            updated: (p?.tasks?.updated ?? []).map(orderFields),
+          }),
+      );
     };
 
     // Shadow-track added/removed IDs from the reliable taskStore events so
@@ -438,7 +469,57 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     gantt.project.on('sync', onSync);
     gantt.project.on('syncFail', onSyncFail);
     gantt.project.on('beforeSync', onBeforeSync);
+
+    // A row reorder is a single discrete drop — unlike a task-bar drag it emits
+    // no continuous stream of changes, so it doesn't need the 500ms autoSync
+    // debounce (autoSyncTimeout). Worse, that debounce means a quick refresh
+    // right after dropping cancels the in-flight save and the new order is lost.
+    // Force an immediate sync on drop so the reorder is persisted before the
+    // user can navigate away.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onRowDrop = () => {
+      // [Gantt:order DEBUG] Confirms the immediate-sync path fired on drop.
+      console.log('[Gantt:order CLIENT] gridRowDrop → forcing immediate sync');
+      void (async () => {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+          await gantt.project?.commitAsync?.();
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+          await gantt.project?.sync?.();
+        } catch {
+          // A debounced autoSync may already be flushing the same change;
+          // "sync already in progress" is benign — that sync persists the order.
+        }
+      })();
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    gantt.on('gridRowDrop', onRowDrop);
+
+    // [Gantt:order DEBUG] Log the task order each load produces, in display
+    // (flattened-tree) order. Capture this across two refreshes: if it changes
+    // with no deliberate reorder in between, that's the reshuffle — and the
+    // `[Gantt:order CLIENT] outgoing` line logged just before shows the sync
+    // that corrupted it. Reproducible from the browser console alone.
+    const onLoad = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const order = (((gantt.project.taskStore as any)?.allRecords ?? []) as any[]).map((r) => ({
+        id: String(r?.id),
+        name: r?.name,
+        parentId: r?.parentId ?? null,
+        orderIndex: r?.orderIndex,
+        orderedParentIndex: r?.orderedParentIndex,
+        parentIndex: r?.parentIndex,
+      }));
+      console.log('[Gantt:order CLIENT] loaded order ' + JSON.stringify(order));
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    gantt.project.on('load', onLoad);
+
     return () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      gantt?.un?.('gridRowDrop', onRowDrop);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      gantt.project?.un('load', onLoad);
       gantt.project?.un('sync', onSync);
       gantt.project?.un('syncFail', onSyncFail);
       gantt.project?.un('beforeSync', onBeforeSync);

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -781,12 +781,47 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         }
         .gantt-task-bar-pill-icon svg { display: block; }
         .gantt-task-bar-pill-text { line-height: 1; }
+
+        /* Drag-to-reorder grip states (the grip is Bryntum's ::before on the
+           name cell). Reordering only applies to users who can manage the
+           project, and only while the chart is unlocked (edit mode). */
+        /* Members / viewers can never reorder — hide the grip entirely. */
+        .bryntum-gantt-container[data-can-reorder="false"] .b-row-reorder-grip::before {
+          display: none;
+        }
+        /* Admins in the locked (view) state: show the grip but make it clearly
+           inert — faded with a not-allowed cursor. The "Enter edit mode to
+           reorder tasks" hint is delivered via the cell tooltip (ganttConfig). */
+        .bryntum-gantt-container[data-can-reorder="true"][data-locked="true"] .b-row-reorder-grip::before {
+          opacity: 0.3;
+          cursor: not-allowed;
+        }
+
+        /* Row-reorder drag feedback. While dragging, Bryntum shows a drop-line
+           (.b-row-drop-indicator) and a highlight on the target row, both
+           colored with --b-secondary — a variable our theme never defines, so
+           they paint invisibly. Pin the indicator vars to app tokens so the
+           drop position is clearly shown: a 3px accent line where the row will
+           land (valid) or red (invalid, e.g. dropping onto a leaf). The vars
+           cascade to the indicator + target highlight and flip with dark mode. */
+        .bryntum-gantt-container {
+          --b-row-reorder-indicator-size: 3px;
+          --b-row-reorder-indicator-color: var(--accent-primary);
+          --b-row-reorder-indicator-invalid-color: #ef4444;
+        }
+        /* Lift the row being dragged so the pickup reads clearly. */
+        .b-row-reorder-proxy {
+          box-shadow: 0 8px 24px rgba(15, 23, 42, 0.22);
+          border-radius: 8px;
+          overflow: hidden;
+        }
       `}</style>
 
       <div
         style={GANTT_CONTENT_STYLE}
         className="bryntum-gantt-container"
         data-locked={editingUnlocked ? 'false' : 'true'}
+        data-can-reorder={canEditChart ? 'true' : 'false'}
       >
         <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
           <BryntumGantt
@@ -801,6 +836,15 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
             // `addNewAtEnd: false` here makes Enter only commit the edit; tasks
             // are created exclusively via the "+ Add Task" button.
             cellEditFeature={{ addNewAtEnd: false }}
+            // Drag-to-reorder rows. Passed as a per-feature prop (the React
+            // wrapper drops `features.rowReorder` nested in ganttConfig, same as
+            // cellEdit/taskMenu above). `gripOnly` confines dragging to the grip
+            // handle so it never collides with row-select / double-click-rename;
+            // `dropOnLeaf: false` keeps it to pure reordering (no accidental
+            // reparenting). It inherits `gantt.readOnly = !editingUnlocked`, so
+            // it's automatically off when the chart is locked or for non-admins.
+            // New order persists via the `orderedParentIndex` field → orderIndex.
+            rowReorderFeature={{ showGrip: true, gripOnly: true, dropOnLeaf: false }}
           />
         </div>
 

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -375,14 +375,6 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         id: t?.id,
         parentId: t?.parentId,
         name: t?.name,
-        // [Gantt:order DEBUG] Surface the order fields so we can see whether a
-        // routine update (e.g. a date edit or post-load scheduling pass) is
-        // dragging orderedParentIndex/parentIndex along — which would make the
-        // server treat it as a reorder and renumber the group. If these appear
-        // in `changedKeys` on a sync the user didn't reorder, that's the bug.
-        orderIndex: t?.orderIndex,
-        orderedParentIndex: t?.orderedParentIndex,
-        parentIndex: t?.parentIndex,
         changedKeys: t ? Object.keys(t).filter((k) => k !== 'id') : [],
       });
 
@@ -396,29 +388,6 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         updated: (p?.tasks?.updated ?? []).map(summarizeUpdated),
         removed: p?.tasks?.removed,
       });
-
-      // [Gantt:order DEBUG] Flat + stringified so console copy-paste keeps it
-      // (collapsed object-arrays get dropped on copy). The key question: does a
-      // sync the user did NOT trigger by dragging carry orderedParentIndex /
-      // parentIndex on its updated rows? If so, the server treats it as a
-      // reorder and renumbers the group.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const orderFields = (t: any) => ({
-        id: t?.id,
-        name: t?.name,
-        parentId: t?.parentId,
-        orderIndex: t?.orderIndex,
-        orderedParentIndex: t?.orderedParentIndex,
-        parentIndex: t?.parentIndex,
-        changed: t ? Object.keys(t).filter((k) => k !== 'id') : [],
-      });
-      console.log(
-        '[Gantt:order CLIENT] outgoing ' +
-          JSON.stringify({
-            added: (p?.tasks?.added ?? []).map(orderFields),
-            updated: (p?.tasks?.updated ?? []).map(orderFields),
-          }),
-      );
     };
 
     // Shadow-track added/removed IDs from the reliable taskStore events so
@@ -476,10 +445,7 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     // right after dropping cancels the in-flight save and the new order is lost.
     // Force an immediate sync on drop so the reorder is persisted before the
     // user can navigate away.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const onRowDrop = () => {
-      // [Gantt:order DEBUG] Confirms the immediate-sync path fired on drop.
-      console.log('[Gantt:order CLIENT] gridRowDrop → forcing immediate sync');
       void (async () => {
         try {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
@@ -495,31 +461,9 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     gantt.on('gridRowDrop', onRowDrop);
 
-    // [Gantt:order DEBUG] Log the task order each load produces, in display
-    // (flattened-tree) order. Capture this across two refreshes: if it changes
-    // with no deliberate reorder in between, that's the reshuffle — and the
-    // `[Gantt:order CLIENT] outgoing` line logged just before shows the sync
-    // that corrupted it. Reproducible from the browser console alone.
-    const onLoad = () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const order = (((gantt.project.taskStore as any)?.allRecords ?? []) as any[]).map((r) => ({
-        id: String(r?.id),
-        name: r?.name,
-        parentId: r?.parentId ?? null,
-        orderIndex: r?.orderIndex,
-        orderedParentIndex: r?.orderedParentIndex,
-        parentIndex: r?.parentIndex,
-      }));
-      console.log('[Gantt:order CLIENT] loaded order ' + JSON.stringify(order));
-    };
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-    gantt.project.on('load', onLoad);
-
     return () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       gantt?.un?.('gridRowDrop', onRowDrop);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      gantt.project?.un('load', onLoad);
       gantt.project?.un('sync', onSync);
       gantt.project?.un('syncFail', onSyncFail);
       gantt.project?.un('beforeSync', onBeforeSync);

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -6,12 +6,21 @@ import type { GanttConfig, ColumnRendererData } from '../types';
 // drops them from loaded data. `needsReviewCount` drives the review-queue badge
 // in the name column. `requirementsTotal` / `requirementsFilled` drive the
 // submittal+inspection completion % shown on each task bar.
+//
+// `parentIndex` / `orderedParentIndex` are Bryntum's built-in calculated tree
+// fields (a node's position among its siblings). We re-declare them ONLY to add
+// `persist: true` — so a drag-reorder includes the new position in the sync pack
+// (the server maps it onto our `orderIndex` column). Do NOT add a `type` here:
+// that would shadow Bryntum's calculated getter and the value would stop
+// auto-updating on reorder. This is the documented WBS-sync pattern.
 class AppTaskModel extends TaskModel {
   static override get fields() {
     return [
       { name: 'needsReviewCount', type: 'int', defaultValue: 0 },
       { name: 'requirementsTotal', type: 'int', defaultValue: 0 },
       { name: 'requirementsFilled', type: 'int', defaultValue: 0 },
+      { name: 'parentIndex', persist: true },
+      { name: 'orderedParentIndex', persist: true },
     ];
   }
 }
@@ -172,7 +181,22 @@ export function createGanttConfig(
       percentBar: false,
       tree: { toggleTreeNode: false },
       cellTooltip: {
-        tooltipRenderer: ({ record, column }) => formatTooltipText(record, column.field),
+        tooltipRenderer: ({ record, column, cellElement }) => {
+          // When the user CAN reorder but the chart is locked (not in edit
+          // mode), the drag grip is grayed out — explain why on hover. State is
+          // read live from the container's data attributes at hover time, so it
+          // tracks the edit-mode toggle without rebuilding the stable config.
+          if (column.field === 'name') {
+            const container = cellElement?.closest('.bryntum-gantt-container');
+            if (
+              container?.getAttribute('data-can-reorder') === 'true' &&
+              container?.getAttribute('data-locked') === 'true'
+            ) {
+              return 'Enter edit mode to reorder tasks';
+            }
+          }
+          return formatTooltipText(record, column.field);
+        },
       },
       // Show the proposed end date in a tooltip while the user drags the
       // end-side resize handle. Bryntum's TaskResize is end-only by design;

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -80,6 +80,7 @@ type TooltipRendererArgs = {
   column: {
     field?: string;
   };
+  cellElement?: HTMLElement;
 };
 
 /** Minimal interface for Bryntum dependency records. */

--- a/src/lib/validations/gantt.ts
+++ b/src/lib/validations/gantt.ts
@@ -22,6 +22,11 @@ const taskRecordSchema = z.object({
   effortUnit: z.string().nullable().optional(),
   expanded: z.boolean().optional(),
   orderIndex: z.number().optional(),
+  // Bryntum's calculated tree-position fields (persisted on AppTaskModel). A
+  // drag-reorder sends these on the moved siblings; the server maps them onto
+  // the orderIndex column. The schema otherwise strips unknown keys.
+  orderedParentIndex: z.number().optional(),
+  parentIndex: z.number().optional(),
   manuallyScheduled: z.boolean().optional(),
   constraintType: z.string().nullable().optional(),
   constraintDate: z.string().or(z.date()).nullable().optional(),

--- a/src/server/api/helpers/ganttSync.ts
+++ b/src/server/api/helpers/ganttSync.ts
@@ -124,6 +124,18 @@ export async function syncTasks(
         parentId = null;
       }
 
+      // [Gantt:order DEBUG] The orderIndex assigned to each newly added task.
+      // For a ">4 tasks" bug this shows whether the 5th/6th task gets a sane,
+      // appended index within its sibling group (expected: dense, increasing).
+      const assignedOrderIndex = task.orderIndex ?? nextOrderIndexFor(parentId);
+      console.log('[Gantt:order] sync ADD', {
+        id,
+        name: task.name,
+        parentId,
+        assignedOrderIndex,
+        clientSentOrderIndex: task.orderIndex,
+      });
+
       await db.ganttTask.create({
         data: {
           id,
@@ -138,7 +150,7 @@ export async function syncTasks(
           effort: task.effort ?? null,
           effortUnit: task.effortUnit ?? null,
           expanded: task.expanded ?? false,
-          orderIndex: task.orderIndex ?? nextOrderIndexFor(parentId),
+          orderIndex: assignedOrderIndex,
           manuallyScheduled: task.manuallyScheduled ?? false,
           constraintType: task.constraintType ?? null,
           constraintDate: task.constraintDate ? new Date(task.constraintDate) : null,
@@ -180,6 +192,19 @@ export async function syncTasks(
 
     for (const task of changes.updated) {
       if (!task.id) continue;
+
+      // [Gantt:order DEBUG] Every incoming UPDATE. The key question: does a
+      // routine edit (date/name/percent) arrive carrying orderedParentIndex or
+      // parentIndex? If so it will be treated as a reorder below and trigger a
+      // group renumber even though the user never dragged a row.
+      console.log('[Gantt:order] sync UPDATE recv', {
+        id: task.id,
+        name: task.name,
+        orderIndex: task.orderIndex,
+        orderedParentIndex: task.orderedParentIndex,
+        parentIndex: task.parentIndex,
+        parentId: task.parentId,
+      });
 
       const updateData: Record<string, unknown> = {};
 
@@ -266,6 +291,15 @@ export async function syncTasks(
       }
     }
 
+    // [Gantt:order DEBUG] What the batch concluded is a reorder. If this map is
+    // non-empty for a sync the user didn't reorder, the renumber that follows is
+    // the source of the reshuffle.
+    console.log('[Gantt:order] sync UPDATE batch done', {
+      updatedCount: changes.updated.length,
+      reorderTargets: Object.fromEntries(reorderTargets),
+      willRenumber: reorderTargets.size > 0,
+    });
+
     // The per-row writes above only cover the rows Bryntum re-sent; un-moved
     // siblings keep whatever orderIndex they had (e.g. legacy rows still at 0,
     // or values from a coarser scale). Rebuild each touched group as a dense
@@ -307,16 +341,34 @@ async function renumberReorderedGroups(
   });
   const affectedParents = new Set<string | null>(movedRows.map((r) => r.parentId));
 
+  // [Gantt:order DEBUG]
+  console.log('[Gantt:order] renumber START', {
+    targets: Object.fromEntries(reorderTargets),
+    affectedParents: [...affectedParents],
+  });
+
   for (const parentId of affectedParents) {
     // Current children in their pre-reorder display order; id breaks ties
     // deterministically. Un-moved rows keep their relative order here.
     const children = await db.ganttTask.findMany({
       where: { projectId, parentId },
-      select: { id: true, orderIndex: true },
+      select: { id: true, name: true, orderIndex: true },
       orderBy: [{ orderIndex: "asc" }, { id: "asc" }],
     });
     const n = children.length;
     if (n === 0) continue;
+
+    // [Gantt:order DEBUG] The group as it stands before renumbering, plus which
+    // of these rows Bryntum reported a target for.
+    console.log('[Gantt:order] renumber group: children-before', {
+      parentId,
+      children: children.map((c) => ({
+        id: c.id,
+        name: c.name,
+        orderIndex: c.orderIndex,
+        target: reorderTargets.get(c.id),
+      })),
+    });
 
     // Place each moved row at the slot Bryntum reported; fill the remaining
     // slots, in order, with the rows that didn't move. A target that is
@@ -336,11 +388,27 @@ async function renumberReorderedGroups(
       if (slots[i] === null) slots[i] = leftovers[nextLeftover++] ?? null;
     }
 
+    // [Gantt:order DEBUG] The reconstructed final order for this group
+    // (slot index = new orderIndex). Compare against children-before: rows that
+    // weren't in `targets` but moved position here are being shuffled by the
+    // renumber, not by the user.
+    console.log('[Gantt:order] renumber group: final order', {
+      parentId,
+      finalOrder: slots,
+      leftovers,
+    });
+
     // Persist the dense sequence, writing only the rows whose index changed.
     const currentOrderById = new Map(children.map((c) => [c.id, c.orderIndex]));
     for (let i = 0; i < n; i++) {
       const id = slots[i];
       if (id && currentOrderById.get(id) !== i) {
+        // [Gantt:order DEBUG] Each orderIndex the renumber actually rewrites.
+        console.log('[Gantt:order] renumber WRITE', {
+          id,
+          from: currentOrderById.get(id),
+          to: i,
+        });
         await db.ganttTask.update({
           where: { id, projectId },
           data: { orderIndex: i },

--- a/src/server/api/helpers/ganttSync.ts
+++ b/src/server/api/helpers/ganttSync.ts
@@ -88,6 +88,30 @@ export async function syncTasks(
     // Pre-assigned IDs in this batch also count as "existing" because they insert first.
     for (const { id } of tasksWithIds) existingTaskIds.add(id);
 
+    // Bryntum doesn't track our custom `orderIndex` field, so freshly added
+    // tasks arrive without one. Append each new task after the current max
+    // orderIndex *within its own sibling group* (same parentId) — NOT the
+    // project-wide max. Scoping per-parent keeps orderIndex in the same 0-based
+    // space as Bryntum's per-level position (`parentIndex`), so a later
+    // drag-reorder — which only re-syncs the siblings that actually moved —
+    // never leaves an un-moved sibling stranded with a larger, project-scale
+    // index that would re-sort it ahead of the moved rows on reload.
+    const maxByParent = await db.ganttTask.groupBy({
+      by: ["parentId"],
+      where: { projectId },
+      _max: { orderIndex: true },
+    });
+    // `null` parentId (root-level tasks) is a valid, distinct Map key.
+    const nextOrderByParent = new Map<string | null, number>();
+    for (const row of maxByParent) {
+      nextOrderByParent.set(row.parentId, (row._max.orderIndex ?? -1) + 1);
+    }
+    const nextOrderIndexFor = (parent: string | null): number => {
+      const next = nextOrderByParent.get(parent) ?? 0;
+      nextOrderByParent.set(parent, next + 1);
+      return next;
+    };
+
     for (const { task, id } of sorted) {
       let parentId = resolveParentId(task.parentId);
       if (parentId && !existingTaskIds.has(parentId)) {
@@ -114,7 +138,7 @@ export async function syncTasks(
           effort: task.effort ?? null,
           effortUnit: task.effortUnit ?? null,
           expanded: task.expanded ?? false,
-          orderIndex: task.orderIndex ?? 0,
+          orderIndex: task.orderIndex ?? nextOrderIndexFor(parentId),
           manuallyScheduled: task.manuallyScheduled ?? false,
           constraintType: task.constraintType ?? null,
           constraintDate: task.constraintDate ? new Date(task.constraintDate) : null,
@@ -147,6 +171,13 @@ export async function syncTasks(
 
   // Process updates
   if (changes.updated) {
+    // A drag-reorder arrives as UPDATEs carrying each moved row's new tree
+    // position. Bryntum only re-sends the rows that actually moved, so we can't
+    // trust per-row writes alone — a sibling that kept its slot is never sent
+    // and would keep a stale orderIndex. Collect the target positions here and
+    // renumber every affected sibling group densely after the loop.
+    const reorderTargets = new Map<string, number>();
+
     for (const task of changes.updated) {
       if (!task.id) continue;
 
@@ -162,6 +193,12 @@ export async function syncTasks(
       if (task.effortUnit !== undefined) updateData.effortUnit = task.effortUnit;
       if (task.expanded !== undefined) updateData.expanded = task.expanded;
       if (task.orderIndex !== undefined) updateData.orderIndex = task.orderIndex;
+      // Bryntum's recalculated tree position for a moved row. orderedParentIndex
+      // respects display order; parentIndex is the structural fallback (equal
+      // when no sorter is active). Write it as the row's tentative target — the
+      // post-loop renumber turns the whole group into a clean 0..N-1 sequence.
+      const reorderIndex = task.orderedParentIndex ?? task.parentIndex;
+      if (reorderIndex !== undefined) updateData.orderIndex = reorderIndex;
       if (task.manuallyScheduled !== undefined) updateData.manuallyScheduled = task.manuallyScheduled;
       if (task.constraintType !== undefined) updateData.constraintType = task.constraintType;
       if (task.constraintDate !== undefined) updateData.constraintDate = task.constraintDate ? new Date(task.constraintDate) : null;
@@ -206,6 +243,10 @@ export async function syncTasks(
           select: { id: true },
         });
 
+        // Record the reorder target only after the row is confirmed to exist,
+        // so a concurrently-deleted row doesn't pull a phantom into the renumber.
+        if (reorderIndex !== undefined) reorderTargets.set(task.id, reorderIndex);
+
         // Bryntum's CrudManager protocol: `tasks.rows` is strictly the
         // phantom→real id swap table for ADDED records. Pushing updated rows
         // (which carry no $PhantomId) into the same array poisons
@@ -224,9 +265,90 @@ export async function syncTasks(
         throw error;
       }
     }
+
+    // The per-row writes above only cover the rows Bryntum re-sent; un-moved
+    // siblings keep whatever orderIndex they had (e.g. legacy rows still at 0,
+    // or values from a coarser scale). Rebuild each touched group as a dense
+    // 0..N-1 sequence so the persisted order always matches what the user
+    // dropped, regardless of the rows' prior orderIndex values.
+    await renumberReorderedGroups(db, projectId, reorderTargets);
   }
 
   return result;
+}
+
+/**
+ * Renumber the sibling groups touched by a drag-reorder so every task in an
+ * affected group ends up with a dense, gap-free, 0-based orderIndex matching
+ * its on-screen position.
+ *
+ * Why this is needed: Bryntum only re-sends the rows whose position actually
+ * changed, so a row that keeps its slot is never synced and would otherwise
+ * hold whatever orderIndex it had before. For legacy rows (all 0) or rows from
+ * a coarser index scale, that stale value can sort it ahead of the moved rows
+ * on reload. We rebuild each group's true new order from (a) the moved rows'
+ * target positions and (b) the un-moved rows in their current relative order,
+ * then persist a clean 0..N-1 sequence.
+ */
+async function renumberReorderedGroups(
+  db: TransactionClient,
+  projectId: string,
+  reorderTargets: Map<string, number>,
+) {
+  if (reorderTargets.size === 0) return;
+
+  // parentId changes were already applied above, so these are the FINAL parents.
+  // A cross-parent move shifts siblings in both the source and target groups,
+  // and Bryntum sends every shifted row, so the moved rows' parents cover every
+  // group that needs renumbering.
+  const movedRows = await db.ganttTask.findMany({
+    where: { projectId, id: { in: [...reorderTargets.keys()] } },
+    select: { id: true, parentId: true },
+  });
+  const affectedParents = new Set<string | null>(movedRows.map((r) => r.parentId));
+
+  for (const parentId of affectedParents) {
+    // Current children in their pre-reorder display order; id breaks ties
+    // deterministically. Un-moved rows keep their relative order here.
+    const children = await db.ganttTask.findMany({
+      where: { projectId, parentId },
+      select: { id: true, orderIndex: true },
+      orderBy: [{ orderIndex: "asc" }, { id: "asc" }],
+    });
+    const n = children.length;
+    if (n === 0) continue;
+
+    // Place each moved row at the slot Bryntum reported; fill the remaining
+    // slots, in order, with the rows that didn't move. A target that is
+    // out-of-range or already taken (Bryntum sends a clean set, so defensive
+    // only) falls through to the leftover fill rather than corrupting the run.
+    const slots: (string | null)[] = new Array<string | null>(n).fill(null);
+    for (const child of children) {
+      const target = reorderTargets.get(child.id);
+      if (target !== undefined && target >= 0 && target < n && slots[target] === null) {
+        slots[target] = child.id;
+      }
+    }
+    const placed = new Set(slots.filter((id): id is string => id !== null));
+    const leftovers = children.filter((c) => !placed.has(c.id)).map((c) => c.id);
+    let nextLeftover = 0;
+    for (let i = 0; i < n; i++) {
+      if (slots[i] === null) slots[i] = leftovers[nextLeftover++] ?? null;
+    }
+
+    // Persist the dense sequence, writing only the rows whose index changed.
+    const currentOrderById = new Map(children.map((c) => [c.id, c.orderIndex]));
+    for (let i = 0; i < n; i++) {
+      const id = slots[i];
+      if (id && currentOrderById.get(id) !== i) {
+        await db.ganttTask.update({
+          where: { id, projectId },
+          data: { orderIndex: i },
+          select: { id: true },
+        });
+      }
+    }
+  }
 }
 
 /**

--- a/src/server/api/helpers/ganttSync.ts
+++ b/src/server/api/helpers/ganttSync.ts
@@ -124,18 +124,6 @@ export async function syncTasks(
         parentId = null;
       }
 
-      // [Gantt:order DEBUG] The orderIndex assigned to each newly added task.
-      // For a ">4 tasks" bug this shows whether the 5th/6th task gets a sane,
-      // appended index within its sibling group (expected: dense, increasing).
-      const assignedOrderIndex = task.orderIndex ?? nextOrderIndexFor(parentId);
-      console.log('[Gantt:order] sync ADD', {
-        id,
-        name: task.name,
-        parentId,
-        assignedOrderIndex,
-        clientSentOrderIndex: task.orderIndex,
-      });
-
       await db.ganttTask.create({
         data: {
           id,
@@ -150,7 +138,7 @@ export async function syncTasks(
           effort: task.effort ?? null,
           effortUnit: task.effortUnit ?? null,
           expanded: task.expanded ?? false,
-          orderIndex: assignedOrderIndex,
+          orderIndex: task.orderIndex ?? nextOrderIndexFor(parentId),
           manuallyScheduled: task.manuallyScheduled ?? false,
           constraintType: task.constraintType ?? null,
           constraintDate: task.constraintDate ? new Date(task.constraintDate) : null,
@@ -192,19 +180,6 @@ export async function syncTasks(
 
     for (const task of changes.updated) {
       if (!task.id) continue;
-
-      // [Gantt:order DEBUG] Every incoming UPDATE. The key question: does a
-      // routine edit (date/name/percent) arrive carrying orderedParentIndex or
-      // parentIndex? If so it will be treated as a reorder below and trigger a
-      // group renumber even though the user never dragged a row.
-      console.log('[Gantt:order] sync UPDATE recv', {
-        id: task.id,
-        name: task.name,
-        orderIndex: task.orderIndex,
-        orderedParentIndex: task.orderedParentIndex,
-        parentIndex: task.parentIndex,
-        parentId: task.parentId,
-      });
 
       const updateData: Record<string, unknown> = {};
 
@@ -291,15 +266,6 @@ export async function syncTasks(
       }
     }
 
-    // [Gantt:order DEBUG] What the batch concluded is a reorder. If this map is
-    // non-empty for a sync the user didn't reorder, the renumber that follows is
-    // the source of the reshuffle.
-    console.log('[Gantt:order] sync UPDATE batch done', {
-      updatedCount: changes.updated.length,
-      reorderTargets: Object.fromEntries(reorderTargets),
-      willRenumber: reorderTargets.size > 0,
-    });
-
     // The per-row writes above only cover the rows Bryntum re-sent; un-moved
     // siblings keep whatever orderIndex they had (e.g. legacy rows still at 0,
     // or values from a coarser scale). Rebuild each touched group as a dense
@@ -341,34 +307,16 @@ async function renumberReorderedGroups(
   });
   const affectedParents = new Set<string | null>(movedRows.map((r) => r.parentId));
 
-  // [Gantt:order DEBUG]
-  console.log('[Gantt:order] renumber START', {
-    targets: Object.fromEntries(reorderTargets),
-    affectedParents: [...affectedParents],
-  });
-
   for (const parentId of affectedParents) {
     // Current children in their pre-reorder display order; id breaks ties
     // deterministically. Un-moved rows keep their relative order here.
     const children = await db.ganttTask.findMany({
       where: { projectId, parentId },
-      select: { id: true, name: true, orderIndex: true },
+      select: { id: true, orderIndex: true },
       orderBy: [{ orderIndex: "asc" }, { id: "asc" }],
     });
     const n = children.length;
     if (n === 0) continue;
-
-    // [Gantt:order DEBUG] The group as it stands before renumbering, plus which
-    // of these rows Bryntum reported a target for.
-    console.log('[Gantt:order] renumber group: children-before', {
-      parentId,
-      children: children.map((c) => ({
-        id: c.id,
-        name: c.name,
-        orderIndex: c.orderIndex,
-        target: reorderTargets.get(c.id),
-      })),
-    });
 
     // Place each moved row at the slot Bryntum reported; fill the remaining
     // slots, in order, with the rows that didn't move. A target that is
@@ -388,27 +336,11 @@ async function renumberReorderedGroups(
       if (slots[i] === null) slots[i] = leftovers[nextLeftover++] ?? null;
     }
 
-    // [Gantt:order DEBUG] The reconstructed final order for this group
-    // (slot index = new orderIndex). Compare against children-before: rows that
-    // weren't in `targets` but moved position here are being shuffled by the
-    // renumber, not by the user.
-    console.log('[Gantt:order] renumber group: final order', {
-      parentId,
-      finalOrder: slots,
-      leftovers,
-    });
-
     // Persist the dense sequence, writing only the rows whose index changed.
     const currentOrderById = new Map(children.map((c) => [c.id, c.orderIndex]));
     for (let i = 0; i < n; i++) {
       const id = slots[i];
       if (id && currentOrderById.get(id) !== i) {
-        // [Gantt:order DEBUG] Each orderIndex the renumber actually rewrites.
-        console.log('[Gantt:order] renumber WRITE', {
-          id,
-          from: currentOrderById.get(id),
-          to: i,
-        });
         await db.ganttTask.update({
           where: { id, projectId },
           data: { orderIndex: i },

--- a/src/server/api/helpers/ganttTree.ts
+++ b/src/server/api/helpers/ganttTree.ts
@@ -56,6 +56,13 @@ export function mapTaskToGantt(
     note: task.note,
     csiCode: task.csiCode,
     baselines: task.baselines,
+    // buildTaskTree sorts each level by orderIndex — it must be present on the
+    // mapped object or the comparator ties every row at 0 and falls back to its
+    // id tiebreak, sorting the whole tree by id and ignoring the real order.
+    // (Bryntum drops this field client-side since it isn't on AppTaskModel; it
+    // exists purely so the server-side sort is correct. The array order it
+    // produces is what Bryntum renders.)
+    orderIndex: task.orderIndex,
     needsReviewCount,
     requirementsTotal,
     requirementsFilled: Math.min(requirementsFilled, requirementsTotal),

--- a/src/server/api/helpers/ganttTree.ts
+++ b/src/server/api/helpers/ganttTree.ts
@@ -143,12 +143,17 @@ export function buildTaskTree(
     }
   }
 
-  // Sort by orderIndex at each level
+  // Sort by orderIndex at each level, tie-breaking on the stable `id`.
+  // Without the tie-break, sibling tasks that share orderIndex (e.g. all 0 for
+  // tasks added before they had an explicit order) would keep whatever order
+  // the DB happened to return, which is non-deterministic — the "rows reshuffle
+  // on refresh" bug. `id` never changes, so the order stays put across reloads.
   const sortByOrderIndex = (arr: Record<string, unknown>[]) => {
     arr.sort((a, b) => {
       const aIndex = (a.orderIndex as number) ?? 0;
       const bIndex = (b.orderIndex as number) ?? 0;
-      return aIndex - bIndex;
+      if (aIndex !== bIndex) return aIndex - bIndex;
+      return String(a.id).localeCompare(String(b.id));
     });
 
     // Recursively sort children

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -256,21 +256,6 @@ export const ganttRouter = createTRPCRouter({
         if (filled > 0) filledRequirementCounts.set(task.id, filled);
       }
 
-      // [Gantt:order DEBUG] The exact order this load returns from the DB.
-      // Compare across refreshes — if it changes without a deliberate reorder,
-      // something is rewriting orderIndex on routine syncs. Per parent group,
-      // a healthy project shows a dense 0..N-1 run.
-      console.log('[Gantt:order] LOAD returned', {
-        projectId,
-        count: tasks.length,
-        rows: tasks.map((t) => ({
-          id: t.id,
-          name: t.name,
-          parentId: t.parentId,
-          orderIndex: t.orderIndex,
-        })),
-      });
-
       // Build hierarchical task tree
       const taskTree = buildTaskTree(tasks, needsReviewCounts, filledRequirementCounts);
 

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -256,6 +256,21 @@ export const ganttRouter = createTRPCRouter({
         if (filled > 0) filledRequirementCounts.set(task.id, filled);
       }
 
+      // [Gantt:order DEBUG] The exact order this load returns from the DB.
+      // Compare across refreshes — if it changes without a deliberate reorder,
+      // something is rewriting orderIndex on routine syncs. Per parent group,
+      // a healthy project shows a dense 0..N-1 run.
+      console.log('[Gantt:order] LOAD returned', {
+        projectId,
+        count: tasks.length,
+        rows: tasks.map((t) => ({
+          id: t.id,
+          name: t.name,
+          parentId: t.parentId,
+          orderIndex: t.orderIndex,
+        })),
+      });
+
       // Build hierarchical task tree
       const taskTree = buildTaskTree(tasks, needsReviewCounts, filledRequirementCounts);
 

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -36,7 +36,11 @@ export const ganttRouter = createTRPCRouter({
 
       return ctx.db.ganttTask.findMany({
         where: { projectId },
-        orderBy: { orderIndex: "asc" },
+        // `id` is the tie-break: orderIndex collides at 0 for tasks that never
+        // got an explicit order (see load), and a bare orderBy on a tied column
+        // returns rows in non-deterministic physical order. `id` is the only
+        // stable, never-changing column, so it makes the order reproducible.
+        orderBy: [{ orderIndex: "asc" }, { id: "asc" }],
         select: {
           id: true,
           parentId: true,
@@ -147,7 +151,13 @@ export const ganttRouter = createTRPCRouter({
       ] = await Promise.all([
         ctx.db.ganttTask.findMany({
           where: { projectId },
-          orderBy: { orderIndex: "asc" },
+          // `id` is the deterministic tie-break. Tasks that never received an
+          // explicit order share orderIndex 0; ordering by orderIndex alone
+          // then leaves Postgres free to return tied rows in physical heap
+          // order, which shifts after any UPDATE (MVCC) — that's the "rows
+          // reshuffle on refresh" bug. buildTaskTree re-sorts per level with
+          // the same tie-break, so the final tree order is reproducible.
+          orderBy: [{ orderIndex: "asc" }, { id: "asc" }],
           // Only select fields needed by Bryntum
           select: {
             id: true,


### PR DESCRIPTION
## Summary

Fixes Gantt rows reshuffling on refresh: `orderIndex` collided at `0` for tasks added without an explicit order, so Postgres returned tied rows in non-deterministic physical (MVCC) order that shifted after any edit — both read paths now tie-break on the stable `id`, `buildTaskTree` mirrors it per level, and newly added tasks get a per-sibling-group `orderIndex` so they append at the end deterministically. Also adds drag-to-reorder rows for owners/admins in edit mode (Bryntum `RowReorder` grip), with the new order persisted through the `orderedParentIndex` field plus a dense per-group renumber on the server so un-moved siblings are never stranded. UX feedback includes a visible accent drop-line while dragging, and a grayed-out grip with an "Enter edit mode to reorder" tooltip when the chart is locked (grip hidden entirely for members/viewers). Adds 6 server unit tests; `tsc --noEmit` and the full unit suite pass.

## Test plan
- [ ] Refresh the Gantt repeatedly — row order stays stable (no reshuffle).
- [ ] As an admin, enter edit mode, drag a row by its grip — an accent drop-line shows the target, and the new order survives a refresh.
- [ ] When locked, the grip is grayed with a "not-allowed" cursor and an "Enter edit mode to reorder" tooltip; members see no grip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)