### PR TITLE
Intuitive Gantt dependency linking: Shift-click, Link mode & right-click

### DIFF
--- a/claudedocs/components-guide.md
+++ b/claudedocs/components-guide.md
@@ -301,6 +301,7 @@ bryntum/
     TaskDetailsPopover.tsx
     SubmittalDrawer.tsx       ← right-side drawer for managing per-slot submittals/inspections
     BryntumPanelHeader.tsx
+    TaskLinkingBar.tsx        ← floating confirm toast for Shift-click/Link-mode dependency creation
     task-popover/             ← extracted sub-components for TaskDetailsPopover
       types.ts
       TaskHeader.tsx
@@ -314,6 +315,7 @@ bryntum/
       CsiCodePanel.tsx
   hooks/
     useTaskPopover.ts
+    useTaskLinking.ts         ← Shift-click / Link-mode ordered selection → Finish-to-Start dependencies
     useBryntumThemeAssets.ts
   utils/
     calculatePopoverPlacement.ts

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -12,11 +12,13 @@ import GanttToolbar from './components/GanttToolbar';
 import ColumnPickerPopover, { TOGGLEABLE_COLUMNS, type ColumnId } from './components/ColumnPickerPopover';
 import { TaskDetailsPopover } from './components/TaskDetailsPopover';
 import TaskInfoDialog from './components/TaskInfoDialog';
+import TaskLinkingBar from './components/TaskLinkingBar';
 import { useBryntumThemeAssets } from './hooks/useBryntumThemeAssets';
 import { useTaskPopover } from './hooks/useTaskPopover';
+import { useTaskLinking } from './hooks/useTaskLinking';
 import { useGanttControls } from './hooks/useGanttControls';
 import { reconcileSyncPack } from './utils/reconcileSyncPack';
-import type { BryntumTaskRecord, BryntumGanttInstance } from './types';
+import type { BryntumTaskRecord, BryntumGanttInstance, TaskClickEventPayload } from './types';
 import { IBeamLoader } from '@/components/ui/IBeamLoader';
 
 const WRAPPER_STYLE: CSSProperties = {
@@ -126,6 +128,17 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
 
   const { selectedTask, popoverPlacement, handleTaskClick, closeTaskPopover, isTaskPopoverOpen } =
     useTaskPopover();
+
+  const {
+    linkMode,
+    setLinkMode,
+    toggleLinkMode,
+    selection: linkSelection,
+    handleLinkClick,
+    startLinkingFrom,
+    clearSelection: clearLinkSelection,
+    commitLinks,
+  } = useTaskLinking(getGanttInstance as unknown as () => BryntumGanttInstance | null);
 
   useBryntumThemeAssets();
 
@@ -521,16 +534,51 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
   // Undo/redo keyboard shortcuts (Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z) come from
   // Bryntum's STM via `enableUndoRedoKeys` (default true).
 
+  // Route task-bar clicks: a Shift-click (any time) or a plain click while
+  // Link mode is on builds the dependency-link selection; everything else opens
+  // the details popover. Linking is an edit op, so it's gated on editingUnlocked.
+  const onTaskClick = useCallback(
+    (payload: TaskClickEventPayload) => {
+      const wantsLink = editingUnlocked && (linkMode || !!payload.event?.shiftKey);
+      if (wantsLink) {
+        closeTaskPopover();
+        handleLinkClick(payload);
+        return;
+      }
+      handleTaskClick(payload);
+    },
+    [editingUnlocked, linkMode, closeTaskPopover, handleLinkClick, handleTaskClick],
+  );
+
   // Attach the taskClick listener on the Bryntum instance (not in the static config)
-  // so we can use the latest handleTaskClick reference from useTaskPopover.
+  // so we can use the latest onTaskClick reference (popover + linking).
   useEffect(() => {
     if (isLoading) return;
     const gantt = getGanttInstance();
     if (!gantt) return;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-    const detach = gantt.on('taskClick', handleTaskClick) as (() => void) | undefined;
+    const detach = gantt.on('taskClick', onTaskClick) as (() => void) | undefined;
     return () => { detach?.(); };
-  }, [isLoading, getGanttInstance, handleTaskClick]);
+  }, [isLoading, getGanttInstance, onTaskClick]);
+
+  // Locking the chart cancels any in-progress linking.
+  useEffect(() => {
+    if (!editingUnlocked && linkMode) {
+      setLinkMode(false);
+      clearLinkSelection();
+    }
+  }, [editingUnlocked, linkMode, setLinkMode, clearLinkSelection]);
+
+  // Esc clears the link selection first, then exits Link mode.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (linkSelection.length > 0) clearLinkSelection();
+      else if (linkMode) setLinkMode(false);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [linkSelection.length, linkMode, clearLinkSelection, setLinkMode]);
 
   // Open task info dialog on double-click of a task bar (replaces Bryntum's built-in task editor).
   // Only attach the listener when editing is unlocked — the dialog is an edit surface.
