### PR TITLE
Gantt: MM/DD/YYYY date columns + fix header/column resize alignment

### DIFF
--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -38,6 +38,30 @@ const GANTT_CONTENT_STYLE: CSSProperties = {
 
 const STALE_THRESHOLD_MS = 60_000; // 60 seconds
 
+// Pin the locked sub-grid to exactly contain its visible columns. Two reasons:
+//  (1) hiding a column should give the freed space to the timeline, and
+//  (2) resizing a column (drag or header double-click auto-fit) should
+//      shrink/grow the sub-grid to match, so header, body, and timeline stay
+//      aligned with no dead gap after the resized column.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function syncLockedSubGridWidth(gantt: any) {
+  if (!gantt) return;
+  let lockedWidth = 0;
+  for (const col of TOGGLEABLE_COLUMNS) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+    const column = gantt.columns.getById(col.id);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (!column || column.hidden) continue;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    lockedWidth += (column.width as number) ?? (column.minWidth as number) ?? 0;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  if (lockedWidth > 0 && gantt.subGrids.locked.width !== lockedWidth) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    gantt.subGrids.locked.width = lockedWidth;
+  }
+}
+
 interface BryntumGanttWrapperProps {
   projectId?: string;
   isVisible?: boolean;
@@ -139,32 +163,46 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
   }, [isLoading, getGanttInstance, editingUnlocked]);
 
   // `column.hidden = true` only redistributes width inside the locked sub-grid;
-  // we also set the sub-grid's width so the timeline absorbs the freed space.
+  // syncLockedSubGridWidth then sizes the sub-grid so the timeline absorbs the
+  // freed space.
   useEffect(() => {
     if (isLoading) return;
     const gantt = getGanttInstance();
     if (!gantt) return;
 
-    let lockedWidth = 0;
     for (const col of TOGGLEABLE_COLUMNS) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
       const column = gantt.columns.getById(col.id);
       if (!column) continue;
-      const visible = columnVisibility[col.id] ?? true;
-      const nextHidden = !visible;
+      const nextHidden = !(columnVisibility[col.id] ?? true);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (column.hidden !== nextHidden) column.hidden = nextHidden;
-      if (visible) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        lockedWidth += column.width ?? column.minWidth ?? 0;
-      }
     }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (gantt.subGrids.locked.width !== lockedWidth) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      gantt.subGrids.locked.width = lockedWidth;
-    }
+    syncLockedSubGridWidth(gantt);
   }, [isLoading, getGanttInstance, columnVisibility]);
+
+  // Keep the locked sub-grid sized to its columns when the user resizes a
+  // column — either by dragging the header divider or double-clicking it to
+  // auto-fit. Bryntum reports both through the `change` event on the columns
+  // store. Without this, the resize updates the column width but not the
+  // sub-grid, so the header and body misalign and dead space appears before the
+  // next column.
+  useEffect(() => {
+    if (isLoading) return;
+    const gantt = getGanttInstance();
+    if (!gantt) return;
+    const onColumnChange = ({ changes }: { changes?: Record<string, unknown> }) => {
+      // Only react to width changes; `hidden` is handled by the effect above.
+      if (changes && !('width' in changes)) return;
+      syncLockedSubGridWidth(gantt);
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    gantt.columns.on('change', onColumnChange);
+    return () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      gantt.columns.un('change', onColumnChange);
+    };
+  }, [isLoading, getGanttInstance]);
 
   // After data loads, run commitAsync to settle the scheduling engine, then
   // enable STM so undo/redo starts tracking from this clean state.

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -105,8 +105,16 @@ export function createGanttConfig(
         type: 'name',
         field: 'name',
         text: 'Name',
-        flex: 1,
-        minWidth: 300,
+        // Fixed width (NOT `flex`) so double-clicking the header resize handle
+        // auto-fits the header AND the body cells to the same width. A `flex`
+        // column lets Bryntum's resizeToFitContent shrink only the body cells
+        // while the header keeps its flex-derived width — leaving them
+        // misaligned (the bug this fixes). The locked sub-grid width is
+        // re-synced to the column widths on every resize in
+        // BryntumGanttWrapper (syncLockedSubGridWidth), so the timeline
+        // reclaims/yields the freed space and there is no dead gap.
+        width: 300,
+        minWidth: 150,
         resizable: true,
         renderer({ value, record }: ColumnRendererData) {
           const needsReviewCount = Number(record.get('needsReviewCount') ?? 0);
@@ -137,6 +145,9 @@ export function createGanttConfig(
         type: 'startdate',
         field: 'startDate',
         text: 'Start',
+        // Compact numeric date (06/02/2026) instead of the verbose
+        // "Jun 2, 2026" default, to save horizontal space.
+        format: 'MM/DD/YYYY',
         width: 120,
         resizable: true,
       },
@@ -145,6 +156,7 @@ export function createGanttConfig(
         type: 'enddate',
         field: 'endDate',
         text: 'End',
+        format: 'MM/DD/YYYY',
         width: 120,
         resizable: true,
       },

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -68,6 +68,8 @@ type GanttColumnConfig = {
   flex?: number;
   minWidth?: number;
   width?: number;
+  /** Bryntum DateHelper format token for date columns (e.g. 'MM/DD/YYYY'). */
+  format?: string;
   resizable?: boolean;
   sortable?: boolean;
   filterable?: boolean;


### PR DESCRIPTION
Formats the Gantt Start and End columns as `MM/DD/YYYY` instead of the verbose `Jun 2, 2026` default to save horizontal space. Fixes double-clicking a column resize handle so the header and body cells resize together: the Name column is now fixed-width instead of `flex` (a `flex` column let Bryntum's `resizeToFitContent` shrink only the body cells while the header kept its flex width, causing misalignment), and its `minWidth` is lowered to 150 so auto-fit can actually shrink it. The locked sub-grid width now re-syncs to the column widths on every resize via the columns store `change` event, so the timeline reclaims/yields the freed space with no dead gap. `tsc --noEmit` passes; the resize behavior was diagnosed from code + Bryntum docs and should be verified in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)