### PR TITLE
Rebrand to TEMERITY and gate Gantt editing on project role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,6 @@ generated/
 
 # visual designs / plans (local-only, never commit)
 visual-plans/
+.lavish/
 
 .env*

--- a/src/__tests__/server/gantt-sync-add.test.ts
+++ b/src/__tests__/server/gantt-sync-add.test.ts
@@ -95,6 +95,7 @@ function makeCtx() {
     session: { user: { id: "user-1", email: "u@example.com" } },
     organization: { id: ORG_ID },
     membership: { role: "owner" as const },
+    projectMember: { role: "owner" as const },
   };
 }
 

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -111,7 +111,7 @@ export default function ForgotPasswordPage() {
                 variant="h6"
                 sx={{ color: 'text.primary', fontWeight: 500 }}
               >
-                BuildTrack Pro
+                TEMERITY
               </Typography>
             </Stack>
 

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -195,7 +195,7 @@ function ResetPasswordForm() {
                 variant="h6"
                 sx={{ color: 'text.primary', fontWeight: 500 }}
               >
-                BuildTrack Pro
+                TEMERITY
               </Typography>
             </Stack>
 

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -251,7 +251,7 @@ function SignInForm() {
             variant="h6"
             sx={{ color: 'white', fontWeight: 600 }}
           >
-            BuildTrack Pro
+            TEMERITY
           </Typography>
         </Stack>
 
@@ -363,7 +363,7 @@ function SignInForm() {
               <LogoIcon size={24} />
             </Box>
             <Typography variant="h6" sx={{ fontWeight: 600 }}>
-              BuildTrack Pro
+              TEMERITY
             </Typography>
           </Stack>
 
@@ -377,7 +377,7 @@ function SignInForm() {
             </Typography>
             <Typography variant="body1" color="text.secondary">
               {step === 'login'
-                ? 'Sign in to your BuildTrack Pro account'
+                ? 'Sign in to your TEMERITY account'
                 : `We sent a 6-digit code to ${email}`}
             </Typography>
           </Box>

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -272,7 +272,7 @@ export default function SignUpPage() {
             variant="h6"
             sx={{ color: 'white', fontWeight: 600 }}
           >
-            BuildTrack Pro
+            TEMERITY
           </Typography>
         </Stack>
 
@@ -282,7 +282,7 @@ export default function SignUpPage() {
             variant="h5"
             sx={{ color: 'white', mb: 1, lineHeight: 1.4 }}
           >
-            &ldquo;BuildTrack Pro has transformed how we manage our construction
+            &ldquo;TEMERITY has transformed how we manage our construction
             projects — saving us weeks of coordination time.&rdquo;
           </Typography>
           <Typography
@@ -384,7 +384,7 @@ export default function SignUpPage() {
               <LogoIcon size={24} />
             </Box>
             <Typography variant="h6" sx={{ fontWeight: 600 }}>
-              BuildTrack Pro
+              TEMERITY
             </Typography>
           </Stack>
 
@@ -399,8 +399,8 @@ export default function SignUpPage() {
             <Typography variant="body1" color="text.secondary">
               {step === 'register'
                 ? isInvitedFlow && invite
-                  ? `Join ${invite.organization.name} on BuildTrack Pro`
-                  : 'Get started with BuildTrack Pro'
+                  ? `Join ${invite.organization.name} on TEMERITY`
+                  : 'Get started with TEMERITY'
                 : `We sent a 6-digit code to ${email}`}
             </Typography>
           </Box>

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -165,7 +165,7 @@ export default function VerifyEmailPage() {
                 variant="h6"
                 sx={{ color: 'text.primary', fontWeight: 500 }}
               >
-                BuildTrack Pro
+                TEMERITY
               </Typography>
             </Stack>
             <Typography variant="h5" sx={{ color: 'text.primary', fontWeight: 500, mb: 1.5 }}>

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -201,7 +201,7 @@ export default function InvitePage() {
           You&apos;re invited!
         </Typography>
         <Typography color="text.secondary">
-          Join your team on BuildTrack Pro
+          Join your team on TEMERITY
         </Typography>
       </Box>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,7 +10,7 @@ import { SnackbarProvider } from "@/hooks/useSnackbar";
 
 
 export const metadata: Metadata = {
-  title: "BuildTrack Pro",
+  title: "TEMERITY",
   description: "Construction project management",
   icons: [
     { rel: "icon", url: "/favicon.svg", type: "image/svg+xml" },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -70,7 +70,7 @@ function DashboardPreview() {
           <div style={{ width: 20, height: 20, borderRadius: 4, background: t.fg, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <span style={{ fontSize: 10, fontWeight: 700, color: '#fff' }}>B</span>
           </div>
-          <span style={{ fontSize: 11, fontWeight: 600, color: t.fg }}>BuildTrack Pro</span>
+          <span style={{ fontSize: 11, fontWeight: 600, color: t.fg }}>TEMERITY</span>
           <CaretDown size={10} style={{ color: t.mutedFg }} />
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 4, background: t.secondary, borderRadius: 6, padding: '4px 10px' }}>
@@ -220,7 +220,7 @@ function NexoraSection({ isLoggedIn }: { isLoggedIn: boolean }) {
             <rect x="18" y="3" width="3" height="10" rx="0.5" fill={t.fg} />
             <rect x="10" y="9" width="2.5" height="12" rx="0.5" fill={t.fg} />
           </svg>
-          <span style={{ fontSize: 20, fontWeight: 600, letterSpacing: '-0.02em', color: t.fg }}>BuildTrack Pro</span>
+          <span style={{ fontSize: 20, fontWeight: 600, letterSpacing: '-0.02em', color: t.fg }}>TEMERITY</span>
         </div>
         <div style={{ position: 'absolute', left: '50%', transform: 'translateX(-50%)', display: 'flex', alignItems: 'center', gap: 32 }}>
           <a href="#features" style={{ fontSize: 14, color: t.mutedFg, textDecoration: 'none', transition: 'color 0.2s' }}>Features</a>
@@ -575,7 +575,7 @@ function Logo3DSection() {
           letterSpacing: '-0.02em',
         }}
       >
-        BuildTrack Pro
+        TEMERITY
       </p>
       <p style={{ fontSize: 14, color: t.mutedFg, margin: 0 }}>
         Built for builders.
@@ -617,7 +617,7 @@ function Footer() {
               <rect x="18" y="3" width="3" height="10" rx="0.5" fill="#111" />
               <rect x="10" y="9" width="2.5" height="12" rx="0.5" fill="#111" />
             </svg>
-            <span style={{ fontSize: 20, fontWeight: 700, color: '#111', letterSpacing: '-0.02em' }}>BuildTrack Pro</span>
+            <span style={{ fontSize: 20, fontWeight: 700, color: '#111', letterSpacing: '-0.02em' }}>TEMERITY</span>
           </a>
           <div style={{ display: 'flex', gap: 8 }}>
             {socialLinks.map((link) => (
@@ -649,7 +649,7 @@ function Footer() {
           <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between', alignItems: 'flex-start', gap: 24 }}>
             {/* Copyright */}
             <div style={{ fontSize: 14, lineHeight: 1.6, color: '#858e8e', whiteSpace: 'nowrap' }}>
-              <div>&copy; {new Date().getFullYear()} BuildTrack Pro</div>
+              <div>&copy; {new Date().getFullYear()} TEMERITY</div>
               <div>All rights reserved</div>
             </div>
 

--- a/src/components/bryntum/BryntumGanttWrapper.tsx
+++ b/src/components/bryntum/BryntumGanttWrapper.tsx
@@ -203,7 +203,16 @@ function BryntumGanttCore({ projectId, isVisible = true, ganttControls }: Bryntu
   // Lock mode: chart is locked by default; admin-level users click the lock
   // toggle in the toolbar to enter edit mode.
   const { currentOrg } = useOrgFromUrl();
-  const canEditChart = canManageProjects(currentOrg?.role ?? '');
+  // Gantt editing is gated on the caller's effective PROJECT role, not their org
+  // role — a user promoted to admin on this project must be able to edit even if
+  // their org role is 'member'. projectMember.myRole resolves the authoritative
+  // project role (and auto-creates a row for org owners/admins). Fall back to the
+  // org role until it loads so org owners/admins don't flash a locked chart.
+  const { data: myProjectRole } = api.projectMember.myRole.useQuery(
+    { projectId: projectId ?? '' },
+    { enabled: !!projectId, retry: false },
+  );
+  const canEditChart = canManageProjects(myProjectRole?.role ?? currentOrg?.role ?? '');
   const [isEditMode, setIsEditMode] = useState(false);
   const editingUnlocked = canEditChart && isEditMode;
   // True while the Shift key is held (tracked only when editing is unlocked) so

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -136,7 +136,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
           color: 'text.primary',
           userSelect: 'none',
         }}
-        aria-label="BuildTrack Pro"
+        aria-label="TEMERITY"
       >
         <LogoIcon size={20} />
         <Typography
@@ -149,7 +149,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
             flex: 1,
           }}
         >
-          BuildTrack Pro
+          TEMERITY
         </Typography>
         <IconButton
           onClick={onClose}

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -43,7 +43,7 @@ export default function MobileHeader({ onMenuOpen }: MobileHeaderProps) {
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <LogoIcon size={16} />
           <Typography sx={{ color: 'text.primary', fontWeight: 500, fontSize: '0.875rem' }}>
-            BuildTrack
+            TEMERITY
           </Typography>
         </Box>
       </Box>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -307,7 +307,7 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
           overflow: 'hidden',
           flexShrink: 0,
         }}
-        aria-label="BuildTrack Pro"
+        aria-label="TEMERITY"
       >
         <LogoIcon size={20} />
         {!collapsed && (
@@ -324,7 +324,7 @@ export default function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
                 flex: 1,
               }}
             >
-              BuildTrack Pro
+              TEMERITY
             </Typography>
             <Tooltip
               title={`Collapse sidebar (${isMac ? '⌘' : 'Ctrl+'}B)`}

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -61,7 +61,7 @@ export function OnboardingWizard() {
   const completeMutation = api.onboarding.createOrganization.useMutation({
     onSuccess: (data) => {
       setShowSuccess(true);
-      showSnackbar("Welcome to BuildTrack Pro!", "success");
+      showSnackbar("Welcome to TEMERITY!", "success");
       setTimeout(() => {
         router.push(`/${data.organization.slug}?welcome=1`);
       }, 1500);
@@ -214,7 +214,7 @@ export function OnboardingWizard() {
                   variant="h4"
                   sx={{ mb: 1, fontWeight: 700, color: 'text.primary' }}
                 >
-                  Welcome to BuildTrack Pro
+                  Welcome to TEMERITY
                 </Typography>
                 <Typography
                   component={motion.p}
@@ -325,7 +325,7 @@ export function OnboardingWizard() {
                         },
                       }}
                     >
-                      Launch BuildTrack Pro
+                      Launch TEMERITY
                     </Button>
                   )}
                 </Box>

--- a/src/components/onboarding/WelcomeAnimation.tsx
+++ b/src/components/onboarding/WelcomeAnimation.tsx
@@ -167,7 +167,7 @@ export function WelcomeAnimation({ show }: { show: boolean }) {
             mb: 0.5,
           }}
         >
-          Welcome to BuildTrack Pro
+          Welcome to TEMERITY
         </Typography>
         <Typography variant="body1" sx={{ color: 'text.secondary' }}>
           Your workspace is ready.

--- a/src/components/ui/Logo.tsx
+++ b/src/components/ui/Logo.tsx
@@ -53,7 +53,7 @@ export const Logo: React.FC<LogoProps> = ({
       <LogoIcon size={size} />
       {showText && (
         <Typography sx={{ fontWeight: 600, fontSize }}>
-          BuildTrack Pro
+          TEMERITY
         </Typography>
       )}
     </Box>

--- a/src/lib/constants/email.ts
+++ b/src/lib/constants/email.ts
@@ -1,1 +1,1 @@
-export const EMAIL_FROM = "BuildTrack Pro <noreply@celn.app>";
+export const EMAIL_FROM = "TEMERITY <noreply@celn.app>";

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -53,7 +53,7 @@ export async function sendVerificationOTPEmail(
               <div style="width: 48px; height: 48px; background: #1f2937; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center;">
                 <div style="width: 32px; height: 32px; border: 2px solid white; border-radius: 50%;"></div>
               </div>
-              <h2 style="color: #1f2937; margin: 16px 0 0 0; font-size: 18px; font-weight: 500;">BuildTrack Pro</h2>
+              <h2 style="color: #1f2937; margin: 16px 0 0 0; font-size: 18px; font-weight: 500;">TEMERITY</h2>
             </div>
 
             <h1 style="color: #1f2937; font-size: 24px; font-weight: 600; margin: 0 0 16px 0; text-align: center;">${subject}</h1>
@@ -118,7 +118,7 @@ export async function sendPasswordResetEmail(
               <div style="width: 48px; height: 48px; background: #1f2937; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center;">
                 <div style="width: 32px; height: 32px; border: 2px solid white; border-radius: 50%;"></div>
               </div>
-              <h2 style="color: #1f2937; margin: 16px 0 0 0; font-size: 18px; font-weight: 500;">BuildTrack Pro</h2>
+              <h2 style="color: #1f2937; margin: 16px 0 0 0; font-size: 18px; font-weight: 500;">TEMERITY</h2>
             </div>
 
             <h1 style="color: #1f2937; font-size: 24px; font-weight: 600; margin: 0 0 16px 0; text-align: center;">Reset your password</h1>
@@ -181,7 +181,7 @@ export async function sendWaitlistConfirmationEmail(
     const { error } = await resend.emails.send({
       from: EMAIL_FROM,
       to: email,
-      subject: "You're on the BuildTrack Pro waitlist!",
+      subject: "You're on the TEMERITY waitlist!",
       html: `
         <!DOCTYPE html>
         <html>
@@ -195,7 +195,7 @@ export async function sendWaitlistConfirmationEmail(
               <div style="width: 48px; height: 48px; background: #1f2937; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center;">
                 <div style="width: 32px; height: 32px; border: 2px solid white; border-radius: 50%;"></div>
               </div>
-              <h2 style="color: #1f2937; margin: 16px 0 0 0; font-size: 18px; font-weight: 500;">BuildTrack Pro</h2>
+              <h2 style="color: #1f2937; margin: 16px 0 0 0; font-size: 18px; font-weight: 500;">TEMERITY</h2>
             </div>
 
             <h1 style="color: #1f2937; font-size: 24px; font-weight: 600; margin: 0 0 16px 0; text-align: center;">You're on the waitlist!</h1>
@@ -211,7 +211,7 @@ export async function sendWaitlistConfirmationEmail(
             <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;">
 
             <p style="color: #9ca3af; font-size: 12px; text-align: center; margin: 0;">
-              You're receiving this because you signed up for the BuildTrack Pro waitlist.
+              You're receiving this because you signed up for the TEMERITY waitlist.
             </p>
           </div>
         </body>
@@ -276,13 +276,13 @@ export async function sendInvitationEmail(
               <div style="width: 48px; height: 48px; background: #1f2937; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center;">
                 <div style="width: 32px; height: 32px; border: 2px solid white; border-radius: 50%;"></div>
               </div>
-              <h2 style="color: #1f2937; margin: 16px 0 0 0; font-size: 18px; font-weight: 500;">BuildTrack Pro</h2>
+              <h2 style="color: #1f2937; margin: 16px 0 0 0; font-size: 18px; font-weight: 500;">TEMERITY</h2>
             </div>
 
             <h1 style="color: #1f2937; font-size: 24px; font-weight: 600; margin: 0 0 16px 0; text-align: center;">You're invited!</h1>
 
             <p style="color: #6b7280; font-size: 16px; line-height: 1.6; margin: 0 0 24px 0; text-align: center;">
-              <strong>${safeInviterName}</strong> has invited you to join ${safeProjectName ? `<strong>${safeProjectName}</strong> at ` : ""}<strong>${safeOrgName}</strong> on BuildTrack Pro.
+              <strong>${safeInviterName}</strong> has invited you to join ${safeProjectName ? `<strong>${safeProjectName}</strong> at ` : ""}<strong>${safeOrgName}</strong> on TEMERITY.
             </p>
 
             <div style="text-align: center; margin-bottom: 24px;">
@@ -292,7 +292,7 @@ export async function sendInvitationEmail(
             </div>
 
             <p style="color: #9ca3af; font-size: 14px; line-height: 1.6; margin: 0 0 16px 0; text-align: center;">
-              This invitation will expire in 7 days. If you don't have a BuildTrack Pro account yet, you'll be able to create one.
+              This invitation will expire in 7 days. If you don't have a TEMERITY account yet, you'll be able to create one.
             </p>
 
             <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;">

--- a/src/server/api/routers/gantt.ts
+++ b/src/server/api/routers/gantt.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { createTRPCRouter, orgProcedure } from "@/server/api/trpc";
-import { canApproveDocuments } from "@/lib/permissions";
+import { createTRPCRouter, orgProcedure, projectProcedure } from "@/server/api/trpc";
+import { canApproveDocuments, canManageProjects } from "@/lib/permissions";
 import {
   ganttLoadInputSchema,
   ganttSyncInputSchema,
@@ -344,21 +344,21 @@ export const ganttRouter = createTRPCRouter({
   /**
    * Sync changes to Gantt data
    */
-  sync: orgProcedure
+  sync: projectProcedure
     .input(ganttSyncInputSchema)
     .mutation(async ({ ctx, input }) => {
       const { projectId, tasks, dependencies, resources, assignments, timeRanges } = input;
 
-      // Verify project belongs to organization
-      const project = await ctx.db.project.findFirst({
-        where: {
-          id: projectId,
-          organizationId: ctx.organization.id,
-        },
-      });
-
-      if (!project) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Project not found or access denied" });
+      // Editing the schedule requires project-manage rights. projectProcedure
+      // resolves and validates the caller's effective PROJECT role (auto-creating
+      // a row for org owners/admins), so this both (a) blocks org members who
+      // aren't project admins/owners from persisting edits and (b) lets a user
+      // promoted to admin on the project edit even when their org role is member.
+      if (!canManageProjects(ctx.projectMember.role)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have permission to edit this project's schedule",
+        });
       }
 
       // Last-write-wins: no version check, no isolation upgrade. Concurrent

--- a/tests/pages/onboarding.page.ts
+++ b/tests/pages/onboarding.page.ts
@@ -13,13 +13,13 @@ export class OnboardingPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.heading = page.getByText("Welcome to BuildTrack Pro");
+    this.heading = page.getByText("Welcome to TEMERITY");
     this.companyNameInput = page.getByPlaceholder("Enter your company name");
     this.companyTypeSelect = page.getByText("Select company type");
     this.continueButton = page.getByRole("button", { name: "Continue" });
     this.skipButton = page.getByRole("button", { name: "Skip for now" });
     this.backButton = page.getByRole("button", { name: "Back" });
-    this.launchButton = page.getByRole("button", { name: "Launch BuildTrack Pro" });
+    this.launchButton = page.getByRole("button", { name: "Launch TEMERITY" });
     this.successHeading = page.getByText("You're all set!");
   }
 


### PR DESCRIPTION
Renames "BuildTrack Pro" to "TEMERITY" across all user-facing surfaces: the marketing landing page, auth pages, app shell (sidebar, mobile header/drawer), onboarding, the shared Logo, every email template, `EMAIL_FROM`, and the page `<title>` metadata. Fixes Gantt edit permissions so a user who is admin/owner on a project can edit even when their org role is `member` — the client edit toggle now reads the effective project role via `projectMember.myRole` (falling back to org role until it loads), and `gantt.sync` moves from `orgProcedure` to `projectProcedure` with a `canManageProjects` check, closing a hole where any org member could persist schedule edits. Also updates the onboarding E2E page-object selectors to the new brand and gitignores the local `.lavish/` planning artifact. Verified with `tsc --noEmit` (exit 0); Playwright E2E was not run here (needs dev server + test DB) but the updated selectors match the rendered strings exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)