@@ -557,6 +605,21 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
   const taskMenuFeature = useMemo(() => ({
     cls: 'gantt-themed-menu',
     items: {
+      // Discoverable entry point for dependency creation. The `gantt-menu-add-dep`
+      // class renders the link glyph + a right-aligned "⇧-click" shortcut hint
+      // (globals.css), teaching the Shift accelerator at the moment of use.
+      // weight 55 sits just below "Scroll to item" (50). processItems hides it
+      // for parent tasks and when the chart is locked.
+      addDependency: {
+        text: 'Add dependency',
+        icon: 'b-icon',
+        cls: 'gantt-menu-add-dep',
+        weight: 55,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onItem({ taskRecord }: { taskRecord: any }) {
+          startLinkingFrom(taskRecord as BryntumTaskRecord);
+        },
+      },
       scrollToItem: {
         text: 'Scroll to item',
         // b-icon-search (magnifying glass) is in the bundled Bryntum CSS;
@@ -591,18 +654,29 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     //      Bryntum disables every write item at once; emit one shared
     //      message rather than guessing per-item reasons.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    processItems({ items }: { items: Record<string, any> }) {
+    processItems({ items, taskRecord }: { items: Record<string, any>; taskRecord: any }) {
       const gantt = getGanttInstance();
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
       const isLocked = !!(gantt as any)?.readOnly;
 
+      // "Add dependency" is an edit action and only applies to leaf tasks —
+      // hide it when the chart is locked or the target is a parent/phantom.
+      if (items.addDependency) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (isLocked || taskRecord?.isParent || taskRecord?.isPhantom) {
+          items.addDependency.hidden = true;
+        }
+      }
+
+      // Hide Bryntum's native linkTasks/unlinkTasks ("Add dependencies" /
+      // "Remove dependencies"). They only fire with 2+ Cmd-selected tasks, so
+      // on a single right-click they're permanently disabled — confusing next
+      // to our always-actionable "Add dependency". Unlinking lives in the task
+      // info dialog's Predecessors/Successors tabs.
+      if (items.linkTasks) items.linkTasks.hidden = true;
+      if (items.unlinkTasks) items.unlinkTasks.hidden = true;
+
       const reasonsByRef: Record<string, string> = {
-        // linkTasks: select 2+ tasks (Cmd-click), right-click → Bryntum
-        // chains them. With one task it's permanently disabled by design.
-        // Drag-to-create from a task edge is the alternative single-dep
-        // flow (enabled by `dependencies: true` in ganttConfig.ts).
-        linkTasks: 'Select 2 or more tasks to link them in sequence, or drag from a task\'s edge to another to create a single dependency',
-        unlinkTasks: 'Select 2 or more linked tasks to remove the dependencies between them',
         indent: 'No task above this one to nest under',
         outdent: 'This task is already at the top level',
         deleteTask: 'This task cannot be deleted right now',
@@ -617,6 +691,7 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
           delete items[ref];
           continue;
         }
+        if (item && typeof item === 'object' && item.hidden) continue;
         if (item && typeof item === 'object' && item.disabled && !item.tooltip) {
           const reason = isLocked
             ? 'Editing is locked — click the lock icon in the toolbar to unlock the chart'
@@ -632,7 +707,7 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         }
       }
     },
-  }), [getGanttInstance]);
+  }), [getGanttInstance, startLinkingFrom]);
 
   return (
     <div style={WRAPPER_STYLE}>
@@ -651,6 +726,8 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         canEditChart={canEditChart}
         isEditMode={editingUnlocked}
         onToggleEditMode={() => setIsEditMode((prev) => !prev)}
+        linkMode={linkMode}
+        onToggleLinkMode={toggleLinkMode}
         onColumnsClick={(e) => setColumnsAnchor(e.currentTarget)}
       />
       <ColumnPickerPopover
@@ -809,6 +886,13 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
             <div style={{ fontSize: '0.875rem' }}>{loadError}</div>
           </Box>
         )}
