### PR TITLE
Redirect into new project after create; invite by email in members step

### DIFF
--- a/src/__tests__/projects/add-project-dialog.test.tsx
+++ b/src/__tests__/projects/add-project-dialog.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRouter } from "next/navigation";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import AddProjectDialog from "@/components/projects/AddProjectDialog";
+
+const mocks = vi.hoisted(() => ({
+  showSnackbar: vi.fn(),
+  showLoading: vi.fn(),
+  hideLoading: vi.fn(),
+  session: { user: { id: "user-1" } } as { user: { id: string } } | null,
+}));
+
+vi.mock("@/hooks/useOrgFromUrl", () => ({
+  useOrgFromUrl: () => ({
+    orgSlug: "test-org",
+    activeOrganizationId: "org-123",
+    currentOrg: { id: "org-123", slug: "test-org" },
+  }),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: mocks.session }),
+}));
+
+vi.mock("@/hooks/useSnackbar", () => ({
+  useSnackbar: () => ({ showSnackbar: mocks.showSnackbar }),
+}));
+
+vi.mock("@/components/providers/LoadingProvider", () => ({
+  useLoading: () => ({ showLoading: mocks.showLoading, hideLoading: mocks.hideLoading }),
+}));
+
+vi.mock("@/components/projects/TemplatePickerStep", () => ({
+  __esModule: true,
+  default: ({ onContinue }: { onContinue: () => void }) => (
+    <button onClick={onContinue}>continue-template</button>
+  ),
+}));
+
+vi.mock("@/components/projects/ProjectFormBody", () => ({
+  __esModule: true,
+  default: ({
+    onSuccess,
+  }: {
+    onSuccess?: (project: { id: string; slug: string; name: string }) => void;
+  }) => (
+    <button
+      onClick={() =>
+        onSuccess?.({ id: "proj-1", slug: "my-project", name: "My Project" })
+      }
+    >
+      create-project
+    </button>
+  ),
+}));
+
+vi.mock("@/components/projects/AddProjectMembersStep", () => ({
+  __esModule: true,
+  default: ({ onComplete, onSkip }: { onComplete: () => void; onSkip: () => void }) => (
+    <div>
+      <button onClick={onComplete}>complete-members</button>
+      <button onClick={onSkip}>skip-members</button>
+    </div>
+  ),
+}));
+
+describe("AddProjectDialog", () => {
+  const mockPush = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.session = { user: { id: "user-1" } };
+    (useRouter as ReturnType<typeof vi.fn>).mockReturnValue({
+      push: mockPush,
+      replace: vi.fn(),
+      refresh: vi.fn(),
+    });
+  });
+
+  const advanceToMembersStep = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByText("continue-template"));
+    await user.click(screen.getByText("create-project"));
+  };
+
+  it("always advances to the members step and shows a 3-step stepper", async () => {
+    const user = userEvent.setup();
+    render(<AddProjectDialog open onOpenChange={vi.fn()} />);
+
+    await advanceToMembersStep(user);
+
+    expect(screen.getByLabelText("Step 3 of 3")).toBeInTheDocument();
+    expect(screen.getByText("complete-members")).toBeInTheDocument();
+  });
+
+  it("navigates to the project's Gantt page and closes the dialog on complete", async () => {
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(<AddProjectDialog open onOpenChange={onOpenChange} />);
+
+    await advanceToMembersStep(user);
+    await user.click(screen.getByText("complete-members"));
+
+    expect(mocks.showLoading).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/test-org/projects/my-project/gantt");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows a created snackbar without the dropdown copy and navigates on skip", async () => {
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(<AddProjectDialog open onOpenChange={onOpenChange} />);
+
+    await advanceToMembersStep(user);
+    await user.click(screen.getByText("skip-members"));
+
+    expect(mocks.showSnackbar).toHaveBeenCalledWith('"My Project" created', "success");
+    expect(mocks.showSnackbar).not.toHaveBeenCalledWith(
+      expect.stringContaining("dropdown"),
+      expect.anything()
+    );
+    expect(mockPush).toHaveBeenCalledWith("/test-org/projects/my-project/gantt");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("navigates directly without ever rendering the members step when session is missing", async () => {
+    mocks.session = null;
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(<AddProjectDialog open onOpenChange={onOpenChange} />);
+
+    await user.click(screen.getByText("continue-template"));
+    await user.click(screen.getByText("create-project"));
+
+    expect(screen.queryByText("complete-members")).not.toBeInTheDocument();
+    expect(mockPush).toHaveBeenCalledWith("/test-org/projects/my-project/gantt");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/__tests__/projects/add-project-members-step.test.tsx
+++ b/src/__tests__/projects/add-project-members-step.test.tsx
@@ -1,18 +1,23 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi, describe, it, expect, beforeEach } from "vitest";
+import { TRPCClientError } from "@trpc/client";
 import AddProjectMembersStep from "@/components/projects/AddProjectMembersStep";
 
 const mocks = vi.hoisted(() => ({
-  bulkAdd: vi.fn(),
-  bulkAddPending: false,
-  invalidate: vi.fn(),
+  bulkAddMutateAsync: vi.fn(),
+  invitationCreateMutateAsync: vi.fn(),
+  invalidateProjectMemberList: vi.fn(),
+  invalidateInvitationList: vi.fn(),
+  invalidateListProjectMemberships: vi.fn(),
+  showSnackbar: vi.fn(),
   members: [] as Array<{
     id: string;
     role: string;
     user: { id: string; name: string | null; email: string; image: string | null };
   }>,
   membersLoading: false,
+  failEmails: new Set<string>(),
 }));
 
 vi.mock("@/trpc/react", () => ({
@@ -27,28 +32,34 @@ vi.mock("@/trpc/react", () => ({
     },
     projectMember: {
       bulkAdd: {
-        useMutation: (opts?: {
-          onSuccess?: (data: { added: number }) => void;
-          onError?: (error: { message?: string }) => void;
-        }) => ({
-          mutate: (input: unknown) => {
-            mocks.bulkAdd(input);
-            opts?.onSuccess?.({ added: 1 });
-          },
-          isPending: mocks.bulkAddPending,
+        useMutation: () => ({
+          mutateAsync: mocks.bulkAddMutateAsync,
+          isPending: false,
+        }),
+      },
+    },
+    invitation: {
+      create: {
+        useMutation: () => ({
+          mutateAsync: mocks.invitationCreateMutateAsync,
+          isPending: false,
         }),
       },
     },
     useUtils: () => ({
       projectMember: {
-        list: { invalidate: mocks.invalidate },
+        list: { invalidate: mocks.invalidateProjectMemberList },
+        listProjectMemberships: { invalidate: mocks.invalidateListProjectMemberships },
+      },
+      invitation: {
+        list: { invalidate: mocks.invalidateInvitationList },
       },
     }),
   },
 }));
 
 vi.mock("@/hooks/useSnackbar", () => ({
-  useSnackbar: () => ({ showSnackbar: vi.fn() }),
+  useSnackbar: () => ({ showSnackbar: mocks.showSnackbar }),
 }));
 
 const baseProps = {
@@ -69,15 +80,28 @@ const otherUser = (id: string, name: string, email: string) => ({
 describe("AddProjectMembersStep", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.bulkAdd.mockReset();
-    mocks.invalidate.mockReset();
-    mocks.bulkAddPending = false;
+    mocks.failEmails = new Set();
     mocks.membersLoading = false;
     mocks.members = [
       otherUser("user-self", "Me Self", "me@buildco.com"),
       otherUser("user-jordan", "Jordan Marquez", "jordan@buildco.com"),
       otherUser("user-samira", "Samira Patel", "samira@buildco.com"),
     ];
+
+    mocks.bulkAddMutateAsync.mockImplementation(
+      async (input: { members: Array<{ userId: string; role: string }> }) => ({
+        added: input.members.length,
+      })
+    );
+
+    mocks.invitationCreateMutateAsync.mockImplementation(
+      async (input: { email: string }) => {
+        if (mocks.failEmails.has(input.email)) {
+          throw new TRPCClientError(`Couldn't reach ${input.email}`);
+        }
+        return { invitation: { id: `inv-${input.email}` } };
+      }
+    );
   });
 
   it("renders org members and excludes the current user", () => {
@@ -131,11 +155,13 @@ describe("AddProjectMembersStep", () => {
     await user.click(screen.getByText("Jordan Marquez"));
     await user.click(screen.getByRole("button", { name: /add to project/i }));
 
-    expect(mocks.bulkAdd).toHaveBeenCalledWith({
-      projectId: "proj-123",
-      members: [{ userId: "user-jordan", role: "member" }],
+    await waitFor(() => {
+      expect(mocks.bulkAddMutateAsync).toHaveBeenCalledWith({
+        projectId: "proj-123",
+        members: [{ userId: "user-jordan", role: "member" }],
+      });
     });
-    expect(onComplete).toHaveBeenCalled();
+    await waitFor(() => expect(onComplete).toHaveBeenCalled());
   });
 
   it("calls onSkip without firing bulkAdd when Skip is clicked", async () => {
@@ -147,7 +173,7 @@ describe("AddProjectMembersStep", () => {
     await user.click(screen.getByRole("button", { name: /^skip$/i }));
 
     expect(onSkip).toHaveBeenCalled();
-    expect(mocks.bulkAdd).not.toHaveBeenCalled();
+    expect(mocks.bulkAddMutateAsync).not.toHaveBeenCalled();
   });
 
   it("shows empty state when there are no other org members", () => {
@@ -157,5 +183,216 @@ describe("AddProjectMembersStep", () => {
     expect(
       screen.getByText(/no other teammates in your organization/i)
     ).toBeInTheDocument();
+  });
+
+  it("shows an invite action for an unknown valid email", async () => {
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    await user.type(screen.getByPlaceholderText(/search teammates/i), "new@buildco.com");
+
+    expect(screen.getByText(/invite new@buildco\.com by email/i)).toBeInTheDocument();
+  });
+
+  it("does not show an invite action for an existing member's email", async () => {
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    await user.type(screen.getByPlaceholderText(/search teammates/i), "jordan@buildco.com");
+
+    expect(
+      screen.queryByText(/invite jordan@buildco\.com by email/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show an invite action for the current user's own email", async () => {
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    await user.type(screen.getByPlaceholderText(/search teammates/i), "me@buildco.com");
+
+    expect(
+      screen.queryByText(/invite me@buildco\.com by email/i)
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/that's you/i)).toBeInTheDocument();
+  });
+
+  it("adds a pending invite when clicked, clears search, and enables Add", async () => {
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    const search = screen.getByPlaceholderText(/search teammates/i);
+    await user.type(search, "new@buildco.com");
+    await user.click(screen.getByText(/invite new@buildco\.com by email/i));
+
+    expect(search).toHaveValue("");
+    expect(screen.getByText("new@buildco.com")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add to project/i })).not.toBeDisabled();
+  });
+
+  it("keeps a pending invite row visible while the search text changes", async () => {
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    const search = screen.getByPlaceholderText(/search teammates/i);
+    await user.type(search, "new@buildco.com");
+    await user.click(screen.getByText(/invite new@buildco\.com by email/i));
+
+    await user.type(search, "samira");
+
+    expect(screen.getByText("new@buildco.com")).toBeInTheDocument();
+    expect(screen.getByText("Samira Patel")).toBeInTheDocument();
+  });
+
+  it("normalizes and dedupes emails (trims + lowercases)", async () => {
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    const search = screen.getByPlaceholderText(/search teammates/i);
+    await user.type(search, "  New@Ex.com ");
+    await user.click(screen.getByText(/invite new@ex\.com by email/i));
+
+    await user.type(search, "NEW@ex.com");
+    expect(screen.queryByText(/invite new@ex\.com by email/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText("new@ex.com")).toHaveLength(1);
+  });
+
+  it("removes a pending invite when its remove button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    const search = screen.getByPlaceholderText(/search teammates/i);
+    await user.type(search, "new@buildco.com");
+    await user.click(screen.getByText(/invite new@buildco\.com by email/i));
+    expect(screen.getByText("new@buildco.com")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /remove invite for new@buildco\.com/i })
+    );
+
+    expect(screen.queryByText("new@buildco.com")).not.toBeInTheDocument();
+  });
+
+  it("submits only invitation.create when only pending invites are present", async () => {
+    const onComplete = vi.fn();
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} onComplete={onComplete} />);
+
+    const search = screen.getByPlaceholderText(/search teammates/i);
+    await user.type(search, "new@buildco.com");
+    await user.click(screen.getByText(/invite new@buildco\.com by email/i));
+    await user.click(screen.getByRole("button", { name: /add to project/i }));
+
+    await waitFor(() => {
+      expect(mocks.invitationCreateMutateAsync).toHaveBeenCalledWith({
+        organizationId: "org-456",
+        projectId: "proj-123",
+        email: "new@buildco.com",
+        role: "member",
+      });
+    });
+    expect(mocks.bulkAddMutateAsync).not.toHaveBeenCalled();
+    await waitFor(() => expect(onComplete).toHaveBeenCalled());
+  });
+
+  it("submits both bulkAdd and invitation.create when members and invites are combined", async () => {
+    const onComplete = vi.fn();
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} onComplete={onComplete} />);
+
+    await user.click(screen.getByText("Jordan Marquez"));
+
+    const search = screen.getByPlaceholderText(/search teammates/i);
+    await user.type(search, "new@buildco.com");
+    await user.click(screen.getByText(/invite new@buildco\.com by email/i));
+
+    await user.click(screen.getByRole("button", { name: /add to project/i }));
+
+    await waitFor(() => {
+      expect(mocks.bulkAddMutateAsync).toHaveBeenCalledWith({
+        projectId: "proj-123",
+        members: [{ userId: "user-jordan", role: "member" }],
+      });
+    });
+    await waitFor(() => {
+      expect(mocks.invitationCreateMutateAsync).toHaveBeenCalledWith({
+        organizationId: "org-456",
+        projectId: "proj-123",
+        email: "new@buildco.com",
+        role: "member",
+      });
+    });
+    await waitFor(() => expect(onComplete).toHaveBeenCalled());
+  });
+
+  it("submits the selected role for a pending invite", async () => {
+    const user = userEvent.setup();
+    render(<AddProjectMembersStep {...baseProps} />);
+
+    const search = screen.getByPlaceholderText(/search teammates/i);
+    await user.type(search, "new@buildco.com");
+    await user.click(screen.getByText(/invite new@buildco\.com by email/i));
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Admin" }));
+
+    await user.click(screen.getByRole("button", { name: /add to project/i }));
+
+    await waitFor(() => {
+      expect(mocks.invitationCreateMutateAsync).toHaveBeenCalledWith({
+        organizationId: "org-456",
+        projectId: "proj-123",
+        email: "new@buildco.com",
+        role: "admin",
+      });
+    });
+  });
+
+  it("keeps the failed invite, removes the succeeded one, skips onComplete, and names the failed email in the error", async () => {
+    const onComplete = vi.fn();
+    const user = userEvent.setup();
+    mocks.failEmails.add("bad@buildco.com");
+
+    render(<AddProjectMembersStep {...baseProps} onComplete={onComplete} />);
+
+    const search = screen.getByPlaceholderText(/search teammates/i);
+    await user.type(search, "good@buildco.com");
+    await user.click(screen.getByText(/invite good@buildco\.com by email/i));
+
+    await user.type(search, "bad@buildco.com");
+    await user.click(screen.getByText(/invite bad@buildco\.com by email/i));
+
+    await user.click(screen.getByRole("button", { name: /add to project/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("good@buildco.com")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("bad@buildco.com")).toBeInTheDocument();
+    expect(onComplete).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mocks.showSnackbar).toHaveBeenCalledWith(
+        expect.stringContaining("bad@buildco.com"),
+        "error"
+      );
+    });
+  });
+
+  it("keeps the member selection when bulkAdd fails", async () => {
+    const onComplete = vi.fn();
+    const user = userEvent.setup();
+    mocks.bulkAddMutateAsync.mockRejectedValueOnce(
+      new TRPCClientError("Failed to add teammates")
+    );
+
+    render(<AddProjectMembersStep {...baseProps} onComplete={onComplete} />);
+
+    await user.click(screen.getByText("Jordan Marquez"));
+    await user.click(screen.getByRole("button", { name: /add to project/i }));
+
+    await waitFor(() => {
+      expect(mocks.showSnackbar).toHaveBeenCalled();
+    });
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 });

--- a/src/components/projects/AddProjectDialog.tsx
+++ b/src/components/projects/AddProjectDialog.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { Dialog, alpha, Box, Typography } from '@mui/material';
 import { Check } from '@phosphor-icons/react';
 import { useSnackbar } from '@/hooks/useSnackbar';
 import { useOrgFromUrl } from '@/hooks/useOrgFromUrl';
 import { useSession } from '@/lib/auth-client';
-import { api } from '@/trpc/react';
+import { useLoading } from '@/components/providers/LoadingProvider';
 import ProjectFormBody from '@/components/projects/ProjectFormBody';
 import AddProjectMembersStep from '@/components/projects/AddProjectMembersStep';
 import TemplatePickerStep, {
@@ -33,6 +34,8 @@ export default function AddProjectDialog({
   const { orgSlug, activeOrganizationId } = useOrgFromUrl();
   const { data: session } = useSession();
   const { showSnackbar } = useSnackbar();
+  const { showLoading } = useLoading();
+  const router = useRouter();
   const currentUserId = session?.user?.id;
 
   const [step, setStep] = useState<Step>('template');
@@ -51,67 +54,44 @@ export default function AddProjectDialog({
     }
   }, [open]);
 
-  // Pre-fetch org members so we can decide whether to skip step 2
-  const { data: orgMembers, isSuccess: orgMembersLoaded } =
-    api.member.list.useQuery(
-      { organizationId: activeOrganizationId },
-      { enabled: open && !!activeOrganizationId }
-    );
-
-  // Only treat the org as confirmed-empty after a successful query resolves.
-  // While the query is in-flight we err toward showing step 2 (which has its
-  // own empty state) so the members step is never silently skipped.
-  const confirmedNoOtherMembers =
-    orgMembersLoaded &&
-    !!currentUserId &&
-    orgMembers.filter((m) => m.user.id !== currentUserId).length === 0;
-
   const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const navigateToProject = (project: CreatedProject) => {
+    showLoading('Opening project'); // auto-hides on pathname change
+    router.push(`/${orgSlug}/projects/${project.slug}/gantt`);
     onOpenChange(false);
   };
 
   const handleProjectCreated = (project: CreatedProject) => {
     setCreatedProject(project);
-    if (currentUserId && !confirmedNoOtherMembers) {
+    if (currentUserId) {
       setStep('members');
     } else {
-      showSnackbar(
-        `"${project.name}" created — switch to it in the project dropdown`,
-        'success'
-      );
-      handleClose();
+      showSnackbar(`"${project.name}" created`, 'success');
+      navigateToProject(project);
     }
   };
 
   const handleMembersComplete = () => {
     if (createdProject) {
-      showSnackbar(
-        `"${createdProject.name}" is ready`,
-        'success'
-      );
+      navigateToProject(createdProject);
     }
-    handleClose();
   };
 
   const handleMembersSkip = () => {
     if (createdProject) {
-      showSnackbar(
-        `"${createdProject.name}" created — switch to it in the project dropdown`,
-        'success'
-      );
+      showSnackbar(`"${createdProject.name}" created`, 'success');
+      navigateToProject(createdProject);
     }
-    handleClose();
   };
-
-  // Members step only appears when the org has other members. Until the query
-  // resolves we assume it might appear (3-dot stepper). After it resolves we
-  // can confidently shrink to a 2-dot stepper for solo orgs.
-  const willHaveMembersStep = !!currentUserId && !confirmedNoOtherMembers;
-  const totalSteps = willHaveMembersStep ? 3 : 2;
 
   return (
     <Dialog
       open={open}
+      // Escape/backdrop stays blocked on the members step — protects pending
+      // invites/selections; both explicit exits (Add, Skip) navigate away.
       onClose={step === 'members' ? undefined : handleClose}
       maxWidth={false}
       PaperProps={{
@@ -124,7 +104,7 @@ export default function AddProjectDialog({
         },
       }}
     >
-      <Stepper currentStep={step} totalSteps={totalSteps} />
+      <Stepper currentStep={step} />
 
       {step === 'template' && (
         <TemplatePickerStep
@@ -162,19 +142,15 @@ export default function AddProjectDialog({
   );
 }
 
-function Stepper({
-  currentStep,
-  totalSteps,
-}: {
-  currentStep: Step;
-  totalSteps: 2 | 3;
-}) {
+const TOTAL_STEPS = 3;
+
+function Stepper({ currentStep }: { currentStep: Step }) {
   // template (1) → create (2) → members (3)
   const currentIndex =
     currentStep === 'template' ? 1 : currentStep === 'create' ? 2 : 3;
 
   const dots: Array<{ index: number; state: 'done' | 'active' | 'pending' }> = [];
-  for (let i = 1; i <= totalSteps; i++) {
+  for (let i = 1; i <= TOTAL_STEPS; i++) {
     dots.push({
       index: i,
       state: i < currentIndex ? 'done' : i === currentIndex ? 'active' : 'pending',
@@ -190,7 +166,7 @@ function Stepper({
         gap: 0.75,
         mb: 2,
       }}
-      aria-label={`Step ${currentIndex} of ${totalSteps}`}
+      aria-label={`Step ${currentIndex} of ${TOTAL_STEPS}`}
     >
       {dots.map((dot, idx) => (
         <Box

--- a/src/components/projects/AddProjectMembersStep.tsx
+++ b/src/components/projects/AddProjectMembersStep.tsx
@@ -7,6 +7,7 @@ import {
   TextField,
   Select,
   MenuItem,
+  IconButton,
   alpha,
   useTheme,
 } from '@mui/material';
@@ -15,11 +16,15 @@ import {
   MagnifyingGlass,
   Check,
   Info,
+  EnvelopeSimple,
+  PaperPlaneTilt,
+  X,
 } from '@phosphor-icons/react';
+import { TRPCClientError } from '@trpc/client';
 import { Button } from '@/components/ui/button';
 import { api } from '@/trpc/react';
 import { useSnackbar } from '@/hooks/useSnackbar';
-import type { AssignableRole } from '@/lib/validations/invitation';
+import { createInvitationSchema, type AssignableRole } from '@/lib/validations/invitation';
 
 interface AddProjectMembersStepProps {
   projectId: string;
@@ -34,6 +39,9 @@ const ROLE_OPTIONS: Array<{ value: AssignableRole; label: string }> = [
   { value: 'admin', label: 'Admin' },
   { value: 'member', label: 'Member' },
 ];
+
+const emailSchema = createInvitationSchema.shape.email;
+const normalizeEmail = (raw: string) => raw.trim().toLowerCase();
 
 function getInitials(name?: string | null, email?: string | null): string {
   if (name) {
@@ -62,6 +70,10 @@ export default function AddProjectMembersStep({
   const [selections, setSelections] = useState<Map<string, AssignableRole>>(
     new Map()
   );
+  const [pendingInvites, setPendingInvites] = useState<Map<string, AssignableRole>>(
+    new Map()
+  );
+  const [submitting, setSubmitting] = useState(false);
 
   const { data: members = [], isLoading } = api.member.list.useQuery({
     organizationId,
@@ -81,6 +93,32 @@ export default function AddProjectMembersStep({
       return name.includes(q) || email.includes(q);
     });
   }, [otherMembers, search]);
+
+  const normalizedSearch = normalizeEmail(search);
+
+  const memberEmails = useMemo(
+    () =>
+      new Set(
+        members
+          .map((m) => m.user.email?.toLowerCase())
+          .filter((email): email is string => !!email)
+      ),
+    [members]
+  );
+
+  const currentUserEmail = useMemo(
+    () => members.find((m) => m.user.id === currentUserId)?.user.email?.toLowerCase() ?? null,
+    [members, currentUserId]
+  );
+  const isOwnEmail = !!normalizedSearch && normalizedSearch === currentUserEmail;
+
+  // The !isLoading guard prevents offering an invite for an existing member
+  // before member.list resolves.
+  const isInvitableEmail =
+    !isLoading &&
+    emailSchema.safeParse(normalizedSearch).success &&
+    !memberEmails.has(normalizedSearch) &&
+    !pendingInvites.has(normalizedSearch);
 
   const toggleMember = (userId: string) => {
     setSelections((prev) => {
@@ -103,27 +141,109 @@ export default function AddProjectMembersStep({
     });
   };
 
-  const bulkAdd = api.projectMember.bulkAdd.useMutation({
-    onSuccess: ({ added }) => {
-      void utils.projectMember.list.invalidate({ projectId });
-      showSnackbar(
-        added === 1
-          ? '1 teammate added to project'
-          : `${added} teammates added to project`,
-        'success'
-      );
-      onComplete();
-    },
-    onError: (error) => {
-      showSnackbar(error.message || 'Failed to add teammates', 'error');
-    },
-  });
+  const addPendingInvite = () => {
+    if (!isInvitableEmail) return;
+    setPendingInvites((prev) => {
+      const next = new Map(prev);
+      next.set(normalizedSearch, 'member');
+      return next;
+    });
+    setSearch('');
+  };
 
-  const handleAdd = () => {
+  const setInviteRole = (email: string, role: AssignableRole) => {
+    setPendingInvites((prev) => {
+      if (!prev.has(email)) return prev;
+      const next = new Map(prev);
+      next.set(email, role);
+      return next;
+    });
+  };
+
+  const removePendingInvite = (email: string) => {
+    setPendingInvites((prev) => {
+      const next = new Map(prev);
+      next.delete(email);
+      return next;
+    });
+  };
+
+  const bulkAdd = api.projectMember.bulkAdd.useMutation();
+  const createInvitation = api.invitation.create.useMutation();
+
+  const handleAdd = async () => {
+    setSubmitting(true);
+
     const memberPayload = Array.from(selections.entries()).map(
       ([userId, role]) => ({ userId, role })
     );
-    bulkAdd.mutate({ projectId, members: memberPayload });
+
+    let addedCount = 0;
+    let bulkAddError: string | null = null;
+
+    if (memberPayload.length > 0) {
+      try {
+        const result = await bulkAdd.mutateAsync({ projectId, members: memberPayload });
+        addedCount = result.added;
+        setSelections(new Map());
+        void utils.projectMember.list.invalidate({ projectId });
+      } catch (error) {
+        bulkAddError =
+          error instanceof TRPCClientError ? error.message : 'Failed to add teammates';
+      }
+    }
+
+    const sentEmails: string[] = [];
+    const failedInvites: Array<{ email: string; message: string }> = [];
+
+    for (const [email, role] of pendingInvites.entries()) {
+      try {
+        await createInvitation.mutateAsync({ organizationId, projectId, email, role });
+        sentEmails.push(email);
+      } catch (error) {
+        failedInvites.push({
+          email,
+          message: error instanceof TRPCClientError ? error.message : 'Failed to send invite',
+        });
+      }
+    }
+
+    if (sentEmails.length > 0) {
+      setPendingInvites((prev) => {
+        const next = new Map(prev);
+        sentEmails.forEach((email) => next.delete(email));
+        return next;
+      });
+      void utils.invitation.list.invalidate();
+      void utils.projectMember.listProjectMemberships.invalidate();
+    }
+
+    setSubmitting(false);
+
+    if (!bulkAddError && failedInvites.length === 0) {
+      const parts: string[] = [];
+      if (addedCount > 0) {
+        parts.push(
+          addedCount === 1
+            ? '1 teammate added to project'
+            : `${addedCount} teammates added to project`
+        );
+      }
+      if (sentEmails.length > 0) {
+        parts.push(sentEmails.length === 1 ? '1 invite sent' : `${sentEmails.length} invites sent`);
+      }
+      if (parts.length > 0) {
+        showSnackbar(parts.join(' · '), 'success');
+      }
+      onComplete();
+    } else {
+      const messages: string[] = [];
+      if (bulkAddError) messages.push(bulkAddError);
+      failedInvites.forEach(({ email, message }) => {
+        messages.push(`Couldn't invite ${email}: ${message}`);
+      });
+      showSnackbar(messages.join(' · '), 'error');
+    }
   };
 
   const selectedCount = selections.size;
@@ -158,7 +278,7 @@ export default function AddProjectMembersStep({
       </Box>
 
       <TextField
-        placeholder="Search teammates by name or email"
+        placeholder="Search teammates or enter an email to invite"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         fullWidth
@@ -183,6 +303,162 @@ export default function AddProjectMembersStep({
           mx: -0.5,
         }}
       >
+        {Array.from(pendingInvites.entries()).map(([email, role]) => (
+          <Box
+            key={email}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.25,
+              px: 1.25,
+              py: 1,
+              borderRadius: '8px',
+              bgcolor: alpha(theme.palette.primary.main, 0.06),
+            }}
+          >
+            <Box
+              sx={{
+                width: 16,
+                height: 16,
+                display: 'grid',
+                placeItems: 'center',
+                flexShrink: 0,
+                color: 'primary.main',
+              }}
+              aria-hidden="true"
+            >
+              <EnvelopeSimple size={16} />
+            </Box>
+
+            <Box
+              sx={{
+                width: 28,
+                height: 28,
+                borderRadius: '50%',
+                bgcolor: alpha(theme.palette.primary.main, 0.1),
+                color: 'primary.main',
+                display: 'grid',
+                placeItems: 'center',
+                fontSize: '0.6875rem',
+                fontWeight: 600,
+                flexShrink: 0,
+              }}
+            >
+              {getInitials(null, email)}
+            </Box>
+
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                sx={{
+                  fontSize: '0.8125rem',
+                  fontWeight: 500,
+                  lineHeight: 1.2,
+                  color: 'text.primary',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {email}
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: '0.6875rem',
+                  color: 'text.secondary',
+                  lineHeight: 1.3,
+                  mt: 0.125,
+                }}
+              >
+                Invite will be sent
+              </Typography>
+            </Box>
+
+            <Select
+              value={role}
+              onChange={(e) => setInviteRole(email, e.target.value as AssignableRole)}
+              disabled={submitting}
+              size="small"
+              sx={{
+                minWidth: 130,
+                fontSize: '0.75rem',
+                flexShrink: 0,
+                bgcolor: 'background.paper',
+                '& .MuiSelect-select': { py: 0.5, fontSize: '0.75rem' },
+              }}
+            >
+              {ROLE_OPTIONS.map((opt) => (
+                <MenuItem key={opt.value} value={opt.value} sx={{ fontSize: '0.8125rem' }}>
+                  {opt.label}
+                </MenuItem>
+              ))}
+            </Select>
+
+            <IconButton
+              onClick={() => removePendingInvite(email)}
+              aria-label={`Remove invite for ${email}`}
+              size="small"
+              sx={{ flexShrink: 0 }}
+            >
+              <X size={14} />
+            </IconButton>
+          </Box>
+        ))}
+
+        {isInvitableEmail && (
+          <Box
+            onClick={addPendingInvite}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                addPendingInvite();
+              }
+            }}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.25,
+              px: 1.25,
+              py: 1,
+              borderRadius: '8px',
+              cursor: 'pointer',
+              '&:hover': { bgcolor: 'action.hover' },
+              transition: 'background-color 0.12s ease',
+            }}
+          >
+            <Box sx={{ width: 16, height: 16, flexShrink: 0 }} aria-hidden="true" />
+
+            <Box
+              sx={{
+                width: 28,
+                height: 28,
+                borderRadius: '50%',
+                bgcolor: alpha(theme.palette.primary.main, 0.1),
+                color: 'primary.main',
+                display: 'grid',
+                placeItems: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <PaperPlaneTilt size={14} />
+            </Box>
+
+            <Typography
+              sx={{
+                fontSize: '0.8125rem',
+                fontWeight: 500,
+                color: 'primary.main',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Invite {normalizedSearch} by email
+            </Typography>
+          </Box>
+        )}
+
         {isLoading ? (
           <Typography
             sx={{
@@ -194,7 +470,7 @@ export default function AddProjectMembersStep({
           >
             Loading teammates…
           </Typography>
-        ) : filtered.length === 0 ? (
+        ) : filtered.length === 0 && !isInvitableEmail ? (
           <Typography
             sx={{
               fontSize: '0.8125rem',
@@ -203,9 +479,11 @@ export default function AddProjectMembersStep({
               py: 3,
             }}
           >
-            {search
-              ? 'No teammates match your search'
-              : 'No other teammates in your organization yet'}
+            {isOwnEmail
+              ? "That's you — you're already on this project"
+              : search
+                ? 'No teammates match your search'
+                : 'No other teammates in your organization yet — type an email above to invite someone'}
           </Typography>
         ) : (
           filtered.map((m) => {
@@ -374,6 +652,15 @@ export default function AddProjectMembersStep({
               {selectedCount}
             </Box>{' '}
             selected
+            {pendingInvites.size > 0 && (
+              <>
+                {' · '}
+                <Box component="span" sx={{ fontWeight: 600, color: 'text.primary' }}>
+                  {pendingInvites.size}
+                </Box>{' '}
+                {pendingInvites.size === 1 ? 'invite' : 'invites'}
+              </>
+            )}
           </Typography>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
             <Info size={11} style={{ opacity: 0.5, flexShrink: 0 }} />
@@ -384,11 +671,7 @@ export default function AddProjectMembersStep({
                 lineHeight: 1.3,
               }}
             >
-              Need to invite someone outside your org? Use the{' '}
-              <Box component="span" sx={{ fontWeight: 600 }}>
-                Team
-              </Box>{' '}
-              tab.
+              Not in your org yet? Type their full email above to send an invite.
             </Typography>
           </Box>
         </Box>
@@ -397,16 +680,17 @@ export default function AddProjectMembersStep({
             onClick={onSkip}
             variant="text"
             size="small"
+            disabled={submitting}
             sx={{ whiteSpace: 'nowrap' }}
           >
             Skip
           </Button>
           <Button
-            onClick={handleAdd}
+            onClick={() => void handleAdd()}
             variant="contained"
             size="small"
-            disabled={selectedCount === 0}
-            loading={bulkAdd.isPending}
+            disabled={selectedCount + pendingInvites.size === 0}
+            loading={submitting}
             endIcon={<ArrowRight size={14} weight="bold" />}
             sx={{ whiteSpace: 'nowrap' }}
           >


### PR DESCRIPTION
Creating a project now always shows the members step and, on either **Add** or **Skip**, navigates straight into the new project's Gantt (with a loading overlay) instead of just showing a "switch to it in the dropdown" snackbar. The members step gains the ability to invite people outside the org: typing a full valid email surfaces an "Invite by email" row with its own role select, and on submit those invitations are sent via `invitation.create` alongside the existing bulk member add, with combined success/error feedback. The org-empty pre-fetch and dynamic 2/3-dot stepper were removed since the members step now always appears (fixed 3-step flow). Escape/backdrop dismissal stays blocked on the members step so pending selections and invites aren't lost. Adds component tests for `AddProjectDialog` and expands the members-step tests to cover the email-invite and partial-failure paths.