### PR TITLE
Gantt: fix task-bar sheen leak and ease dependency linking

### DIFF
--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -138,6 +138,9 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
   const canEditChart = canManageProjects(currentOrg?.role ?? '');
   const [isEditMode, setIsEditMode] = useState(false);
   const editingUnlocked = canEditChart && isEditMode;
+  // True while the Shift key is held (tracked only when editing is unlocked) so
+  // the toolbar's Link button can light up during a Shift-click link gesture.
+  const [shiftHeld, setShiftHeld] = useState(false);
 
   // Bryntum's CrudManager "added"/"removed" bags can drop records when the
   // scheduling engine commits state between cycles. We shadow-track IDs from
@@ -163,6 +166,11 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     clearSelection: clearLinkSelection,
     commitLinks,
   } = useTaskLinking(getGanttInstance as unknown as () => BryntumGanttInstance | null);
+
+  // Visual "linking is happening" state for the toolbar Link button: the
+  // persistent Link-mode toggle, a held Shift key, or a chain already in
+  // progress (users release Shift after the first pick but keep linking).
+  const linkActive = linkMode || shiftHeld || linkSelection.length > 0;
 
   useBryntumThemeAssets();
 
@@ -650,6 +658,27 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [linkSelection.length, linkMode, clearLinkSelection, setLinkMode]);
 