+
+        <TaskLinkingBar
+          selection={linkSelection}
+          linkMode={linkMode}
+          onLink={commitLinks}
+          onClear={clearLinkSelection}
+        />
       </div>
 
       <TaskDetailsPopover

--- a/src/components/bryntum/components/GanttToolbar.tsx
+++ b/src/components/bryntum/components/GanttToolbar.tsx
@@ -13,6 +13,7 @@ import {
   DownloadSimple,
   Columns,
   DotsThreeVertical,
+  LinkSimple,
   Lock,
   LockOpen,
   Minus,
@@ -165,6 +166,9 @@ type GanttToolbarProps = {
   /** Whether the chart is currently unlocked for editing. */
   isEditMode?: boolean;
   onToggleEditMode?: () => void;
+  /** Whether dependency-link mode is active (plain click selects tasks to link). */
+  linkMode?: boolean;
+  onToggleLinkMode?: () => void;
 };
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -186,6 +190,8 @@ export default function GanttToolbar({
   canEditChart = false,
   isEditMode = false,
   onToggleEditMode,
+  linkMode = false,
+  onToggleLinkMode,
 }: GanttToolbarProps) {
   const editingActive = canEditChart && isEditMode;
   const [activePreset, setActivePreset] = useState('weekAndDayLetterCompact');
@@ -591,6 +597,72 @@ export default function GanttToolbar({
             {editingActive ? 'Editing' : 'Edit'}
           </Box>
         </Box>
+      )}
+
+      {/* ── Link tasks toggle (only active in edit mode) ───────────────── */}
+      {onToggleLinkMode && editingActive && (
+        <Tooltip
+          title={
+            linkMode
+              ? 'Linking on — click tasks in order to chain them. Tip: Shift-click works any time, even with this off.'
+              : 'Link tasks — click two tasks in order to connect them. Tip: Shift-click any task to link without this button.'
+          }
+          placement="bottom"
+          enterDelay={400}
+          arrow
+        >
+          <Box
+            component="button"
+            type="button"
+            onClick={onToggleLinkMode}
+            aria-label={linkMode ? 'Exit link mode' : 'Link tasks'}
+            aria-pressed={linkMode}
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.75,
+              height: 34,
+              px: '14px',
+              borderRadius: '10px',
+              fontSize: '12px',
+              fontWeight: 600,
+              fontFamily: 'var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif',
+              letterSpacing: '-0.01em',
+              cursor: 'pointer',
+              flexShrink: 0,
+              whiteSpace: 'nowrap',
+              animation: 'gantt-tool-pop-in 0.24s cubic-bezier(0.2, 0.9, 0.3, 1.2) both',
+              transition:
+                'background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.12s ease',
+              '&:active': { transform: 'scale(0.96)' },
+              '@container gantt-toolbar (max-width: 720px)': { px: 0, gap: 0, width: 34 },
+              ...(linkMode
+                ? {
+                    bgcolor: 'var(--accent-primary, #2563eb)',
+                    color: 'var(--accent-contrast, #fff)',
+                    border: '1px solid var(--accent-primary, #2563eb)',
+                    boxShadow: '0 0 0 4px rgba(37, 99, 235, 0.14)',
+                    '&:hover': { filter: 'brightness(0.9)' },
+                  }
+                : {
+                    bgcolor: 'var(--bg-card)',
+                    color: 'var(--text-primary)',
+                    border: '1px solid var(--border-color)',
+                    boxShadow: '0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)',
+                    '&:hover': { bgcolor: 'action.hover' },
+                  }),
+            }}
+          >
+            <LinkSimple size={13} weight="bold" />
+            <Box
+              component="span"
+              sx={{ '@container gantt-toolbar (max-width: 720px)': { display: 'none' } }}
+            >
+              {linkMode ? 'Linking' : 'Link'}
+            </Box>
+          </Box>
+        </Tooltip>
       )}
 
       {/* ── Add Task (only active in edit mode) ────────────────────────── */}

