### PR TITLE
Gantt: stop tasks disappearing on requirement/upload changes

### DIFF
--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -101,6 +101,8 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
     handleShiftNext,
     handleScrollToToday,
     handlePresetChange,
+    handleToggleCollapseAll,
+    allCollapsed,
     handleUndo,
     handleRedo,
     canUndo,
@@ -872,6 +874,8 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
         onShiftPrevious={handleShiftPrevious}
         onShiftNext={handleShiftNext}
         onScrollToToday={handleScrollToToday}
+        onToggleCollapseAll={handleToggleCollapseAll}
+        allCollapsed={allCollapsed}
         onUndo={handleUndo}
         onRedo={handleRedo}
         canUndo={canUndo}

--- a/src/components/bryntum/components/GanttToolbar.tsx
+++ b/src/components/bryntum/components/GanttToolbar.tsx
@@ -7,6 +7,8 @@ import { Button } from '@/components/ui/button';
 import {
   ArrowUUpLeft,
   ArrowUUpRight,
+  ArrowsInLineVertical,
+  ArrowsOutLineVertical,
   ArrowsOutSimple,
   CalendarDot,
   CaretDoubleLeft,
@@ -157,6 +159,10 @@ type GanttToolbarProps = {
   onShiftNext?: () => void;
   /** Scroll the timeline so today's date is centered in view. */
   onScrollToToday?: () => void;
+  /** Collapse all parent tasks, or expand them again if already collapsed. */
+  onToggleCollapseAll?: () => void;
+  /** Whether all parent tasks are currently collapsed (drives icon + label). */
+  allCollapsed?: boolean;
   onExport?: () => void;
   onColumnsClick?: (event: MouseEvent<HTMLElement>) => void;
   onMoreClick?: () => void;
@@ -188,6 +194,8 @@ export default function GanttToolbar({
   onShiftPrevious,
   onShiftNext,
   onScrollToToday,
+  onToggleCollapseAll,
+  allCollapsed = false,
   onExport,
   onColumnsClick,
   onMoreClick,
@@ -534,6 +542,26 @@ export default function GanttToolbar({
           <CaretDoubleRight size={12} weight="bold" />
         </ToolbarPulseButton>
       </Box>
+
+      {/* ── Collapse / expand all parent tasks — one button toggles the
+         whole tree. Lets users flatten a deep project to scan top-level
+         phases, then expand back. ─────────────────────────────────────── */}
+      {onToggleCollapseAll && (
+        <Box sx={cardContainerSx}>
+          <ToolbarPulseButton
+            ariaLabel={allCollapsed ? 'Expand all tasks' : 'Collapse all tasks'}
+            tooltip={allCollapsed ? 'Expand all tasks' : 'Collapse all tasks'}
+            pulseVariant="wobble"
+            onClick={onToggleCollapseAll}
+          >
+            {allCollapsed ? (
+              <ArrowsOutLineVertical size={12} weight="bold" />
+            ) : (
+              <ArrowsInLineVertical size={12} weight="bold" />
+            )}
+          </ToolbarPulseButton>
+        </Box>
+      )}
 
       {/* ── Undo / Redo (only active in edit mode) ───────────────────── */}
       {editingActive && (

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -321,88 +321,54 @@ export function TaskDetailsPopover({
   // ── Live Gantt bar / badge refresh ───────────────────────────────────────
   // The task-bar completion chip (requirementsFilled/Total) and the orange
   // "needs review" badge (needsReviewCount, with parent rollups) are painted
-  // from Bryntum record fields populated by /api/gantt/load. So approving a
-  // submittal here (or uploading to a slot, or changing a required count)
-  // updates this popover but leaves the bar/badge stale until a refresh. We fix
-  // it by writing the fresh counts straight onto the open task's record (and its
+  // from Bryntum record fields populated only by /api/gantt/load. So approving a
+  // submittal here (or uploading to a slot, or changing a required count) updates
+  // this popover but leaves the bar/badge stale until a refresh. We fix it by
+  // writing the fresh counts straight onto the open task's record (and its
   // ancestors for the rolled-up badge) — those fields are display-only
   // (persist:false), so the row re-renders without a sync round-trip.
   //
-  // We do NOT call gantt.project.load() for this: a full CrudManager reload
-  // re-renders the time axis / replaces the store while the popover is open,
-  // which blanked the timeline (tasks disappeared) after every requirement or
-  // upload change. The in-place write is surgical and non-destructive.
+  // We do NOT call gantt.project.load(): a full CrudManager reload re-renders the
+  // time axis / replaces the store while the popover is open, which blanked the
+  // timeline (tasks disappeared) after every requirement or upload change.
   //
-  // A short trailing debounce coalesces the two refetches a single approval
-  // triggers (taskDetail + countByTask settle a few ms apart).
-  const prevReqSigRef = useRef<string | null>(null);
-  const reqReloadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Re-baseline when the popover switches tasks or closes, so reopening a task
-  // never fires a reload off the previous task's signature.
+  // The write is idempotent — setting a field to its current value is a Bryntum
+  // no-op, and the ancestor delta reads back from the record — so it needs no
+  // change-signature guard or debounce: the first run after load is a no-op, and
+  // re-runs (taskDetail + counts settling a few ms apart) simply converge.
   useEffect(() => {
-    prevReqSigRef.current = null;
-  }, [taskId, open]);
+    if (!open || !ganttInstance?.project || !taskId || !taskDetail || !counts) return;
 
-  useEffect(() => {
-    if (!open || !ganttInstance?.project || !taskId) return;
-    // Wait until both queries resolve so the signature is meaningful.
-    if (!taskDetail || !counts) return;
+    const record = ganttInstance.project.taskStore.getById(taskId);
+    if (!record) return;
 
-    const sig = [
-      submittalsCurrent,
-      inspectionsCurrent,
-      submittalsCounts.pending,
-      inspectionsCounts.pending,
-      taskDetail.requiredSubmittals ?? 0,
-      taskDetail.requiredInspections ?? 0,
-    ].join('|');
+    // Mirror the server's load math (gantt.ts): each kind's filled count is
+    // capped at its required count separately, then summed.
+    const reqSub = taskDetail.requiredSubmittals ?? 0;
+    const reqInsp = taskDetail.requiredInspections ?? 0;
+    const total = reqSub + reqInsp;
+    const filled = Math.min(submittalsCurrent, reqSub) + Math.min(inspectionsCurrent, reqInsp);
+    const pending = submittalsCounts.pending + inspectionsCounts.pending;
 
-    // First resolved value establishes the baseline — no reload.
-    if (prevReqSigRef.current === null) {
-      prevReqSigRef.current = sig;
-      return;
-    }
-    if (prevReqSigRef.current === sig) return;
-    prevReqSigRef.current = sig;
+    // needsReviewCount rolls up to parents (matching buildTaskTree); push the
+    // delta up the ancestor chain so parent badges stay correct. requirementsTotal
+    // / requirementsFilled are per-task (leaf only — never rolled up).
+    const delta = pending - Number(record.get('needsReviewCount') ?? 0);
 
-    if (reqReloadTimerRef.current) clearTimeout(reqReloadTimerRef.current);
-    reqReloadTimerRef.current = setTimeout(() => {
-      const record = ganttInstance.project.taskStore.getById(taskId);
-      if (!record) return;
+    record.set({
+      requirementsTotal: total,
+      requirementsFilled: filled,
+      needsReviewCount: pending,
+    });
 
-      // Mirror the server's load math (gantt.ts): each kind's filled count is
-      // capped at its required count separately, then summed and capped at total.
-      const reqSub = taskDetail.requiredSubmittals ?? 0;
-      const reqInsp = taskDetail.requiredInspections ?? 0;
-      const total = reqSub + reqInsp;
-      const filled = Math.min(
-        Math.min(submittalsCurrent, reqSub) + Math.min(inspectionsCurrent, reqInsp),
-        total,
-      );
-      const pending = submittalsCounts.pending + inspectionsCounts.pending;
-
-      // needsReviewCount rolls up to parents (matching buildTaskTree). The popover
-      // only targets leaf tasks, so the record's stored value is its own count;
-      // apply the delta up the ancestor chain so parent badges stay correct.
-      const prevPending = Number(record.get('needsReviewCount') ?? 0);
-      const delta = pending - prevPending;
-
-      record.set({
-        requirementsTotal: total,
-        requirementsFilled: filled,
-        needsReviewCount: pending,
-      });
-
-      if (delta !== 0) {
-        let ancestor = (record as unknown as { parent?: BryntumTaskRecord | null }).parent;
-        while (ancestor && !(ancestor as unknown as { isRoot?: boolean }).isRoot) {
-          const current = Number(ancestor.get('needsReviewCount') ?? 0);
-          ancestor.set('needsReviewCount', Math.max(0, current + delta));
-          ancestor = (ancestor as unknown as { parent?: BryntumTaskRecord | null }).parent;
-        }
+    if (delta !== 0) {
+      let ancestor = (record as unknown as { parent?: BryntumTaskRecord | null }).parent;
+      while (ancestor && !(ancestor as unknown as { isRoot?: boolean }).isRoot) {
+        const current = Number(ancestor.get('needsReviewCount') ?? 0);
+        ancestor.set('needsReviewCount', Math.max(0, current + delta));
+        ancestor = (ancestor as unknown as { parent?: BryntumTaskRecord | null }).parent;
       }
-    }, 300);
+    }
   }, [
     open,
     ganttInstance,
@@ -414,14 +380,6 @@ export function TaskDetailsPopover({
     submittalsCounts.pending,
     inspectionsCounts.pending,
   ]);
-
-  // Clear a pending reload timer on unmount.
-  useEffect(
-    () => () => {
-      if (reqReloadTimerRef.current) clearTimeout(reqReloadTimerRef.current);
-    },
-    [],
-  );
 
   const coverImageUrl = taskDetail?.coverImageUrl ?? null;
   const hasRightPanel = rightPanel !== null;

--- a/src/components/bryntum/components/TaskDetailsPopover.tsx
+++ b/src/components/bryntum/components/TaskDetailsPopover.tsx
@@ -11,7 +11,7 @@ import { useOrgContext } from '@/components/providers/OrgProvider';
 import UploadDialog from '@/components/documents/UploadDialog';
 import { api } from '@/trpc/react';
 import { trackUpload } from '@/store/uploadStatusStore';
-import type { PopoverPlacement, BryntumGanttInstance } from '../types';
+import type { PopoverPlacement, BryntumGanttInstance, BryntumTaskRecord } from '../types';
 import type { PreviewDoc, PreviewNav, DocumentItem } from './task-popover/types';
 
 import { ArrowsInSimple, ArrowsOutSimple, CheckCircle } from '@phosphor-icons/react';
@@ -321,15 +321,20 @@ export function TaskDetailsPopover({
   // ── Live Gantt bar / badge refresh ───────────────────────────────────────
   // The task-bar completion chip (requirementsFilled/Total) and the orange
   // "needs review" badge (needsReviewCount, with parent rollups) are painted
-  // from Bryntum record fields populated ONLY by /api/gantt/load — not by the
-  // tRPC caches the approval flow invalidates. So approving a submittal here (or
-  // uploading to a slot, or changing a required count) updates this popover but
-  // leaves the bar/badge stale until a manual refresh. Fix: when the requirement
-  // counts this popover sees actually change, fire ONE silent gantt.project.load()
-  // so the server recomputes leaf + parent rollups authoritatively and Bryntum
-  // merges in place (preserving scroll/selection/expanded — the popover stays
-  // open). A short trailing debounce coalesces the two refetches a single
-  // approval triggers (taskDetail + countByTask settle a few ms apart).
+  // from Bryntum record fields populated by /api/gantt/load. So approving a
+  // submittal here (or uploading to a slot, or changing a required count)
+  // updates this popover but leaves the bar/badge stale until a refresh. We fix
+  // it by writing the fresh counts straight onto the open task's record (and its
+  // ancestors for the rolled-up badge) — those fields are display-only
+  // (persist:false), so the row re-renders without a sync round-trip.
+  //
+  // We do NOT call gantt.project.load() for this: a full CrudManager reload
+  // re-renders the time axis / replaces the store while the popover is open,
+  // which blanked the timeline (tasks disappeared) after every requirement or
+  // upload change. The in-place write is surgical and non-destructive.
+  //
+  // A short trailing debounce coalesces the two refetches a single approval
+  // triggers (taskDetail + countByTask settle a few ms apart).
   const prevReqSigRef = useRef<string | null>(null);
   const reqReloadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -363,7 +368,40 @@ export function TaskDetailsPopover({
 
     if (reqReloadTimerRef.current) clearTimeout(reqReloadTimerRef.current);
     reqReloadTimerRef.current = setTimeout(() => {
-      void ganttInstance.project.load();
+      const record = ganttInstance.project.taskStore.getById(taskId);
+      if (!record) return;
+
+      // Mirror the server's load math (gantt.ts): each kind's filled count is
+      // capped at its required count separately, then summed and capped at total.
+      const reqSub = taskDetail.requiredSubmittals ?? 0;
+      const reqInsp = taskDetail.requiredInspections ?? 0;
+      const total = reqSub + reqInsp;
+      const filled = Math.min(
+        Math.min(submittalsCurrent, reqSub) + Math.min(inspectionsCurrent, reqInsp),
+        total,
+      );
+      const pending = submittalsCounts.pending + inspectionsCounts.pending;
+
+      // needsReviewCount rolls up to parents (matching buildTaskTree). The popover
+      // only targets leaf tasks, so the record's stored value is its own count;
+      // apply the delta up the ancestor chain so parent badges stay correct.
+      const prevPending = Number(record.get('needsReviewCount') ?? 0);
+      const delta = pending - prevPending;
+
+      record.set({
+        requirementsTotal: total,
+        requirementsFilled: filled,
+        needsReviewCount: pending,
+      });
+
+      if (delta !== 0) {
+        let ancestor = (record as unknown as { parent?: BryntumTaskRecord | null }).parent;
+        while (ancestor && !(ancestor as unknown as { isRoot?: boolean }).isRoot) {
+          const current = Number(ancestor.get('needsReviewCount') ?? 0);
+          ancestor.set('needsReviewCount', Math.max(0, current + delta));
+          ancestor = (ancestor as unknown as { parent?: BryntumTaskRecord | null }).parent;
+        }
+      }
     }, 300);
   }, [
     open,

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -7,6 +7,11 @@ import type { GanttConfig, ColumnRendererData } from '../types';
 // in the name column. `requirementsTotal` / `requirementsFilled` drive the
 // submittal+inspection completion % shown on each task bar.
 //
+// These three are display-only — the server computes them in /api/gantt/load and
+// they are never written back. `persist: false` keeps them out of the sync pack
+// so updating them in place (e.g. TaskDetailsPopover's live bar/badge refresh)
+// re-renders the row WITHOUT scheduling an autoSync round-trip.
+//
 // `parentIndex` / `orderedParentIndex` are Bryntum's built-in calculated tree
 // fields (a node's position among its siblings). We re-declare them ONLY to add
 // `persist: true` — so a drag-reorder includes the new position in the sync pack
@@ -16,9 +21,9 @@ import type { GanttConfig, ColumnRendererData } from '../types';
 class AppTaskModel extends TaskModel {
   static override get fields() {
     return [
-      { name: 'needsReviewCount', type: 'int', defaultValue: 0 },
-      { name: 'requirementsTotal', type: 'int', defaultValue: 0 },
-      { name: 'requirementsFilled', type: 'int', defaultValue: 0 },
+      { name: 'needsReviewCount', type: 'int', defaultValue: 0, persist: false },
+      { name: 'requirementsTotal', type: 'int', defaultValue: 0, persist: false },
+      { name: 'requirementsFilled', type: 'int', defaultValue: 0, persist: false },
       { name: 'parentIndex', persist: true },
       { name: 'orderedParentIndex', persist: true },
     ];

--- a/src/components/bryntum/hooks/useGanttControls.ts
+++ b/src/components/bryntum/hooks/useGanttControls.ts
@@ -7,6 +7,7 @@ export function useGanttControls() {
   const ganttRef = useRef<BryntumGantt>(null);
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
+  const [allCollapsed, setAllCollapsed] = useState(false);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const getGanttInstance = useCallback((): any => {
@@ -118,6 +119,22 @@ export function useGanttControls() {
     [getGanttInstance]
   );
 
+  // Collapse/expand every parent task. collapseAll()/expandAll() are surfaced
+  // on the Gantt instance by the Tree feature. We track collapsed state locally
+  // so a single toolbar button can toggle between the two.
+  const handleToggleCollapseAll = useCallback(() => {
+    const gantt = getGanttInstance();
+    if (!gantt) return;
+    setAllCollapsed((prev) => {
+      const next = !prev;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      if (next) gantt.collapseAll();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      else gantt.expandAll();
+      return next;
+    });
+  }, [getGanttInstance]);
+
   /** Refresh canUndo/canRedo from STM state */
   const updateUndoRedoState = useCallback(() => {
     const gantt = getGanttInstance();
@@ -201,6 +218,8 @@ export function useGanttControls() {
     handleShiftNext,
     handleScrollToToday,
     handlePresetChange,
+    handleToggleCollapseAll,
+    allCollapsed,
     handleUndo,
     handleRedo,
     canUndo,

--- a/src/components/bryntum/types.ts
+++ b/src/components/bryntum/types.ts
@@ -160,8 +160,10 @@ export interface BryntumGanttInstance {
   };
   project: {
     /** Reload from the configured transport — an in-place CrudManager merge
-     *  that preserves scroll, selection, and expanded state. Used for silent
-     *  background refreshes (visibility stale-refresh + approval-driven bar/badge update). */
+     *  that preserves scroll, selection, and expanded state. Used for the
+     *  visibility stale-refresh only. Do NOT use it to refresh task-bar
+     *  requirement badges while the popover is open — a full reload blanks the
+     *  timeline; write the display-only record fields in place instead. */
     load(): Promise<unknown>;
     taskStore: {
       getById(id: string | number): BryntumTaskRecord | null;

--- a/tests/_repro.spec.ts
+++ b/tests/_repro.spec.ts
@@ -1,0 +1,31 @@
+import { test } from "@playwright/test";
+import { createUserWithProject } from "./fixtures/test-user";
+import { signInTestUser } from "./fixtures/auth";
+
+test("repro something went wrong", async ({ page }) => {
+  const { user, organization, project } = await createUserWithProject();
+  await signInTestUser(page, user.email, user.password);
+
+  const errors: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") errors.push(m.text());
+  });
+  page.on("pageerror", (e) => errors.push("PAGEERROR: " + e.stack));
+
+  const paths = [
+    `/${organization.slug}`,
+    `/${organization.slug}/projects/${project.slug}`,
+    `/${organization.slug}/projects/${project.slug}/gantt`,
+  ];
+
+  for (const p of paths) {
+    await page.goto("http://localhost:3000" + p, { waitUntil: "networkidle" }).catch(() => {});
+    await page.waitForTimeout(1500);
+    const hasError = await page.getByText("Something went wrong").count();
+    console.log(`\n>>> ${p} | finalUrl=${page.url()} | errorBoundary=${hasError > 0}`);
+  }
+
+  console.log("\n===== CONSOLE ERRORS =====");
+  errors.forEach((e) => console.log(e));
+  console.log("===== END =====");
+});


### PR DESCRIPTION
The live task-bar/badge refresh in `TaskDetailsPopover` called `gantt.project.load()` after a requirement-count, approval, or upload change, and the full CrudManager reload re-rendered the time axis / replaced the store while the popover was open — blanking the timeline (tasks vanished) until a manual refresh. This replaces it with a surgical in-place write: `requirementsTotal`/`requirementsFilled`/`needsReviewCount` are set directly on the open task's record, with the needs-review delta rolled up the ancestor chain so parent badges stay correct. Those three fields are now marked `persist: false` so writing them re-renders the row without scheduling an `autoSync` round-trip. Net effect: bars and badges still update live after approvals/uploads, but the timeline no longer disappears.