### PR TITLE
Gantt: stop auto-constraints from locking tasks against dragging earlier

### DIFF
--- a/src/components/bryntum/components/ProjectStartCard.tsx
+++ b/src/components/bryntum/components/ProjectStartCard.tsx
@@ -92,7 +92,8 @@ export default function ProjectStartCard({ projectId, canEdit, getGanttInstance 
       void utils.project.list.invalidate();
 
       // Move the live scheduling floor so bars can immediately slide to it —
-      // no page reload. autoSetConstraints keeps tasks pinned at their dates.
+      // no page reload. Independent leaf tasks are manuallyScheduled (see
+      // gantt.load), so lowering the floor no longer collapses them onto it.
       if (draft) {
         const gantt = getGanttInstance();
         if (gantt?.project) {

--- a/src/components/bryntum/config/ganttConfig.ts
+++ b/src/components/bryntum/config/ganttConfig.ts
@@ -76,13 +76,13 @@ export function createGanttConfig(
       autoSyncTimeout: 500,
       taskModelClass: AppTaskModel,
       resetUndoRedoQueuesAfterLoad: true,
-      // Pin each task at its own date with an implicit `startnoearlier`
-      // constraint instead of rescheduling unconstrained tasks to the project
-      // start. This lets the project start date (the scheduling floor) be set
-      // EARLIER than existing tasks — moving the left wall without yanking the
-      // bars onto it. Without this, lowering project.startDate would collapse
-      // unconstrained tasks back to the new start on load.
-      autoSetConstraints: true,
+      // NOTE: autoSetConstraints is intentionally OFF (Path B). When on, Bryntum
+      // stamps a `startnoearlier` constraint on every unconstrained task pinned
+      // to its own start date — which blocks dragging the bar EARLIER (you can
+      // only move it later). That made day-to-day editing feel broken. Instead,
+      // the load path (gantt.load) holds independent leaf tasks in place by
+      // marking them manuallyScheduled, so they keep their dates and drag freely
+      // in both directions while dependency-linked tasks stay engine-scheduled.
 
       stm: {
         autoRecord: true,

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -256,6 +256,38 @@ export const ganttRouter = createTRPCRouter({
         if (filled > 0) filledRequirementCounts.set(task.id, filled);
       }
 
+      // Path B scheduling relaxation (see ganttConfig.ts — autoSetConstraints is
+      // OFF). Two adjustments, re-derived on every load so no DB migration is
+      // needed and reverting is code-only:
+      //   1. Drop the legacy auto-stamped `startnoearlierthan` walls. These were
+      //      pinned to each task's own start date and blocked dragging a bar
+      //      earlier. User-set constraints (any other type) are left untouched.
+      //   2. Hold independent LEAF tasks at their date by marking them
+      //      manuallyScheduled. Without a wall, an auto-scheduled task with no
+      //      predecessor reschedules to the project floor on load (the "bars pile
+      //      up" problem). Tasks with an incoming dependency are held by their
+      //      predecessor, and parents roll up from their children — neither needs
+      //      this, so both stay engine-scheduled and dependency auto-push is kept.
+      const parentIds = new Set(
+        tasks.map((t) => t.parentId).filter((id): id is string => id !== null),
+      );
+      const tasksWithIncomingDep = new Set(dependencies.map((d) => d.toTaskId));
+      for (const task of tasks) {
+        if (task.constraintType === "startnoearlierthan") {
+          task.constraintType = null;
+          task.constraintDate = null;
+        }
+        const isLeaf = !parentIds.has(task.id);
+        if (
+          isLeaf &&
+          !tasksWithIncomingDep.has(task.id) &&
+          !task.constraintType &&
+          !task.manuallyScheduled
+        ) {
+          task.manuallyScheduled = true;
+        }
+      }
+
       // Build hierarchical task tree
       const taskTree = buildTaskTree(tasks, needsReviewCounts, filledRequirementCounts);
 


### PR DESCRIPTION
Bryntum's `autoSetConstraints` was stamping a `startnoearlier` constraint on every unconstrained task, pinned to its own start date — which blocked dragging a bar earlier and surfaced as confusing constraints on header/parent tasks. This turns it off and instead relaxes scheduling at load time in `gantt.load`: it strips the auto-stamped `startnoearlierthan` walls and holds independent leaf tasks in place by marking them `manuallyScheduled`. Tasks now drag freely in both directions while dependency-linked tasks stay engine-scheduled and keep auto-pushing successors. The fix is re-derived on every load, so no DB migration is required and reverting is code-only.