--- a/src/components/bryntum/components/TaskLinkingBar.tsx
+++ b/src/components/bryntum/components/TaskLinkingBar.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { Box, Stack, Typography } from '@mui/material';
+import { ArrowRight, LinkSimple, X } from '@phosphor-icons/react';
+import { Button } from '@/components/ui/button';
+import type { LinkSelectionItem } from '../hooks/useTaskLinking';
+
+interface TaskLinkingBarProps {
+  selection: Pick<LinkSelectionItem, 'id' | 'name'>[];
+  /** Link mode active — changes the one-task hint from "Shift-click" to "Click". */
+  linkMode: boolean;
+  onLink: () => void;
+  onClear: () => void;
+}
+
+// Position → badge color. Mirrors the `--gantt-link-c` values in globals.css:
+// ① predecessor blue, ② successor violet, ③+ chain navy.
+const DOT_COLORS = ['#2563eb', '#7c3aed', 'var(--accent-primary, #2B2D42)'] as const;
+
+function dotColor(index: number): string {
+  return DOT_COLORS[Math.min(index, DOT_COLORS.length - 1)]!;
+}
+
+function NumberDot({ index }: { index: number }) {
+  return (
+    <Box
+      sx={{
+        flexShrink: 0,
+        width: 18,
+        height: 18,
+        borderRadius: '50%',
+        bgcolor: dotColor(index),
+        color: '#fff',
+        fontSize: '0.6875rem',
+        fontWeight: 800,
+        lineHeight: '18px',
+        textAlign: 'center',
+      }}
+    >
+      {index < 9 ? index + 1 : '+'}
+    </Box>
+  );
+}
+
+export default function TaskLinkingBar({ selection, linkMode, onLink, onClear }: TaskLinkingBarProps) {
+  if (selection.length === 0) return null;
+
+  const ready = selection.length >= 2;
+
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        bottom: 18,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 20,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.25,
+        maxWidth: 'calc(100% - 24px)',
+        px: 1.25,
+        py: 1,
+        pl: 1.75,
+        borderRadius: '12px',
+        bgcolor: 'background.paper',
+        border: '1px solid',
+        borderColor: 'divider',
+        boxShadow: '0 8px 28px rgba(0,0,0,0.18), 0 2px 6px rgba(0,0,0,0.08)',
+        animation: 'gantt-link-bar-in 0.18s cubic-bezier(0.2, 0.9, 0.3, 1.2) both',
+        '@keyframes gantt-link-bar-in': {
+          from: { opacity: 0, transform: 'translate(-50%, 8px)' },
+          to: { opacity: 1, transform: 'translate(-50%, 0)' },
+        },
+        '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+      }}
+    >
+      <LinkSimple size={16} weight="bold" style={{ color: 'var(--text-secondary)', flexShrink: 0 }} />
+
+      {/* Selected tasks — names with direction arrows */}
+      <Stack direction="row" alignItems="center" spacing={0.75} sx={{ minWidth: 0, overflow: 'hidden' }}>
+        {selection.map((task, index) => (
+          <Stack key={task.id} direction="row" alignItems="center" spacing={0.75} sx={{ minWidth: 0 }}>
+            {index > 0 && <ArrowRight size={13} weight="bold" style={{ color: 'var(--text-muted)', flexShrink: 0 }} />}
+            <NumberDot index={index} />
+            <Typography
+              sx={{
+                fontSize: '0.8125rem',
+                fontWeight: 500,
+                color: 'text.primary',
+                maxWidth: 150,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                lineHeight: 1.2,
+              }}
+            >
+              {task.name || 'Untitled task'}
+            </Typography>
+          </Stack>
+        ))}
+      </Stack>
+
+      {!ready && (
+        <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary', whiteSpace: 'nowrap', flexShrink: 0 }}>
+          — {linkMode ? 'click' : 'Shift-click'} the successor task
+        </Typography>
+      )}
+
+      <Box sx={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 0.5, ml: 0.25 }}>
+        <Button
+          variant="contained"
+          size="small"
+          onClick={onLink}
+          disabled={!ready}
+          startIcon={<LinkSimple size={13} weight="bold" />}
+          sx={{ textTransform: 'none', fontSize: '0.78rem', fontWeight: 600, px: 1.5, borderRadius: '8px', whiteSpace: 'nowrap' }}
+        >
+          Link
+        </Button>
+        <Box
+          component="button"
+          type="button"
+          onClick={onClear}
+          aria-label="Cancel linking"
+          title="Cancel (Esc)"
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 28,
+            height: 28,
+            borderRadius: '8px',
+            border: 'none',
+            bgcolor: 'transparent',
+            color: 'text.secondary',
+            cursor: 'pointer',
+            transition: 'background-color 0.15s ease, color 0.15s ease',
+            '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
+          }}
+        >
+          <X size={14} weight="bold" />
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/bryntum/hooks/useTaskLinking.ts
+++ b/src/components/bryntum/hooks/useTaskLinking.ts
@@ -1,0 +1,219 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSnackbar } from '@/hooks/useSnackbar';
+import type {
+  BryntumGanttInstance,
+  BryntumTaskRecord,
+  TaskClickEventPayload,
+} from '../types';
+
+/** One entry in the ordered link selection. `record` is the live Bryntum task. */
+export interface LinkSelectionItem {
+  id: string;
+  name: string;
+  record: BryntumTaskRecord;
+}
+
+// Finish-to-Start (EndToStart) — the default construction dependency. Matches
+// the `type: 2` used by TaskInfoDialog's predecessor/successor picker.
+const FINISH_TO_START = 2;
+
+// Position → color class. The CSS sets `--gantt-link-c` per class so the bar
+// outline and the numbered badge share one color source.
+const COLOR_CLASSES = ['gantt-link-c1', 'gantt-link-c2', 'gantt-link-c3'] as const;
+const LINK_CLASSES = ['gantt-link-selected', ...COLOR_CLASSES];
+
+function colorClassFor(index: number): string {
+  return COLOR_CLASSES[Math.min(index, COLOR_CLASSES.length - 1)]!;
+}
+
+/** Resolve the `.b-gantt-task` bar element for a record, normalizing whatever
+ *  `getElementFromTaskRecord` hands back to the bar itself. */
+function findBarElement(
+  gantt: BryntumGanttInstance,
+  record: BryntumTaskRecord,
+): HTMLElement | null {
+  const raw = gantt.getElementFromTaskRecord?.(record) ?? null;
+  if (raw) {
+    if (raw.classList.contains('b-gantt-task')) return raw;
+    const inner = raw.querySelector?.('.b-gantt-task') as HTMLElement | null;
+    if (inner) return inner;
+    const outer = raw.closest?.('.b-gantt-task') as HTMLElement | null;
+    if (outer) return outer;
+  }
+  // Fallback: scope a DOM query to the Gantt root by task id.
+  const id = String(record?.id ?? '');
+  if (!id) return null;
+  const container = gantt.element ?? document.querySelector('.bryntum-gantt-container');
+  return (container?.querySelector(
+    `.b-gantt-task-wrap[data-task-id="${CSS.escape(id)}"] .b-gantt-task`,
+  ) as HTMLElement | null) ?? null;
+}
+
+function clearBar(bar: HTMLElement): void {
+  bar.classList.remove(...LINK_CLASSES);
+  bar.querySelector(':scope > .gantt-link-badge')?.remove();
+}
+
+/**
+ * Shift-click (or Link-mode click) dependency creation.
+ *
+ * Builds an ordered selection of task bars — first pick is the predecessor (①),
+ * each subsequent pick chains a Finish-to-Start dependency (①→②→③). The bars
+ * get a colored outline + numbered badge applied via direct DOM (mirrors the
+ * popover highlight in useTaskPopover — both accept that Bryntum's virtual
+ * re-render on scroll can clear an off-screen bar's badge; the floating toast
+ * remains the source of truth). `commitLinks` writes them via dependencyStore,
+ * which autoSyncs to the DB.
+ */
+export function useTaskLinking(getGanttInstance: () => BryntumGanttInstance | null) {
+  const { showSnackbar } = useSnackbar();
+  const [linkMode, setLinkMode] = useState(false);
+  const [selection, setSelection] = useState<LinkSelectionItem[]>([]);
+  const selectionRef = useRef<LinkSelectionItem[]>([]);
+  const appliedRef = useRef<HTMLElement[]>([]);
+
+  // Re-paint the bar outlines + badges for the given ordered selection.
+  const applyStyling = useCallback(
+    (items: LinkSelectionItem[]) => {
+      appliedRef.current.forEach(clearBar);
+      appliedRef.current = [];
+      const gantt = getGanttInstance();
+      if (!gantt) return;
+      items.forEach((item, index) => {
+        const bar = findBarElement(gantt, item.record);
+        if (!bar) return;
+        bar.classList.add('gantt-link-selected', colorClassFor(index));
+        const badge = document.createElement('span');
+        badge.className = 'gantt-link-badge';
+        badge.textContent = index < 9 ? String(index + 1) : '+';
+        bar.appendChild(badge);
+        appliedRef.current.push(bar);
+      });
+    },
+    [getGanttInstance],
+  );
+
+  const setSelectionAll = useCallback(
+    (items: LinkSelectionItem[]) => {
+      selectionRef.current = items;
+      setSelection(items);
+      applyStyling(items);
+    },
+    [applyStyling],
+  );
+
+  const clearSelection = useCallback(() => {
+    setSelectionAll([]);
+  }, [setSelectionAll]);
+
+  // Leaving link mode always drops any in-progress selection.
+  useEffect(() => {
+    if (!linkMode) setSelectionAll([]);
+  }, [linkMode, setSelectionAll]);
+
+  const toggleLinkMode = useCallback(() => {
+    setLinkMode((prev) => !prev);
+  }, []);
+
+  // Add / toggle a task in the ordered selection.
+  const handleLinkClick = useCallback(
+    (payload: TaskClickEventPayload) => {
+      const { taskRecord, event } = payload;
+      // Suppress the browser's Shift text-selection during the gesture.
+      event?.preventDefault?.();
+      if (taskRecord.isParent) return; // parent bars can't be dependency endpoints
+      if (taskRecord.isPhantom) {
+        showSnackbar('Saving task — try again in a moment', 'info');
+        return;
+      }
+      const id = String(taskRecord.id);
+      const prev = selectionRef.current;
+      const existing = prev.findIndex((s) => s.id === id);
+      const next =
+        existing >= 0
+          ? prev.filter((s) => s.id !== id)
+          : [
+              ...prev,
+              {
+                id,
+                name: taskRecord.name ?? '',
+                record: taskRecord as unknown as BryntumTaskRecord,
+              },
+            ];
+      setSelectionAll(next);
+    },
+    [setSelectionAll, showSnackbar],
+  );
+
+  // Entry point for the right-click "Add dependency" menu item: turn on link
+  // mode and seed the clicked task as the predecessor ①, so the next click
+  // picks the successor. Reuses the same selection + confirm flow as Shift-click.
+  const startLinkingFrom = useCallback(
+    (taskRecord: BryntumTaskRecord) => {
+      if (taskRecord.isParent) return;
+      if ((taskRecord as { isPhantom?: boolean }).isPhantom) {
+        showSnackbar('Saving task — try again in a moment', 'info');
+        return;
+      }
+      setLinkMode(true);
+      setSelectionAll([{ id: String(taskRecord.id), name: taskRecord.name ?? '', record: taskRecord }]);
+    },
+    [setSelectionAll, showSnackbar],
+  );
+
+  // Write the Finish-to-Start dependencies along the chain, skipping pairs that
+  // are already linked, then offer an Undo.
+  const commitLinks = useCallback(() => {
+    const items = selectionRef.current;
+    if (items.length < 2) return;
+    const gantt = getGanttInstance();
+    const store = gantt?.project.dependencyStore;
+    if (!store) return;
+
+    const created: unknown[] = [];
+    for (let i = 0; i < items.length - 1; i++) {
+      const from = items[i]!.id;
+      const to = items[i + 1]!.id;
+      if (from === to) continue;
+      if (store.getDependencyForSourceAndTargetEvents?.(from, to)) continue;
+      const added = store.add({ from, to, type: FINISH_TO_START });
+      const record = Array.isArray(added) ? added[0] : added;
+      if (record) created.push(record);
+    }
+
+    clearSelection();
+
+    if (created.length === 0) {
+      showSnackbar('Those tasks are already linked', 'info');
+      return;
+    }
+
+    const message =
+      items.length === 2
+        ? `Linked “${items[0]!.name}” → “${items[1]!.name}”`
+        : `Linked ${items.length} tasks in sequence`;
+    showSnackbar(message, {
+      severity: 'success',
+      action: {
+        label: 'Undo',
+        onClick: () => {
+          // Removing from the store autoSyncs the deletion to the DB.
+          getGanttInstance()?.project.dependencyStore.remove(created);
+        },
+      },
+    });
+  }, [getGanttInstance, clearSelection, showSnackbar]);
+
+  return {
+    linkMode,
+    setLinkMode,
+    toggleLinkMode,
+    selection,
+    handleLinkClick,
+    startLinkingFrom,
+    clearSelection,
+    commitLinks,
+  };
+}

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -30,6 +30,9 @@ export type TaskClickEventPayload = {
     target: EventTarget | null;
     clientX: number;
     clientY: number;
+    /** Modifier held during the click — Shift-click is the link-selection gesture. */
+    shiftKey?: boolean;
+    preventDefault?: () => void;
   };
 };
 