+  // Track the Shift key so the Link button lights up during a Shift-click link
+  // gesture. Only listen while editing is unlocked (linking is gated on it),
+  // and reset on blur so a Shift released off-window doesn't get stuck on.
+  useEffect(() => {
+    if (!editingUnlocked) {
+      setShiftHeld(false);
+      return;
+    }
+    const onDown = (e: KeyboardEvent) => { if (e.key === 'Shift') setShiftHeld(true); };
+    const onUp = (e: KeyboardEvent) => { if (e.key === 'Shift') setShiftHeld(false); };
+    const onBlur = () => setShiftHeld(false);
+    window.addEventListener('keydown', onDown);
+    window.addEventListener('keyup', onUp);
+    window.addEventListener('blur', onBlur);
+    return () => {
+      window.removeEventListener('keydown', onDown);
+      window.removeEventListener('keyup', onUp);
+      window.removeEventListener('blur', onBlur);
+    };
+  }, [editingUnlocked]);
+
   // Open task info dialog on double-click of a task bar (replaces Bryntum's built-in task editor).
   // Only attach the listener when editing is unlocked — the dialog is an edit surface.
   useEffect(() => {
@@ -797,6 +826,7 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         isEditMode={editingUnlocked}
         onToggleEditMode={() => setIsEditMode((prev) => !prev)}
         linkMode={linkMode}
+        linkActive={linkActive}
         onToggleLinkMode={toggleLinkMode}
         onColumnsClick={(e) => setColumnsAnchor(e.currentTarget)}
       />

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -602,7 +602,14 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
   // the details popover. Linking is an edit op, so it's gated on editingUnlocked.
   const onTaskClick = useCallback(
     (payload: TaskClickEventPayload) => {
-      const wantsLink = editingUnlocked && (linkMode || !!payload.event?.shiftKey);
+      // Route to linking when: Link mode is on, this click holds Shift, OR a
+      // link selection is already in progress. The last case means only the
+      // FIRST task needs Shift — every subsequent plain click continues the
+      // chain (and re-clicking a picked task deselects it) instead of opening
+      // the details popover, which is what made the second pick hard to land.
+      const wantsLink =
+        editingUnlocked &&
+        (linkMode || !!payload.event?.shiftKey || linkSelection.length > 0);
       if (wantsLink) {
         closeTaskPopover();
         handleLinkClick(payload);
@@ -610,7 +617,7 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
       }
       handleTaskClick(payload);
     },
-    [editingUnlocked, linkMode, closeTaskPopover, handleLinkClick, handleTaskClick],
+    [editingUnlocked, linkMode, linkSelection.length, closeTaskPopover, handleLinkClick, handleTaskClick],
   );
 
   // Attach the taskClick listener on the Bryntum instance (not in the static config)
@@ -1027,7 +1034,6 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
 
         <TaskLinkingBar
           selection={linkSelection}
-          linkMode={linkMode}
           onLink={commitLinks}
           onClear={clearLinkSelection}
         />

--- a/src/components/bryntum/components/GanttToolbar.tsx
+++ b/src/components/bryntum/components/GanttToolbar.tsx
@@ -168,6 +168,10 @@ type GanttToolbarProps = {
   onToggleEditMode?: () => void;
   /** Whether dependency-link mode is active (plain click selects tasks to link). */
   linkMode?: boolean;
+  /** Whether linking is visually active — Link mode on, Shift held, or a link
+   *  selection in progress. Drives the button's colorful state + "Linking"
+   *  label independently of the persistent `linkMode` toggle. */
+  linkActive?: boolean;
   onToggleLinkMode?: () => void;
 };
 
@@ -191,6 +195,7 @@ export default function GanttToolbar({
   isEditMode = false,
   onToggleEditMode,
   linkMode = false,
+  linkActive = false,
   onToggleLinkMode,
 }: GanttToolbarProps) {
   const editingActive = canEditChart && isEditMode;
@@ -637,7 +642,7 @@ export default function GanttToolbar({
                 'background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.12s ease',
               '&:active': { transform: 'scale(0.96)' },
               '@container gantt-toolbar (max-width: 720px)': { px: 0, gap: 0, width: 34 },
-              ...(linkMode
+              ...(linkActive
                 ? {
                     bgcolor: 'var(--accent-primary, #2563eb)',
                     color: 'var(--accent-contrast, #fff)',
@@ -659,7 +664,7 @@ export default function GanttToolbar({
               component="span"
               sx={{ '@container gantt-toolbar (max-width: 720px)': { display: 'none' } }}
             >
-              {linkMode ? 'Linking' : 'Link'}
+              {linkActive ? 'Linking' : 'Link'}
             </Box>
           </Box>
         </Tooltip>

--- a/src/components/bryntum/components/TaskLinkingBar.tsx
+++ b/src/components/bryntum/components/TaskLinkingBar.tsx
@@ -7,8 +7,6 @@ import type { LinkSelectionItem } from '../hooks/useTaskLinking';
 
 interface TaskLinkingBarProps {
   selection: Pick<LinkSelectionItem, 'id' | 'name'>[];
-  /** Link mode active — changes the one-task hint from "Shift-click" to "Click". */
-  linkMode: boolean;
   onLink: () => void;
   onClear: () => void;
 }
@@ -42,7 +40,7 @@ function NumberDot({ index }: { index: number }) {
   );
 }
 
-export default function TaskLinkingBar({ selection, linkMode, onLink, onClear }: TaskLinkingBarProps) {
+export default function TaskLinkingBar({ selection, onLink, onClear }: TaskLinkingBarProps) {
   if (selection.length === 0) return null;
 
   const ready = selection.length >= 2;
@@ -103,7 +101,7 @@ export default function TaskLinkingBar({ selection, linkMode, onLink, onClear }:
 
       {!ready && (
         <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary', whiteSpace: 'nowrap', flexShrink: 0 }}>
-          — {linkMode ? 'click' : 'Shift-click'} the successor task
+          — click the successor task
         </Typography>
       )}
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -401,6 +401,10 @@ body {
     transparent 100%
   ) !important;
   transform: translateX(-100%);
+  /* Hidden at rest via opacity (not just clipping) so the parked band never
+     shows when the bar flips to overflow:visible for dependency terminals.
+     The keyframes turn opacity on only during the sweep. */
+  opacity: 0;
   pointer-events: none !important;
 }
 
@@ -414,8 +418,8 @@ body {
 }
 
 @keyframes gantt-task-sheen {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(100%); }
+  0% { transform: translateX(-100%); opacity: 1; }
+  100% { transform: translateX(100%); opacity: 1; }
 }
 
 /* Task bar hover — slight lift, plus an inset right-edge cue so users know


### PR DESCRIPTION
Fixes a decorative task-bar sheen that leaked out the left edge of bars: it was hidden only by `overflow` clipping, so it reappeared when a bar flipped to `overflow: visible` to show dependency terminals — it's now hidden at rest via opacity and restored only during the hover sweep. Also eases dependency linking so that once a chain is started, plain clicks continue it (only the first task needs Shift, or use Link mode), preventing the details popover from hijacking the second pick. Updated the floating link bar's hint to "click the successor task" and removed the now-unused `linkMode` prop on `TaskLinkingBar`. All changes are CSS/TSX only with no schema, API, or env changes; `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)