@@ -142,6 +145,10 @@ export interface BryntumGanttInstance {
   expand(record: BryntumTaskRecord): void;
   indent(records: BryntumTaskRecord[]): void;
   outdent(records: BryntumTaskRecord[]): void;
+  /** Root DOM element of the Gantt widget — used to scope task-bar DOM lookups. */
+  element?: HTMLElement;
+  /** Returns the rendered task-bar element for a record, or null if off-screen. */
+  getElementFromTaskRecord?(record: BryntumTaskRecord): HTMLElement | null;
   selectedRecords: BryntumTaskRecord[];
   dependencyStore: {
     remove(records: unknown[]): void;
@@ -165,6 +172,11 @@ export interface BryntumGanttInstance {
       add(data: Record<string, unknown>): unknown;
       remove(records: unknown[]): void;
       allRecords: BryntumDependencyRecord[];
+      /** Returns an existing dependency linking the two tasks (either direction), or null. */
+      getDependencyForSourceAndTargetEvents?(
+        from: string | number,
+        to: string | number,
+      ): BryntumDependencyRecord | null;
     };
   };
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -563,6 +563,46 @@ body {
   animation: none !important;
 }
 
+/* ── Dependency link selection (Shift-click / Link mode) ──────────────────
+   Bars picked for linking get a colored outline + a numbered badge. The color
+   flows from a single `--gantt-link-c` custom property set by the position
+   class (c1/c2/c3) so the outline and badge always agree. `overflow: visible`
+   lets the badge escape the bar's frosted-glass clip (same opt-out the hover
+   terminals use above). The badge itself is a real child <span> appended in
+   useTaskLinking — not a ::before/::after, both of which the bar already uses. */
+.bryntum-gantt-container .b-gantt-task.gantt-link-selected {
+  overflow: visible !important;
+  outline: 2.5px solid var(--gantt-link-c, #2563eb) !important;
+  outline-offset: 2px;
+  z-index: 6 !important;
+}
+.bryntum-gantt-container .b-gantt-task.gantt-link-c1 { --gantt-link-c: #2563eb; } /* ① predecessor */
+.bryntum-gantt-container .b-gantt-task.gantt-link-c2 { --gantt-link-c: #7c3aed; } /* ② successor */
+.bryntum-gantt-container .b-gantt-task.gantt-link-c3 { --gantt-link-c: var(--accent-primary, #2B2D42); } /* ③+ chain */
+.bryntum-gantt-container .b-gantt-task.gantt-link-selected .gantt-link-badge {
+  position: absolute;
+  top: -9px;
+  left: -9px;
+  box-sizing: border-box;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--gantt-link-c, #2563eb);
+  color: #fff;
+  font-family: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
+  border: 2px solid var(--bg-card, #fff);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+  z-index: 7;
+  pointer-events: none;
+}
+
 /* ── Scrollbars ──────────────────────────────────────────────── */
 
 .bryntum-gantt-container .b-virtual-scroller::-webkit-scrollbar {
@@ -731,6 +771,30 @@ body {
 
 .b-menu.b-popup .b-menu-item.b-disabled .b-menu-item-icon {
   opacity: 0.6;
+}
+
+/* ── "Add dependency" menu item ───────────────────────────────────────────
+   Bryntum's bundled FA subset has no link glyph, so the icon is drawn with a
+   CSS mask (monochrome, follows the menu item's currentColor through hover/
+   disabled). The right-aligned "⇧-click" suffix teaches the Shift accelerator
+   at the moment of use — like a menu showing "Copy  ⌘C". */
+.b-menu.b-popup .b-menu-item.gantt-menu-add-dep .b-menu-item-icon {
+  font-size: 0; /* suppress the empty b-icon font glyph */
+  width: 14px;
+  height: 14px;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='black'%20stroke-width='2.2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M9%2017H7A5%205%200%200%201%207%207h2'/%3E%3Cpath%20d='M15%207h2a5%205%200%200%201%200%2010h-2'/%3E%3Cline%20x1='8'%20y1='12'%20x2='16'%20y2='12'/%3E%3C/svg%3E") center / 14px no-repeat;
+          mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='black'%20stroke-width='2.2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M9%2017H7A5%205%200%200%201%207%207h2'/%3E%3Cpath%20d='M15%207h2a5%205%200%200%201%200%2010h-2'/%3E%3Cline%20x1='8'%20y1='12'%20x2='16'%20y2='12'/%3E%3C/svg%3E") center / 14px no-repeat;
+}
+.b-menu.b-popup .b-menu-item.gantt-menu-add-dep::after {
+  content: '⇧-click';
+  margin-left: auto;
+  padding-left: 28px;
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  flex-shrink: 0;
 }
 
 /* Disabled rows — not-allowed cursor signals "you can't click this". The


### PR DESCRIPTION
## What & why

Creating task dependencies was nearly undiscoverable — you had to Cmd-select 2+ tasks, then right-click a permanently-disabled "Link tasks" item. This adds three coherent, discoverable ways to create **Finish-to-Start** dependencies.

## How it works

- **Shift-click** task bars → ordered selection (① predecessor → ② successor → ③+ chain) with numbered badges + a floating confirm bar (`TaskLinkingBar`) with **Link / Cancel** and a post-link **Undo**.
- **Toolbar "Link" toggle** → modifier-free / bulk wiring; tooltip surfaces the Shift accelerator.
- **Right-click → "Add dependency"** → seeds the clicked task as the predecessor and enters the same flow. Shows a greyed **"⇧-click"** shortcut hint (teaches the accelerator at point of use) and a CSS-mask link glyph (the bundled Bryntum FA subset has no link icon).

Dependencies are written via `dependencyStore.add({ from, to, type: 2 })` (the proven path from #169), which draws the connector and autoSyncs to the DB. Bryntum's native, redundant "Add/Remove dependencies" menu items are hidden.

Linking is gated on edit mode. **Esc** clears the selection, then exits link mode. Plain clicks still open the task details popover (no regression).

## Files
- `hooks/useTaskLinking.ts` *(new)* — selection state, badge styling, FS-link commit + Undo, `startLinkingFrom`
- `components/TaskLinkingBar.tsx` *(new)* — floating confirm bar
- `BryntumGanttWrapper.tsx` — click routing (Shift/mode → link, plain → popover), "Add dependency" menu item + native-item hiding, Esc/lock handling
- `components/GanttToolbar.tsx` — "Link" toggle + Shift-hint tooltip
- `styles/globals.css` — selection outline + numbered badge, menu glyph + "⇧-click" annotation
- `types.ts`, `claudedocs/components-guide.md` — type extensions + doc update

## Verification
- `tsc --noEmit` clean; all 224 unit tests pass
- Manually verified end-to-end in a real project Gantt: Shift-click chain, toolbar toggle, right-click "Add dependency", FS reschedule, DB persistence via autoSync, Undo removes the row, Esc two-stage, popover regression check, and the cleaned-up menu. 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)